### PR TITLE
bootstrap: allow control role only

### DIFF
--- a/sunbeam-python/sunbeam/commands/bootstrap.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap.py
@@ -99,8 +99,8 @@ snap = Snap()
     "--role",
     "roles",
     multiple=True,
-    default=["compute"],
-    type=click.Choice(["compute", "storage"], case_sensitive=False),
+    default=["control", "compute"],
+    type=click.Choice(["control", "compute", "storage"], case_sensitive=False),
     callback=validate_roles,
     help="Specify additional roles, compute or storage, for the "
     "bootstrap node. Defaults to the compute role.",
@@ -135,8 +135,10 @@ def bootstrap(
 
     Initialize the sunbeam cluster.
     """
-    # The bootstrap node must always be a control node.
-    roles.append(Role.CONTROL)
+    # Bootstrap node must always have the control role
+    if Role.CONTROL not in roles:
+        LOG.debug("Enabling control role for bootstrap")
+        roles.append(Role.CONTROL)
     is_control_node = any(role.is_control_node() for role in roles)
     is_compute_node = any(role.is_compute_node() for role in roles)
     is_storage_node = any(role.is_storage_node() for role in roles)


### PR DESCRIPTION
Allow bootstrap of a cluster using the control role only for a dedicated set of control plane nodes.