### PR TITLE
Pin golangci-lint to latest compatible with go 1.19

### DIFF
--- a/sunbeam-microcluster/Makefile
+++ b/sunbeam-microcluster/Makefile
@@ -25,7 +25,7 @@ check-system:
 .PHONY: check-static
 check-static:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0
 endif
 ifeq ($(shell command -v revive 2> /dev/null),)
 	go install github.com/mgechev/revive@latest


### PR DESCRIPTION
Golint check is failing on main branch because golangci-golint@latest dropped support for golang 1.19