### PR TITLE
Add juju-login cmd to enable re-login to controller

### DIFF
--- a/sunbeam-python/sunbeam/commands/utils.py
+++ b/sunbeam-python/sunbeam/commands/utils.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import click
+from rich.console import Console
+from snaphelpers import Snap
+
+from sunbeam.commands.juju import JujuLoginStep
+from sunbeam.jobs.checks import VerifyBootstrappedCheck
+from sunbeam.jobs.common import run_plan, run_preflight_checks
+
+LOG = logging.getLogger(__name__)
+console = Console()
+snap = Snap()
+
+
+@click.command()
+def juju_login() -> None:
+    """Login to the controller with current host user."""
+    preflight_checks = [VerifyBootstrappedCheck()]
+    run_preflight_checks(preflight_checks, console)
+
+    data_location = snap.paths.user_data
+
+    plan = []
+    plan.append(JujuLoginStep(data_location))
+
+    run_plan(plan, console)
+
+    console.print("Juju re-login complete.")

--- a/sunbeam-python/sunbeam/main.py
+++ b/sunbeam-python/sunbeam/main.py
@@ -30,6 +30,7 @@ from sunbeam.commands import node as node_cmds
 from sunbeam.commands import openrc as openrc_cmds
 from sunbeam.commands import prepare_node as prepare_node_cmds
 from sunbeam.commands import resize as resize_cmds
+from sunbeam.commands import utils as utils_cmds
 from sunbeam.jobs.plugin import PluginManager
 from sunbeam.utils import CatchGroup
 
@@ -74,6 +75,12 @@ def disable(ctx):
     """Disable plugins"""
 
 
+@click.group("utils", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
+@click.pass_context
+def utils(ctx):
+    """Utilities for debugging and managing sunbeam."""
+
+
 def main():
     snap = Snap()
     logfile = log.prepare_logfile(snap.paths.user_common / "logs", "sunbeam")
@@ -101,6 +108,9 @@ def main():
 
     # Register the plugins
     PluginManager.register(cli)
+
+    cli.add_command(utils)
+    utils.add_command(utils_cmds.juju_login)
 
     cli()
 


### PR DESCRIPTION
Add utils group with subcommand juju-login. The juju-login command will re-login to controller with the user of the current node.

Fixes LP#2028139

Moved from https://github.com/openstack-snaps/snap-openstack/pull/190