### PR TITLE
Switch to rabbit 3.12

### DIFF
--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -216,6 +216,7 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
                 # Make these channel options configurable by the user
                 "openstack-channel": "2023.1/edge",
                 "ovn-channel": "23.03/edge",
+                "rabbitmq-channel": "3.12/edge",
                 "cloud": self.cloud,
                 "credential": f"{self.cloud}{CREDENTIAL_SUFFIX}",
                 "config": {"workload-storage": MICROK8S_DEFAULT_STORAGECLASS},


### PR DESCRIPTION
Switch to using rabbit from the 3.12/edge to take advantage of quorum queues.