### PR TITLE
Refresh to bobcat channels

### DIFF
--- a/cloud/etc/deploy-openstack-hypervisor/variables.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/variables.tf
@@ -22,13 +22,13 @@ variable "machine_ids" {
 variable "snap_channel" {
   description = "Snap channel to deploy openstack-hypervisor snap from"
   type        = string
-  default     = "2023.1/edge"
+  default     = "2023.2/edge"
 }
 
 variable "charm_channel" {
   description = "Charm channel to deploy openstack-hypervisor charm from"
   type        = string
-  default     = "2023.1/edge"
+  default     = "2023.2/edge"
 }
 
 variable "openstack_model" {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Dead simple OpenStack installation
 license: Apache-2.0
 description: |
   snap-openstack aims to provide a scalable, simple to deploy OpenStack solution.
-version: "2023.1"
+version: "2023.2"
 
 confinement: strict
 grade: stable

--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -214,8 +214,8 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
             {
                 "model": self.model,
                 # Make these channel options configurable by the user
-                "openstack-channel": "2023.1/edge",
-                "ovn-channel": "23.03/edge",
+                "openstack-channel": "2023.2/edge",
+                "ovn-channel": "23.09/edge",
                 "rabbitmq-channel": "3.12/edge",
                 "cloud": self.cloud,
                 "credential": f"{self.cloud}{CREDENTIAL_SUFFIX}",

--- a/sunbeam-python/sunbeam/plugins/dns/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/dns/plugin.py
@@ -82,7 +82,7 @@ class DnsPlugin(OpenStackControlPlanePlugin):
     def set_tfvars_on_enable(self) -> dict:
         """Set terraform variables to enable the application."""
         return {
-            "designate-channel": "2023.1/edge",
+            "designate-channel": "2023.2/edge",
             "enable-designate": True,
             "nameservers": self.nameservers,
         }

--- a/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
@@ -46,7 +46,7 @@ class LoadbalancerPlugin(OpenStackControlPlanePlugin):
     def set_tfvars_on_enable(self) -> dict:
         """Set terraform variables to enable the application."""
         return {
-            "octavia-channel": "2023.1/edge",
+            "octavia-channel": "2023.2/edge",
             "enable-octavia": True,
         }
 

--- a/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
@@ -46,7 +46,7 @@ class OrchestrationPlugin(OpenStackControlPlanePlugin):
     def set_tfvars_on_enable(self) -> dict:
         """Set terraform variables to enable the application."""
         return {
-            "heat-channel": "2023.1/edge",
+            "heat-channel": "2023.2/edge",
             "enable-heat": True,
         }
 

--- a/sunbeam-python/sunbeam/plugins/secrets/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/secrets/plugin.py
@@ -46,7 +46,7 @@ class SecretsPlugin(OpenStackControlPlanePlugin):
         """Set terraform variables to enable the application."""
         return {
             "enable-barbican": True,
-            "barbican-channel": "2023.1/edge",
+            "barbican-channel": "2023.2/edge",
         }
 
     def set_tfvars_on_disable(self) -> dict:

--- a/sunbeam-python/sunbeam/plugins/telemetry/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/telemetry/plugin.py
@@ -112,7 +112,7 @@ class TelemetryPlugin(OpenStackControlPlanePlugin):
     def set_tfvars_on_enable(self) -> dict:
         """Set terraform variables to enable the application."""
         return {
-            "telemetry-channel": "2023.1/edge",
+            "telemetry-channel": "2023.2/edge",
             "enable-telemetry": True,
         }
 

--- a/sunbeam-python/upper-constraints.txt
+++ b/sunbeam-python/upper-constraints.txt
@@ -60,7 +60,7 @@ grpcio===1.49.1
 pysendfile===2.0.1
 sniffio===1.3.0
 fixtures===4.0.1
-neutron-lib===3.4.0
+neutron-lib===3.4.1
 XStatic-FileSaver===1.3.2.0
 oslo.metrics===0.6.0
 storage-interfaces===1.0.4
@@ -158,7 +158,7 @@ XStatic-roboto-fontface===0.5.0.0
 pyudev===0.24.0
 eventlet===0.33.1
 openstack-doc-tools===3.3.1
-oslo.messaging===14.2.0
+oslo.messaging===14.2.1
 jira===3.4.1
 extras===1.0.0
 PyJWT===2.5.0
@@ -219,7 +219,7 @@ h11===0.12.0
 Pygments===2.13.0
 XStatic-Hogan===2.0.0.3
 XStatic-objectpath===1.2.1.0
-python-manilaclient===4.3.0
+python-manilaclient===4.4.0
 sphinxcontrib-serializinghtml===1.1.5
 requests===2.28.1
 snowballstemmer===2.2.0
@@ -249,7 +249,7 @@ funcparserlib===1.0.0
 passlib===1.7.4
 dib-utils===0.0.11
 cliff===4.2.0
-os-brick===6.2.0
+os-brick===6.2.2
 ansible-runner===2.2.1
 pytz-deprecation-shim===0.1.0.post0
 scp===0.14.4
@@ -282,7 +282,7 @@ XStatic-bootswatch===3.3.7.0
 pytest-xdist===2.5.0
 XStatic-JS-Yaml===3.8.1.0
 XStatic-term.js===0.0.7.0
-oslo.log===5.0.0
+oslo.log===5.2.0
 nodeenv===1.7.0
 gossip===2.4.0
 suds-community===1.1.2
@@ -358,7 +358,7 @@ python-cinderclient===9.3.0
 keystonemiddleware===10.2.0
 django-formtools===2.4
 XStatic-Spin===1.2.5.3
-tap-as-a-service===11.0.0.0rc1
+tap-as-a-service===11.0.0
 os-traits===2.10.0
 typepy===1.3.0
 SecretStorage===3.3.3
@@ -522,7 +522,7 @@ keystoneauth1===5.1.2
 statsd===3.3.0
 XenAPI===2.14
 python-keystoneclient===5.1.0
-ceilometer===20.0.0.0rc1
+ceilometer===20.0.0
 diskimage-builder===3.25.0
 heat-translator===2.7.0
 python-magnumclient===4.1.0
@@ -544,7 +544,7 @@ sphinxcontrib-devhelp===1.0.2
 python-blazarclient===3.6.0
 alembic===1.8.1
 execnet===1.9.0
-glance-store===4.3.0
+glance-store===4.3.1
 sphinxcontrib-programoutput===0.17
 storpool.spopenstack===3.1.0
 sphinx-testing===1.0.1


### PR DESCRIPTION
Update deployment plans, terraform modules to use 2023.2 or 23.09 for OpenStack and OVN components.

Refresh upper-constraints to latest 2023.1 commit.