### PR TITLE
Switch to new charm microk8s

### DIFF
--- a/cloud/etc/deploy-microk8s/variables.tf
+++ b/cloud/etc/deploy-microk8s/variables.tf
@@ -14,13 +14,8 @@
 # limitations under the License.
 
 variable "charm_microk8s_channel" {
-  description = "Operator channel for microk8s deployment"
-  default     = "legacy/stable"
-}
-
-variable "microk8s_channel" {
-  description = "K8S channel to deploy, not the operator channel"
-  default     = "1.28-strict/stable"
+  description = "Operator channel for charm microk8s deployment"
+  default     = "1.28/stable"
 }
 
 variable "machine_ids" {
@@ -29,13 +24,48 @@ variable "machine_ids" {
   default     = []
 }
 
-variable "addons" {
-  description = "Addon configuration to enable on the deployment"
-  type        = map(string)
-  default = {
-    dns              = ""
-    hostpath-storage = ""
-    metallb          = "10.20.21.1-10.20.21.10"
-  }
+variable "enable-addons" {
+  description = "Enable microk8s addons"
+  default     = false
 }
 
+variable "addons-model" {
+  description = "Name of Juju model to use for deployment of addons"
+  default     = "microk8s-addons"
+}
+
+variable "cloud" {
+  description = "Name of K8S cloud to use for deployment"
+  default     = "microk8s"
+}
+
+# https://github.com/juju/terraform-provider-juju/issues/147
+variable "credential" {
+  description = "Name of credential to use for deployment"
+  default     = ""
+}
+
+variable "config" {
+  description = "Set configuration on model"
+  default     = {}
+}
+
+variable "charm-metallb-channel" {
+  description = "Operator channel for metallb deployment"
+  default     = "1.28/stable"
+}
+
+variable "charm-coredns-channel" {
+  description = "Operator channel for coredns deployment"
+  default     = "1.28/stable"
+}
+
+variable "coredns-ha-scale" {
+  description = "Scale of coredns deployment"
+  default     = 1
+}
+
+variable "metallb-iprange" {
+  description = "IP address range to assign for services"
+  default     = "10.20.21.1-10.20.21.10"
+}

--- a/sunbeam-python/sunbeam/commands/bootstrap.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap.py
@@ -50,6 +50,7 @@ from sunbeam.commands.microceph import (
 from sunbeam.commands.microk8s import (
     AddMicrok8sCloudStep,
     AddMicrok8sUnitStep,
+    DeployMicrok8sAddonsStep,
     DeployMicrok8sApplicationStep,
     StoreMicrok8sConfigStep,
 )
@@ -250,16 +251,21 @@ def bootstrap(
     plan4.append(TerraformInitStep(tfhelper_sunbeam_machine))
     plan4.append(DeploySunbeamMachineApplicationStep(tfhelper_sunbeam_machine, jhelper))
     plan4.append(AddSunbeamMachineUnitStep(fqdn, jhelper))
+
     # Deploy Microk8s application during bootstrap irrespective of node role.
     plan4.append(TerraformInitStep(tfhelper))
-    plan4.append(
-        DeployMicrok8sApplicationStep(
-            tfhelper, jhelper, accept_defaults=accept_defaults, preseed_file=preseed
-        )
-    )
+    plan4.append(DeployMicrok8sApplicationStep(tfhelper, jhelper))
     plan4.append(AddMicrok8sUnitStep(fqdn, jhelper))
     plan4.append(StoreMicrok8sConfigStep(jhelper))
     plan4.append(AddMicrok8sCloudStep(jhelper))
+    plan4.append(
+        DeployMicrok8sAddonsStep(
+            tfhelper,
+            jhelper,
+            accept_defaults=accept_defaults,
+            preseed_file=preseed,
+        )
+    )
     # Deploy Microceph application during bootstrap irrespective of node role.
     plan4.append(TerraformInitStep(tfhelper_microceph_deploy))
     plan4.append(DeployMicrocephApplicationStep(tfhelper_microceph_deploy, jhelper))

--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -25,15 +25,24 @@ from rich.status import Status
 from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.commands.juju import JujuStepHelper
-from sunbeam.commands.terraform import TerraformHelper
+from sunbeam.commands.terraform import TerraformException, TerraformHelper
 from sunbeam.jobs import questions
-from sunbeam.jobs.common import BaseStep, Result, ResultType, read_config, update_config
+from sunbeam.jobs.common import (
+    BaseStep,
+    Result,
+    ResultType,
+    read_config,
+    update_config,
+    update_status_background,
+)
 from sunbeam.jobs.juju import (
     MODEL,
     ActionFailedException,
     ApplicationNotFoundException,
     JujuHelper,
+    JujuWaitException,
     LeaderNotFoundException,
+    TimeoutException,
     UnsupportedKubeconfigException,
     run_sync,
 )
@@ -46,8 +55,10 @@ from sunbeam.jobs.steps import (
 LOG = logging.getLogger(__name__)
 MICROK8S_CLOUD = "sunbeam-microk8s"
 APPLICATION = "microk8s"
+MICROK8S_ADDONS_MODEL = "microk8s-addons"
 MICROK8S_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
 MICROK8S_UNIT_TIMEOUT = 1200  # 20 minutes, adding / removing units can take a long time
+MICROK8S_ADDONS_APP_TIMEOUT = 600  # 10 minutes
 CREDENTIAL_SUFFIX = "-creds"
 MICROK8S_DEFAULT_STORAGECLASS = "microk8s-hostpath"
 MICROK8S_KUBECONFIG_KEY = "Microk8sConfig"
@@ -93,8 +104,6 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
         self,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
-        preseed_file: Optional[Path] = None,
-        accept_defaults: bool = False,
     ):
         super().__init__(
             tfhelper,
@@ -106,53 +115,8 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
             "Deploying MicroK8S",
         )
 
-        self.preseed_file = preseed_file
-        self.accept_defaults = accept_defaults
-        self.answer_file = self.tfhelper.path / "addons.auto.tfvars.json"
-        self.variables = {}
-
     def get_application_timeout(self) -> int:
         return MICROK8S_APP_TIMEOUT
-
-    def prompt(self, console: Optional[Console] = None) -> None:
-        """Determines if the step can take input from the user.
-
-        Prompts are used by Steps to gather the necessary input prior to
-        running the step. Steps should not expect that the prompt will be
-        available and should provide a reasonable default where possible.
-        """
-        self.variables = questions.load_answers(self.client, self._ADDONS_CONFIG)
-        self.variables.setdefault("addons", {})
-
-        if self.preseed_file:
-            preseed = questions.read_preseed(self.preseed_file)
-        else:
-            preseed = {}
-        microk8s_addons_bank = questions.QuestionBank(
-            questions=microk8s_addons_questions(),
-            console=console,  # type: ignore
-            preseed=preseed.get("addons"),
-            previous_answers=self.variables.get("addons", {}),
-            accept_defaults=self.accept_defaults,
-        )
-        # Microk8s configuration
-        # Let microk8s handle dns server configuration
-        self.variables["addons"]["dns"] = ""
-        self.variables["addons"]["metallb"] = microk8s_addons_bank.metallb.ask()
-        self.variables["addons"]["hostpath-storage"] = ""
-
-        LOG.debug(self.variables)
-        questions.write_answers(self.client, self._ADDONS_CONFIG, self.variables)
-        # Write answers to terraform location as a separate variables file
-        self.tfhelper.write_tfvars(self.variables, self.answer_file)
-
-    def has_prompts(self) -> bool:
-        """Returns true if the step has prompts that it can ask the user.
-
-        :return: True if the step can ask the user for prompts,
-                 False otherwise
-        """
-        return True
 
 
 class AddMicrok8sUnitStep(AddMachineUnitStep):
@@ -257,6 +221,11 @@ class StoreMicrok8sConfigStep(BaseStep, JujuStepHelper):
     def run(self, status: Optional[Status] = None) -> Result:
         """Store MicroK8S config in clusterd."""
         try:
+            # New charm-microk8s does not have action to get kubeconfig,
+            # use microk8s config to retrieve kubeconfig
+            # Use commented code once charm microk8s support action to
+            # retrieve kubeconfig
+            """
             unit = run_sync(self.jhelper.get_leader_unit(APPLICATION, MODEL))
             result = run_sync(self.jhelper.run_action(unit, MODEL, "kubeconfig"))
             if not result.get("content"):
@@ -265,6 +234,17 @@ class StoreMicrok8sConfigStep(BaseStep, JujuStepHelper):
                     "ERROR: Failed to retrieve kubeconfig",
                 )
             kubeconfig = yaml.safe_load(result["content"])
+            """
+
+            cmd = "microk8s config -l"
+            unit = run_sync(self.jhelper.get_leader_unit(APPLICATION, MODEL))
+            result = run_sync(self.jhelper.run_command(unit, MODEL, cmd))
+            if not result.get("stdout"):
+                return Result(
+                    ResultType.FAILED,
+                    "ERROR: Failed to retrieve kubeconfig",
+                )
+            kubeconfig = yaml.safe_load(result["stdout"])
             update_config(Client(), self._CONFIG, kubeconfig)
         except (
             ApplicationNotFoundException,
@@ -273,5 +253,118 @@ class StoreMicrok8sConfigStep(BaseStep, JujuStepHelper):
         ) as e:
             LOG.debug("Failed to store microk8s config", exc_info=True)
             return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)
+
+
+class DeployMicrok8sAddonsStep(BaseStep, JujuStepHelper):
+    """Deploy Microk8s addons using Terraform"""
+
+    _QUESTIONS_CONFIG = MICROK8S_ADDONS_CONFIG_KEY
+    _CONFIG = MICROK8S_CONFIG_KEY
+
+    def __init__(
+        self,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        preseed_file: Optional[Path] = None,
+        accept_defaults: bool = False,
+    ):
+        super().__init__("Deploy MicroK8S Addons", "Deploying MicroK8S Addons")
+        self.tfhelper = tfhelper
+        self.jhelper = jhelper
+        self.preseed_file = preseed_file
+        self.accept_defaults = accept_defaults
+        self.model = MICROK8S_ADDONS_MODEL
+        self.cloud = MICROK8S_CLOUD
+        self.client = Client()
+        self.variables = {}
+
+    def prompt(self, console: Optional[Console] = None) -> None:
+        """Determines if the step can take input from the user.
+
+        Prompts are used by Steps to gather the necessary input prior to
+        running the step. Steps should not expect that the prompt will be
+        available and should provide a reasonable default where possible.
+        """
+        self.variables = questions.load_answers(self.client, self._QUESTIONS_CONFIG)
+        self.variables.setdefault("addons", {})
+
+        if self.preseed_file:
+            preseed = questions.read_preseed(self.preseed_file)
+        else:
+            preseed = {}
+        microk8s_addons_bank = questions.QuestionBank(
+            questions=microk8s_addons_questions(),
+            console=console,  # type: ignore
+            preseed=preseed.get("addons"),
+            previous_answers=self.variables.get("addons", {}),
+            accept_defaults=self.accept_defaults,
+        )
+        # Microk8s configuration
+        # Let microk8s handle dns server configuration
+        self.variables["addons"]["metallb"] = microk8s_addons_bank.metallb.ask()
+        LOG.debug(self.variables)
+        questions.write_answers(self.client, self._QUESTIONS_CONFIG, self.variables)
+
+    def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user.
+
+        :return: True if the step can ask the user for prompts,
+                 False otherwise
+        """
+        return True
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Apply terraform configuration to deploy microk8s"""
+        try:
+            tfvars = read_config(self.client, self._CONFIG)
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        try:
+            answers = read_config(self.client, self._QUESTIONS_CONFIG)
+        except ConfigItemNotFoundException:
+            answers = {}
+
+        tfvars.update(
+            {
+                "enable-addons": True,
+                "addons-model": self.model,
+                "cloud": self.cloud,
+                "credential": f"{self.cloud}{CREDENTIAL_SUFFIX}",
+                "config": {"workload-storage": MICROK8S_DEFAULT_STORAGECLASS},
+                "charm-coredns-channel": "1.28/stable",
+                "charm-metallb-channel": "1.28/stable",
+            }
+        )
+        if answers.get("addons", {}).get("metallb"):
+            tfvars.update({"metallb-iprange": answers["addons"]["metallb"]})
+
+        update_config(self.client, self._CONFIG, tfvars)
+        self.tfhelper.write_tfvars(tfvars)
+        self.update_status(status, "deploying services")
+        try:
+            self.tfhelper.apply()
+        except TerraformException as e:
+            return Result(ResultType.FAILED, str(e))
+
+        apps = run_sync(self.jhelper.get_application_names(self.model))
+        LOG.debug(f"Application monitored for readiness: {apps}")
+        task = run_sync(update_status_background(self, apps, status))
+        try:
+            run_sync(
+                self.jhelper.wait_until_active(
+                    self.model,
+                    apps,
+                    timeout=MICROK8S_ADDONS_APP_TIMEOUT,
+                )
+            )
+        except (JujuWaitException, TimeoutException) as e:
+            LOG.warning(str(e))
+            return Result(ResultType.FAILED, str(e))
+        finally:
+            if not task.done():
+                task.cancel()
 
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/jobs/juju.py
+++ b/sunbeam-python/sunbeam/jobs/juju.py
@@ -436,6 +436,20 @@ class JujuHelper:
         return action_obj.results
 
     @controller
+    async def run_command(self, name: str, model: str, command: str) -> Dict:
+        """Run command and return the response"""
+        model_impl = await self.get_model(model)
+
+        unit = await self.get_unit(name, model)
+        action_obj = await unit.run(command)
+        await action_obj.wait()
+        if action_obj._status != "completed":
+            output = await model_impl.get_action_output(action_obj.id)
+            raise ActionFailedException(output)
+
+        return action_obj.results
+
+    @controller
     async def scp_from(self, name: str, model: str, source: str, destination: str):
         """scp files from unit to local
 

--- a/sunbeam-python/sunbeam/plugins/migrate/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/migrate/plugin.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Plugin to add any migration tasks."""
+
+import logging
+import shutil
+from typing import Optional
+
+import click
+from packaging.version import Version
+from rich.console import Console
+from rich.status import Status
+from snaphelpers import Snap
+
+from sunbeam.commands.microk8s import DeployMicrok8sAddonsStep
+from sunbeam.commands.terraform import TerraformHelper, TerraformInitStep
+from sunbeam.jobs.common import BaseStep, Result, ResultType, run_plan
+from sunbeam.jobs.juju import JujuHelper
+from sunbeam.plugins.interface.v1.base import BasePlugin
+from sunbeam.utils import CatchGroup
+
+LOG = logging.getLogger(__name__)
+console = Console()
+
+
+class RemoveMicrok8sAddonsTerraformVarStep(BaseStep):
+    def __init__(self):
+        super().__init__(
+            "Remove Unnecessary files",
+            "Remove addons terraform vars",
+        )
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Remove addons.auto.tfvars.json"""
+        snap = Snap()
+        addons_file = (
+            snap.paths.user_common
+            / "etc"  # noqa: W503
+            / "deploy-microk8s"  # noqa: W503
+            / "addons.auto.tfvars.json"  # noqa: W503
+        )
+        addons_file.unlink(missing_ok=True)
+
+        return Result(ResultType.COMPLETED)
+
+
+class MigrateMicrok8sStep(DeployMicrok8sAddonsStep):
+    """Migrate Microk8s from legacy"""
+
+    def __init__(
+        self,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+    ):
+        super().__init__(tfhelper, jhelper)
+
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        if self.client.cluster.list_nodes_by_role("control"):
+            return Result(ResultType.COMPLETED)
+
+        return Result(ResultType.SKIPPED)
+
+    def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user.
+
+        :return: True if the step can ask the user for prompts,
+                 False otherwise
+        """
+        return False
+
+
+class MigratePlugin(BasePlugin):
+    version = Version("0.0.1")
+
+    def __init__(self) -> None:
+        self.name = "migrate"
+        super().__init__(name=self.name)
+
+    def commands(self) -> dict:
+        return {
+            "init": [{"name": self.name, "command": self.migrate}],
+            "migrate": [
+                {"name": "microk8s", "command": self.microk8s},
+            ],
+        }
+
+    @click.group("migrate", cls=CatchGroup)
+    def migrate(self):
+        """Manage migrations."""
+
+    @click.command()
+    def microk8s(self) -> None:
+        """Migrate charm microk8s from legacy."""
+        snap = Snap()
+
+        for tfplan_dir in ["deploy-microk8s"]:
+            src = snap.paths.snap / "etc" / tfplan_dir
+            dst = snap.paths.user_common / "etc" / tfplan_dir
+            LOG.debug(f"Updating {dst} from {src}...")
+            shutil.copytree(src, dst, dirs_exist_ok=True)
+
+        data_location = snap.paths.user_data
+        jhelper = JujuHelper(data_location)
+        tfhelper = TerraformHelper(
+            path=snap.paths.user_common / "etc" / "deploy-microk8s",
+            plan="microk8s-plan",
+            backend="http",
+            data_location=data_location,
+        )
+
+        plan = []
+        # TODO(hemanth): Add a step to determine if deployed charm microk8s
+        # channel is legacy/stable or not
+        plan.append(RemoveMicrok8sAddonsTerraformVarStep())
+        plan.append(TerraformInitStep(tfhelper))
+        # TOCHK(hemanth): Verify once the below bugs are resolved
+        # https://github.com/juju/terraform-provider-juju/issues/249
+        # https://github.com/juju/terraform-provider-juju/issues/278
+        plan.append(MigrateMicrok8sStep(tfhelper, jhelper))
+
+        run_plan(plan, console)
+        click.echo("Migration from legacy microk8s charm completed.")

--- a/sunbeam-python/sunbeam/plugins/plugins.yaml
+++ b/sunbeam-python/sunbeam/plugins/plugins.yaml
@@ -49,3 +49,9 @@ sunbeam-plugins:
       path: sunbeam.plugins.dns.plugin.DnsPlugin
       supported_architectures:
         - amd64
+    - name: "migrate"
+      version: "0.0.1"
+      description: "Plugin for migrations"
+      path: plugins.migrate.plugin.MigratePlugin
+      supported_architectures:
+        - amd64


### PR DESCRIPTION
Update microk8s terraform plan to switch to new
charm microk8s. Add new step to enable addons
in microk8s that should deploy and configure
coredns and metallb charm.
coredns addon is enabled by default in microk8s.
But coredns charm is deployed so that coredns
can be configured in future using charm configs.

Note:
* New charm microk8s deploys only classic snap
but not the strict variant.
* Limitation in charm metallb to scale
https://github.com/charmed-kubernetes/metallb-operator/blob/30038cc35174ffdf944edd3dc18baf6141b5e95c/src/charm.py#L80

TODO:
1. Migration have to be tested from legacy charm
to new charm. To do this, following bugs have
to be resolved
https://github.com/juju/terraform-provider-juju/issues/249
https://github.com/juju/terraform-provider-juju/issues/278

2. Add README and tests to migration plugin
3. Wait for support for microk8s snap strict varinat in charm-microk8s