### PR TITLE
Freeze traefik-public IP address

### DIFF
--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -367,7 +367,7 @@ class ResizeControlPlaneStep(BaseStep, JujuStepHelper):
 
 
 class PatchLoadBalancerServicesStep(BaseStep):
-    SERVICES = ["traefik", "rabbitmq", "ovn-relay"]
+    SERVICES = ["traefik", "traefik-public", "rabbitmq", "ovn-relay"]
     MODEL = OPENSTACK_MODEL
 
     def __init__(


### PR DESCRIPTION
Traefik has been split in two to accelerate deployment and split internal and public networks.