### PR TITLE
Increase timeout to 90 minutes

### DIFF
--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -54,7 +54,7 @@ from sunbeam.jobs.juju import (
 
 LOG = logging.getLogger(__name__)
 OPENSTACK_MODEL = "openstack"
-OPENSTACK_DEPLOY_TIMEOUT = 3600  # 60 minutes
+OPENSTACK_DEPLOY_TIMEOUT = 5400  # 90 minutes
 METALLB_ANNOTATION = "metallb.universe.tf/loadBalancerIPs"
 
 CONFIG_KEY = "TerraformVarsOpenstack"


### PR DESCRIPTION
Some underlying components have increased execution time, increase the timeout for deploy and resize operations.