### PR TITLE
Remove juju agent override

### DIFF
--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -284,7 +284,6 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
                 "bootstrap",
                 self.cloud,
                 self.controller,
-                "--agent-version=3.2.0",
             ]
             LOG.debug(f'Running command {" ".join(cmd)}')
             process = subprocess.run(cmd, capture_output=True, text=True, check=True)


### PR DESCRIPTION
Juju 3.2.3 is now in the 3.2/stable channel and fixes the issue that required tha agent version to be pinned to 3.2.0