### PR TITLE
User should not specify more than 5 DNS nameservers per subnet

### DIFF
--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -242,7 +242,7 @@ def get_free_nic() -> str:
     return nic
 
 
-def get_nameservers(ipv4_only=True) -> List[str]:
+def get_nameservers(ipv4_only=True, max_count=5) -> List[str]:
     """Return a list of nameservers used by the host."""
     resolve_config = Path("/run/systemd/resolve/resolv.conf")
     nameservers = []
@@ -258,7 +258,7 @@ def get_nameservers(ipv4_only=True) -> List[str]:
         nameservers = list(set(nameservers))
     except FileNotFoundError:
         nameservers = []
-    return nameservers
+    return nameservers[:max_count]
 
 
 def generate_password() -> str:


### PR DESCRIPTION
The default max_dns_nameservers for neutron is 5, so using less than 5 DNS namesservers per subnet can avoid the exception DNSNameServersExhausted.

Closes-Bug: 2039403