### PR TITLE
Tidy up removal

### DIFF
--- a/sunbeam-python/sunbeam/commands/openstack_api.py
+++ b/sunbeam-python/sunbeam/commands/openstack_api.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import TYPE_CHECKING, List
+
+import openstack
+
+from sunbeam.commands.configure import retrieve_admin_credentials
+from sunbeam.commands.openstack import OPENSTACK_MODEL
+
+if TYPE_CHECKING:
+    from juju import JujuHelper
+
+LOG = logging.getLogger(__name__)
+
+
+def get_admin_connection(jhelper: "JujuHelper") -> openstack.connection.Connection:
+    """Return a connection to keystone using admin credentials.
+
+    :param jhelper: Juju helpers for retrieving admin credentials
+    :raises: openstack.exceptions.SDKException
+    """
+    admin_auth_info = retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)
+    conn = openstack.connect(
+        auth_url=admin_auth_info.get("OS_AUTH_URL"),
+        username=admin_auth_info.get("OS_USERNAME"),
+        password=admin_auth_info.get("OS_PASSWORD"),
+        project_name=admin_auth_info.get("OS_PROJECT_NAME"),
+        user_domain_name=admin_auth_info.get("OS_USER_DOMAIN_NAME"),
+        project_domain_name=admin_auth_info.get("OS_PROJECT_DOMAIN_NAME"),
+    )
+    return conn
+
+
+def guests_on_hypervisor(
+    hypervisor_name: str, jhelper: "JujuHelper"
+) -> List[openstack.compute.v2.server.Server]:
+    """Return a list of guests that run on the given hypervisor.
+
+    :param hypervisor_name: Name of hypervisor
+    :param jhelper: Juju helpers for retrieving admin credentials
+    :raises: openstack.exceptions.SDKException
+    """
+    conn = get_admin_connection(jhelper)
+    return list(conn.compute.servers(all_projects=True, host=hypervisor_name))
+
+
+def remove_compute_service(
+    hypervisor_name: str, conn: openstack.connection.Connection
+) -> None:
+    """Remove compute services associated with hypervisor from nova.
+
+    :param hypervisor_name: Name of hypervisor
+    :param conn: Admin connection
+    """
+    for service in conn.compute.services(host=hypervisor_name):
+        LOG.info(f"Disabling {service.binary} on {service.host}")
+        conn.compute.disable_service(service)
+        conn.compute.delete_service(service)
+
+
+def remove_network_service(
+    hypervisor_name: str, conn: openstack.connection.Connection
+) -> None:
+    """Remove network services associated with hypervisor from neutron.
+
+    :param hypervisor_name: Name of hypervisor
+    :param conn: Admin connection
+    """
+    for service in conn.network.agents(host=hypervisor_name):
+        LOG.info(f"Disabling {service.binary} on {service.host}")
+        conn.network.delete_agent(service)
+
+
+def remove_hypervisor(hypervisor_name: str, jhelper: "JujuHelper") -> None:
+    """Remove services associated with hypervisor from OpenStack.
+
+    :param hypervisor_name: Name of hypervisor
+    :param jhelper: Juju helpers for retrieving admin credentials
+    """
+    conn = get_admin_connection(jhelper)
+    remove_compute_service(hypervisor_name, conn)
+    remove_network_service(hypervisor_name, conn)

--- a/sunbeam-python/test-requirements.txt
+++ b/sunbeam-python/test-requirements.txt
@@ -13,6 +13,7 @@ osprofiler>=1.4.0 # Apache-2.0
 wrapt>=1.7.0 # BSD License
 ddt>=1.0.1 # MIT
 codespell>=2.2.2 # GPL v2
