### PR TITLE
Miscellaneous fixes in plugins

### DIFF
--- a/sunbeam-python/sunbeam/jobs/plugin.py
+++ b/sunbeam-python/sunbeam/jobs/plugin.py
@@ -85,7 +85,11 @@ class PluginManager:
                 module = importlib.import_module(module_class_[0])
                 plugin_class = getattr(module, module_class_[1])
                 plugin_classes.append(plugin_class)
-            except (ModuleNotFoundError, AttributeError) as e:
+            # Catching Exception instead of specific errors as plugins
+            # can raise any exception based on implementation.
+            except Exception as e:
+                # Exceptions observed so far
+                # ModuleNotFoundError, AttributeError, NameError
                 LOG.debug(str(e))
                 LOG.warning(f"Ignored loading plugin: {plugin_class}")
                 if raise_exception:

--- a/sunbeam-python/sunbeam/main.py
+++ b/sunbeam-python/sunbeam/main.py
@@ -106,11 +106,11 @@ def main():
     cli.add_command(enable)
     cli.add_command(disable)
 
-    # Register the plugins
-    PluginManager.register(cli)
-
     cli.add_command(utils)
     utils.add_command(utils_cmds.juju_login)
+
+    # Register the plugins after all groups,commands are registered
+    PluginManager.register(cli)
 
     cli()
 


### PR DESCRIPTION
Register plugins after all groups and commands
are registered. This is required as plugins
can refer the groups that are defined in main.
Loading plugin modules might raise any exception
and so catch generic Exception instead of specific ones while loading plugin module.