### PR TITLE
[telemetry] Remove ceilometer upgrade step

### DIFF
--- a/sunbeam-python/sunbeam/plugins/secrets/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/secrets/plugin.py
@@ -16,7 +16,6 @@
 import click
 from packaging.version import Version
 
-
 from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.jobs.common import read_config
 from sunbeam.plugins.interface.v1.openstack import (


### PR DESCRIPTION
Ceilometer dbsync is done as part of the bootstrap process in ceilometer-k8s charm and so running that step is no more necessary in sunbeam.
Remove ceilometer upgrade step.