### PR TITLE
Switch to using juju 3.1

### DIFF
--- a/sunbeam-python/requirements.txt
+++ b/sunbeam-python/requirements.txt
@@ -21,8 +21,8 @@ pexpect
 # YAML parsing library
 pyyaml>=6.0
 
-# Set upper bound to match Juju 3.2.x series target
-juju>=3.2,<3.3
+# Set upper bound to match Juju 3.1.x series target
+juju>=3.1,<3.2
 
 # Used in the launch command to launch an instance
 petname

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -19,7 +19,7 @@ from rich.console import Console
 console = Console()
 
 
-JUJU_CHANNEL = "3.2/stable"
+JUJU_CHANNEL = "3.1/stable"
 SUPPORTED_RELEASE = "jammy"
 
 PREPARE_NODE_TEMPLATE = f"""#!/bin/bash


### PR DESCRIPTION
Switch to using Juju 3.1 as it has a longer support life than Juju 3.2.