+openstacksdk # Apache-2.0
 
 pytest
 pytest-mock

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_openstack_api.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_openstack_api.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+import sunbeam.commands.configure
+import sunbeam.commands.openstack_api
+
+FAKE_CREDS = {
+    "OS_AUTH_URL": "http://10.20.21.12:80/openstack-keystone",
+    "OS_USERNAME": "admin",
+    "OS_PASSWORD": "fake",
+    "OS_PROJECT_DOMAIN_NAME": "admin_domain",
+    "OS_USER_DOMAIN_NAME": "admin_domain",
+    "OS_PROJECT_NAME": "admin",
+    "OS_IDENTITY_API_VERSION": "3",
+    "OS_AUTH_VERSION": "3",
+}
+
+
+@pytest.fixture()
+def retrieve_admin_credentials():
+    with patch.object(
+        sunbeam.commands.openstack_api, "retrieve_admin_credentials"
+    ) as p:
+        p.return_value = FAKE_CREDS
+        yield p
+
+
+@pytest.fixture()
+def os_connect():
+    with patch.object(sunbeam.commands.openstack_api.openstack, "connect") as p:
+        yield p
+
+
+@pytest.fixture()
+def get_admin_connection():
+    with patch.object(sunbeam.commands.openstack_api, "get_admin_connection") as p:
+        yield p
+
+
+@pytest.fixture()
+def remove_compute_service():
+    with patch.object(sunbeam.commands.openstack_api, "remove_compute_service") as p:
+        yield p
+
+
+@pytest.fixture()
+def remove_network_service():
+    with patch.object(sunbeam.commands.openstack_api, "remove_network_service") as p:
+        yield p
+
+
+class TestOpenStackAPI:
+    def test_get_admin_connection(self, retrieve_admin_credentials, os_connect):
+        sunbeam.commands.openstack_api.get_admin_connection(None)
+        os_connect.assert_called_once_with(
+            auth_url=FAKE_CREDS.get("OS_AUTH_URL"),
+            username=FAKE_CREDS.get("OS_USERNAME"),
+            password=FAKE_CREDS.get("OS_PASSWORD"),
+            project_name=FAKE_CREDS.get("OS_PROJECT_NAME"),
+            user_domain_name=FAKE_CREDS.get("OS_USER_DOMAIN_NAME"),
+            project_domain_name=FAKE_CREDS.get("OS_PROJECT_DOMAIN_NAME"),
+        )
+
+    def test_guests_on_hypervisor(self, get_admin_connection):
+        conn = Mock()
+        get_admin_connection.return_value = conn
+        conn.compute.servers.return_value = [1]
+        assert sunbeam.commands.openstack_api.guests_on_hypervisor("hyper1", None) == [
+            1
+        ]
+        conn.compute.servers.assert_called_once_with(all_projects=True, host="hyper1")
+
+    def test_remove_compute_service(self):
+        service1 = Mock(binary="nova-compute", host="hyper1")
+        conn = Mock()
+        conn.compute.services.return_value = [service1]
+        sunbeam.commands.openstack_api.remove_compute_service("hyper1", conn)
+        conn.compute.disable_service.assert_called_once_with(service1)
+        conn.compute.delete_service.assert_called_once_with(service1)
+
+    def test_remove_network_service(self):
+        service1 = Mock(binary="ovn-controller", host="hyper1")
+        conn = Mock()
+        conn.network.agents.return_value = [service1]
+        sunbeam.commands.openstack_api.remove_network_service("hyper1", conn)
+        conn.network.delete_agent.assert_called_once_with(service1)
+
+    def test_remove_hypervisor(
+        self, get_admin_connection, remove_compute_service, remove_network_service
+    ):
+        conn = Mock()
+        get_admin_connection.return_value = conn
+        sunbeam.commands.openstack_api.remove_hypervisor("hyper1", None)
+        get_admin_connection.assert_called_once_with(None)
+        remove_compute_service.assert_called_once_with("hyper1", conn)
+        remove_network_service.assert_called_once_with("hyper1", conn)


### PR DESCRIPTION
    Removing a node is currently broken as the sunbeam and hypervisor
    charm remove steps are not being called. This change adds them in.
    
    For the hypervisor removal this change adds a check to see if any
    guests are running on the hypervisor targeted for removal. If there
    are then an error is thrown unless the "--force" flag has been set.
    
    As part of the hypervisor removal the compute and network agents are
    also de-registered.
