### PR TITLE
Use of wrong constant on Remove microk8s step

### DIFF
--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -188,7 +188,7 @@ class RemoveMicrok8sUnitStep(RemoveMachineUnitStep):
         )
 
     def get_unit_timeout(self) -> int:
-        return SUNBEAM_MACHINE_UNIT_TIMEOUT
+        return MICROK8S_UNIT_TIMEOUT
 
 
 class AddMicrok8sCloudStep(BaseStep, JujuStepHelper):


### PR DESCRIPTION
Use of the wrong constant in microk8s remove step, and the constant used is not even in scope.