### PR TITLE
Pin juju terraform provider to 0.8.0

### DIFF
--- a/cloud/etc/deploy-microceph/main.tf
+++ b/cloud/etc/deploy-microceph/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.7.0"
+      version = "= 0.8.0"
     }
   }
 

--- a/cloud/etc/deploy-microk8s/main.tf
+++ b/cloud/etc/deploy-microk8s/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.7.0"
+      version = "= 0.8.0"
     }
   }
 

--- a/cloud/etc/deploy-openstack-hypervisor/main.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.7.0"
+      version = "= 0.8.0"
     }
   }
 

--- a/cloud/etc/deploy-sunbeam-machine/main.tf
+++ b/cloud/etc/deploy-sunbeam-machine/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.7.0"
+      version = "= 0.8.0"
     }
   }
 

--- a/sunbeam-python/sunbeam/plugins/cos/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/plugins/cos/etc/deploy-cos/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.7.0"
+      version = "= 0.8.0"
     }
   }
 }

--- a/sunbeam-python/sunbeam/plugins/pro/etc/deploy-pro/main.tf
+++ b/sunbeam-python/sunbeam/plugins/pro/etc/deploy-pro/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.7.0"
+      version = "= 0.8.0"
     }
   }
 

--- a/sunbeam-python/sunbeam/plugins/vault/etc/deploy-vault/main.tf
+++ b/sunbeam-python/sunbeam/plugins/vault/etc/deploy-vault/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.8.0"
+      version = "= 0.8.0"
     }
   }
 


### PR DESCRIPTION
sunbeam-terraform fails with new versions of
juju terraform provider, see [1]. Pin the
version to 0.8.0 until [1] is fixed and released.

[1] juju/terraform-provider-juju#310