### PR TITLE
Add cluster refresh command for upgrades

### DIFF
--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -22,7 +22,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 import pexpect
 import pwgen
@@ -172,29 +172,8 @@ class JujuStepHelper:
 
         return True
 
-    def get_available_charm_revision(
-        self, charm_name: str, track: str, risk: str, arch: str = "amd64"
-    ) -> int:
-        """Find the latest available revision of a charm in a given channel
-
-        :param charm_name: Name of charm to look up
-        :param track: Track of charm
-        :param risk: Risk of charm
-        :param arch: Arch of charm
-        """
-        available_charm_data = self._juju_cmd(*["info", charm_name])
-        channel_data = [
-            d
-            for d in available_charm_data["channels"][track][risk]
-            if arch in d["architectures"]
-        ]
-        assert len(channel_data) == 1, "Unexpected candidate charms {}".format(
-            len(channel_data)
-        )
-        return int(channel_data[0]["revision"])
-
     def revision_update_needed(
-        self, application_name: str, model: str, status: Union[dict, None] = None
+        self, application_name: str, model: str, status: dict | None = None
     ) -> bool:
         """Check if a revision update is available for an applicaton.
 
@@ -212,15 +191,14 @@ class JujuStepHelper:
         deployed_revision = int(self._extract_charm_revision(app_status["charm"]))
         charm_name = self._extract_charm_name(app_status["charm"])
         deployed_channel = self.normalise_channel(app_status["charm-channel"])
-        track = deployed_channel.split("/")[0]
-        risk = deployed_channel.split("/")[1]
-        try:
-            deployed_channel.split("/")[2]
+        if len(deployed_channel.split("/")) > 2:
             LOG.debug(f"Cannot calculate upgrade for {application_name}, branch in use")
             return False
-        except IndexError:
-            pass
-        available_revision = self.get_available_charm_revision(charm_name, track, risk)
+        available_revision = run_sync(
+            self.jhelper.get_available_charm_revision(
+                model, charm_name, deployed_channel
+            )
+        )
         return bool(available_revision > deployed_revision)
 
     def normalise_channel(self, channel: str) -> str:

--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -51,6 +51,7 @@ from sunbeam.jobs.juju import (
     TimeoutException,
     run_sync,
 )
+from sunbeam.versions import OPENSTACK_CHANNEL, OVN_CHANNEL, RABBITMQ_CHANNEL
 
 LOG = logging.getLogger(__name__)
 OPENSTACK_MODEL = "openstack"
@@ -214,9 +215,9 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
             {
                 "model": self.model,
                 # Make these channel options configurable by the user
-                "openstack-channel": "2023.2/edge",
-                "ovn-channel": "23.09/edge",
-                "rabbitmq-channel": "3.12/edge",
+                "openstack-channel": OPENSTACK_CHANNEL,
+                "ovn-channel": OVN_CHANNEL,
+                "rabbitmq-channel": RABBITMQ_CHANNEL,
                 "cloud": self.cloud,
                 "credential": f"{self.cloud}{CREDENTIAL_SUFFIX}",
                 "config": {"workload-storage": MICROK8S_DEFAULT_STORAGECLASS},

--- a/sunbeam-python/sunbeam/commands/refresh.py
+++ b/sunbeam-python/sunbeam/commands/refresh.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+import click
+from rich.console import Console
+from snaphelpers import Snap
+
+from sunbeam.commands.terraform import TerraformHelper
+from sunbeam.commands.upgrades.inter_channel import ChannelUpgradeCoordinator
+from sunbeam.commands.upgrades.intra_channel import LatestInChannelCoordinator
+from sunbeam.jobs.juju import JujuHelper
+
+LOG = logging.getLogger(__name__)
+console = Console()
+snap = Snap()
+
+
+@click.command()
+@click.option(
+    "--upgrade-release",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Upgrade OpenStack release.",
+)
+def refresh(upgrade_release) -> None:
+    """Refresh deployment.
+
+    Refresh the deployment. If --upgrade-release is supplied then charms are
+    upgraded the channels aligned with this snap revision
+    """
+    tfplan = "deploy-openstack"
+    data_location = snap.paths.user_data
+    tfhelper = TerraformHelper(
+        path=snap.paths.user_common / "etc" / tfplan,
+        plan="openstack-plan",
+        backend="http",
+        data_location=data_location,
+    )
+    jhelper = JujuHelper(data_location)
+    if upgrade_release:
+        a = ChannelUpgradeCoordinator(jhelper, tfhelper)
+        a.run_plan()
+    else:
+        a = LatestInChannelCoordinator(jhelper, tfhelper)
+        a.run_plan()
+    click.echo("Refresh complete.")

--- a/sunbeam-python/sunbeam/commands/upgrades/base.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/base.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Optional
+
+from rich.console import Console
+from rich.status import Status
+
+from sunbeam.commands.terraform import TerraformHelper
+from sunbeam.jobs.common import BaseStep, Result, ResultType, run_plan
+from sunbeam.jobs.juju import JujuHelper
+from sunbeam.jobs.plugin import PluginManager
+
+LOG = logging.getLogger(__name__)
+console = Console()
+
+
+class UpgradePlugins(BaseStep):
+    def __init__(
+        self,
+        jhelper: JujuHelper,
+        tfhelper: TerraformHelper,
+        upgrade_release: bool = False,
+    ):
+        """Upgrade plugins.
+
+        :jhelper: Helper for interacting with pylibjuju
+        :tfhelper: Helper for interaction with Terraform
+        :upgrade_release: Whether to upgrade channel
+        """
+        super().__init__("Validation", "Running pre-upgrade validation")
+        self.jhelper = jhelper
+        self.tfhelper = tfhelper
+        self.upgrade_release = upgrade_release
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        PluginManager.update_plugins(
+            repos=["core"], upgrade_release=self.upgrade_release
+        )
+        return Result(ResultType.COMPLETED)
+
+
+class UpgradeCoordinator:
+    def __init__(
+        self, jhelper: JujuHelper, tfhelper: TerraformHelper, channel: str = None
+    ):
+        """Upgrade coordinator.
+
+        Execute plan for conducting an upgrade.
+
+        :jhelper: Helper for interacting with pylibjuju
+        :tfhelper: Helper for interaction with Terraform
+        :channel: OpenStack channel to upgrade charms to
+        """
+        self.channel = channel
+        self.jhelper = jhelper
+        self.tfhelper = tfhelper
+
+    def get_plan(self) -> list[BaseStep]:
+        """Return the plan for this upgrade.
+
+        Return the steps to complete this upgrade.
+        """
+        return []
+
+    def run_plan(self) -> None:
+        """Execute the upgrade plan."""
+        plan = self.get_plan()
+        run_plan(plan, console)

--- a/sunbeam-python/sunbeam/commands/upgrades/base.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/base.py
@@ -55,7 +55,7 @@ class UpgradePlugins(BaseStep):
 
 class UpgradeCoordinator:
     def __init__(
-        self, jhelper: JujuHelper, tfhelper: TerraformHelper, channel: str = None
+        self, jhelper: JujuHelper, tfhelper: TerraformHelper, channel: str | None = None
     ):
         """Upgrade coordinator.
 

--- a/sunbeam-python/sunbeam/commands/upgrades/inter_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/inter_channel.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Callable, Dict, List, Optional, Union
+
+from rich.console import Console
+from rich.status import Status
+
+from sunbeam.clusterd.client import Client
+from sunbeam.commands.juju import JujuStepHelper
+from sunbeam.commands.terraform import TerraformHelper
+from sunbeam.commands.upgrades.base import UpgradeCoordinator, UpgradePlugins
+from sunbeam.commands.upgrades.intra_channel import LatestInChannel
+from sunbeam.jobs.common import (
+    BaseStep,
+    Result,
+    ResultType,
+    read_config,
+    run_plan,
+    update_config,
+)
+from sunbeam.jobs.juju import JujuHelper, run_sync
+from sunbeam.versions import (
+    CHARM_VERSIONS,
+    MACHINE_SERVICES,
+    MISC_SERVICES_K8S,
+    OPENSTACK_SERVICES_K8S,
+    OVN_SERVICES_K8S,
+)
+
+LOG = logging.getLogger(__name__)
+console = Console()
+
+
+class BaseUpgrade(BaseStep, JujuStepHelper):
+    def __init__(self, name, description, jhelper, tfhelper, model):
+        """Create instance of BaseUpgrade class.
+
+        :jhelper: Helper for interacting with pylibjuju
+        :tfhelper: Helper for interaction with Terraform
+        :model: Name of model containing charms.
+        """
+        super().__init__(name, description)
+        self.jhelper = jhelper
+        self.tfhelper = tfhelper
+        self.model = model
+
+    def get_upgrade_strategy(self) -> List[Dict[str, Union[Callable, List]]]:
+        """Return a strategy for performing the upgrade.
+
+        The strategy is a list of dicts. Each dict consists of:
+            {
+                "upgrade_f": f,
+                "applications": [apps]
+            },
+
+        upgrade_f is the function to be applied to each application (in
+        parallel) to perform the upgrade.
+
+        applications is a list of applications that can be upgraded in parallel.
+
+        Currently only apps that are upgraded with the same function can be
+        grouped together.
+        """
+        raise NotImplementedError
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Run control plane and machine charm upgrade."""
+        self.pre_upgrade_tasks()
+        for step in self.get_upgrade_strategy():
+            step["upgrade_f"](step["applications"], self.model)
+        self.post_upgrade_tasks()
+        return Result(ResultType.COMPLETED)
+
+    def pre_upgrade_tasks(self) -> None:
+        """Tasks to run before the upgrade."""
+        return
+
+    def post_upgrade_tasks(self) -> None:
+        """Tasks to run after the upgrade."""
+        return
+
+    def upgrade_applications(
+        self,
+        application_list: List[str],
+        model: str,
+        expect_wls: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Upgrade applications.
+
+        :param application_list: List of applications to be upgraded
+        :param model: Name of model
+        :param expect_wls: The expected workload status after charm upgrade.
+        """
+        if not expect_wls:
+            expect_wls = {"workload": ["blocked", "active"]}
+        batch = {}
+        for app_name in application_list:
+            new_channel = self.get_new_channel(app_name, model)
+            if new_channel:
+                LOG.debug(f"Upgrade needed for {app_name}")
+                batch[app_name] = {
+                    "channel": new_channel,
+                    "expected_status": expect_wls,
+                }
+            else:
+                LOG.debug(f"{app_name} no channel upgrade needed")
+        run_sync(self.jhelper.update_applications_channel(model, batch))
+
+    def get_new_channel(self, application_name: str, model: str) -> Union[str, None]:
+        """Check application to see if an upgrade is needed.
+
+        Check application to see if an upgrade is needed. A 'None'
+        returned indicates no upgrade is needed.
+
+        :param application_name: Name of application
+        :param model: Model application is in
+        """
+        new_channel = None
+        current_channel = run_sync(
+            self.jhelper.get_charm_channel(application_name, model)
+        )
+        new_channel = CHARM_VERSIONS.get(application_name)
+        if current_channel and new_channel:
+            if self.channel_update_needed(current_channel, new_channel):
+                return new_channel
+            else:
+                return None
+        else:
+            # No current_channel indicates application is missing
+            return new_channel
+
+    def terraform_sync(self, config_key: str, tfvars_delta: dict) -> None:
+        """Sync the running state back to the Terraform state file.
+
+        :param config_key: The config key used to access the data in microcluster
+        :param tfvars_delta: The delta of changes to be applied to the terraform
+                             vars stored in microcluster.
+        """
+        self.client = Client()
+        tfvars = read_config(self.client, config_key)
+        tfvars.update(tfvars_delta)
+        update_config(self.client, config_key, tfvars)
+        self.tfhelper.write_tfvars(tfvars)
+        self.tfhelper.sync()
+
+
+class UpgradeControlPlane(BaseUpgrade):
+    def __init__(self, jhelper, tfhelper, model):
+        """Create instance of BaseUpgrade class.
+
+        :jhelper: Helper for interacting with pylibjuju
+        :tfhelper: Helper for interaction with Terraform
+        :model: Name of model containing charms.
+        """
+        super().__init__(
+            "Upgrade K8S charms",
+            "Upgrade K8S charms channels to align with snap",
+            jhelper,
+            tfhelper,
+            model,
+        )
+
+    def get_upgrade_strategy(self) -> List[Dict[str, Union[Callable, List]]]:
+        """Return a strategy for performing the upgrade.
+
+        Upgrade all control plane applications in parallel.
+        """
+        upgrade_strategy = [
+            {
+                "upgrade_f": self.upgrade_applications,
+                "applications": list(MISC_SERVICES_K8S.keys())
+                + list(OVN_SERVICES_K8S.keys())  # noqa
+                + list(OPENSTACK_SERVICES_K8S.keys()),  # noqa
+            },
+        ]
+        return upgrade_strategy
+
+    def post_upgrade_tasks(self) -> None:
+        """Update channels in terraform vars db."""
+        tfvars_delta = {
+            "openstack-channel": run_sync(
+                self.jhelper.get_charm_channel("keystone", "openstack")
+            ),
+            "ovn-channel": run_sync(
+                self.jhelper.get_charm_channel("ovn-central", "openstack")
+            ),
+            "rabbitmq-channel": run_sync(
+                self.jhelper.get_charm_channel("rabbitmq", "openstack")
+            ),
+            "traefik-channel": run_sync(
+                self.jhelper.get_charm_channel("traefik", "openstack")
+            ),
+        }
+        self.terraform_sync("TerraformVarsOpenstack", tfvars_delta)
+
+
+class UpgradeMachineCharms(BaseUpgrade):
+    def __init__(self, jhelper, tfhelper, model):
+        """Create instance of BaseUpgrade class.
+
+        :jhelper: Helper for interacting with pylibjuju
+        :tfhelper: Helper for interaction with Terraform
+        :model: Name of model containing charms.
+        """
+        super().__init__(
+            "Upgrade Machine charms",
+            "Upgrade machine charms channels to align with snap",
+            jhelper,
+            tfhelper,
+            model,
+        )
+
+    def get_upgrade_strategy(self) -> List[Dict[str, Union[Callable, List]]]:
+        """Return a strategy for performing the upgrade.
+
+        Upgrade all machine applications in parallel.
+        """
+        upgrade_strategy = [
+            {
+                "upgrade_f": self.upgrade_applications,
+                "applications": MACHINE_SERVICES,
+            },
+        ]
+        return upgrade_strategy
+
+    def post_upgrade_tasks(self) -> None:
+        """Update channels in terraform vars db."""
+        self.terraform_sync(
+            "TerraformVarsMicrocephPlan",
+            {
+                "microceph_channel": run_sync(
+                    self.jhelper.get_charm_channel("microceph", "controller")
+                )
+            },
+        )
+        self.terraform_sync(
+            "TerraformVarsSunbeamMachine",
+            {
+                "charm_channel": run_sync(
+                    self.jhelper.get_charm_channel("sunbeam-machine", "controller")
+                )
+            },
+        )
+        self.terraform_sync(
+            "TerraformVarsHypervisor",
+            {
+                "charm_channel": run_sync(
+                    self.jhelper.get_charm_channel("openstack-hypervisor", "controller")
+                )
+            },
+        )
+        self.terraform_sync(
+            "TerraformVarsMicrok8sAddons",
+            {
+                "microk8s_channel": run_sync(
+                    self.jhelper.get_charm_channel("microk8s", "controller")
+                )
+            },
+        )
+
+
+class ChannelUpgradeCoordinator(UpgradeCoordinator):
+    def __init__(self, jhelper: JujuHelper, tfhelper: TerraformHelper):
+        """Upgrade coordinator.
+
+        Execute plan for conducting an upgrade.
+
+        :jhelper: Helper for interacting with pylibjuju
+        :tfhelper: Helper for interaction with Terraform
+        """
+        self.jhelper = jhelper
+        self.tfhelper = tfhelper
+
+    def get_plan(self) -> list[BaseStep]:
+        """Return the plan for this upgrade.
+
+        Return the steps to complete this upgrade.
+        """
+        plan = [
+            ValidationCheck(self.jhelper, self.tfhelper),
+            LatestInChannel(self.jhelper),
+            UpgradeControlPlane(self.jhelper, self.tfhelper, "openstack"),
+            UpgradeMachineCharms(self.jhelper, self.tfhelper, "controller"),
+            UpgradePlugins(self.jhelper, self.tfhelper, upgrade_release=True),
+        ]
+        return plan
+
+    def run_plan(self) -> None:
+        """Execute the upgrade plan."""
+        plan = self.get_plan()
+        run_plan(plan, console)
+
+
+class ValidationCheck(BaseStep):
+    def __init__(self, jhelper: JujuHelper, tfhelper: TerraformHelper):
+        """Run validation on the deployment.
+
+        Check whether the requested upgrade is possible.
+
+        :jhelper: Helper for interacting with pylibjuju
+        :tfhelper: Helper for interaction with Terraform
+        :channel: OpenStack channel to upgrade charms to
+        """
+        super().__init__("Validation", "Running pre-upgrade validation")
+        self.jhelper = jhelper
+        self.tfhelper = tfhelper
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Run validation check."""
+        rabbit_channel = run_sync(
+            self.jhelper.get_charm_channel("rabbitmq", "openstack")
+        )
+        if rabbit_channel.split("/")[0] == "3.9":
+            return Result(
+                ResultType.FAILED,
+                (
+                    "Pre-upgrade validation failed: Rabbit charm cannot be "
+                    "upgraded from 3.9"
+                ),
+            )
+        else:
+            return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+from typing import Optional
+
+from rich.console import Console
+from rich.status import Status
+
+from sunbeam.commands.juju import JujuStepHelper
+from sunbeam.commands.upgrades.base import UpgradeCoordinator, UpgradePlugins
+from sunbeam.jobs.common import BaseStep, Result, ResultType
+from sunbeam.jobs.juju import run_sync
+from sunbeam.versions import K8S_SERVICES, MACHINE_SERVICES
+
+LOG = logging.getLogger(__name__)
+console = Console()
+
+
+class LatestInChannel(BaseStep, JujuStepHelper):
+    def __init__(self, jhelper):
+        """Upgrade all charms to latest in current channel.
+
+        :jhelper: Helper for interacting with pylibjuju
+        """
+        super().__init__(
+            "In channel upgrade", "Upgrade charms to latest revision in current channel"
+        )
+        self.jhelper = jhelper
+
+    def get_charm_update(self, applications, model) -> list[str]:
+        """Return a list applications that need to be refreshed."""
+        candidates = []
+        _status = run_sync(self.jhelper.get_model_status_full(model))
+        status = json.loads(_status.to_json())
+        for app_name in applications:
+            if self.revision_update_needed(app_name, model, status=status):
+                candidates.append(app_name)
+            else:
+                LOG.debug(f"{app_name} already at latest version in current channel")
+        return candidates
+
+    def get_charm_update_candidates_k8s(self) -> list[str]:
+        """Return a list of all k8s charms that need to be refreshed."""
+        return self.get_charm_update(K8S_SERVICES.keys(), "openstack")
+
+    def get_charm_update_candidates_machine(self) -> list[str]:
+        """Return a list of all machine charms that need to be refreshed."""
+        return self.get_charm_update(MACHINE_SERVICES.keys(), "controller")
+
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Step can be skipped if nothing needs refreshing."""
+        if (
+            self.get_charm_update_candidates_k8s()
+            or self.get_charm_update_candidates_machine()  # noqa
+        ):
+            return Result(ResultType.COMPLETED)
+        else:
+            return Result(ResultType.SKIPPED)
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Refresh all charms identified as needing a refresh."""
+        for app_name in self.get_charm_update_candidates_k8s():
+            LOG.debug(f"Refreshing {app_name}")
+            app = run_sync(self.jhelper.get_application(app_name, "openstack"))
+            run_sync(app.refresh())
+        for app_name in self.get_charm_update_candidates_machine():
+            LOG.debug(f"Refreshing {app_name}")
+            app = run_sync(self.jhelper.get_application(app_name, "controller"))
+            run_sync(app.refresh())
+        return Result(ResultType.COMPLETED)
+
+
+class LatestInChannelCoordinator(UpgradeCoordinator):
+    """Coordinator for refreshing charms in their current channel."""
+
+    def get_plan(self) -> list[BaseStep]:
+        return [
+            LatestInChannel(self.jhelper),
+            UpgradePlugins(self.jhelper, self.tfhelper, upgrade_release=False),
+        ]

--- a/sunbeam-python/sunbeam/jobs/plugin.py
+++ b/sunbeam-python/sunbeam/jobs/plugin.py
@@ -316,7 +316,9 @@ class PluginManager:
         )
 
     @classmethod
-    def update_plugins(cls, repos: Optional[list] = []) -> None:
+    def update_plugins(
+        cls, repos: Optional[list] = [], upgrade_release: bool = False
+    ) -> None:
         """Call plugin upgrade hooks.
 
         Get all the plugins defined in repos and call the corresponding plugin
@@ -350,8 +352,16 @@ class PluginManager:
                 if (
                     hasattr(plugin, "enabled")
                     and p.enabled  # noqa W503
-                    and cls.is_plugin_version_changed(p)  # noqa W503
                     and hasattr(plugin, "upgrade_hook")  # noqa W503
                 ):
                     LOG.debug(f"Upgrading plugin {p.name} defined in repo {repo}")
-                    p.upgrade_hook()
+                    try:
+                        p.upgrade_hook(upgrade_release=upgrade_release)
+                    except TypeError:
+                        LOG.debug(
+                            (
+                                f"Plugin {p.name} does not support upgrades "
+                                "between channels"
+                            )
+                        )
+                        p.upgrade_hook()

--- a/sunbeam-python/sunbeam/main.py
+++ b/sunbeam-python/sunbeam/main.py
@@ -29,6 +29,7 @@ from sunbeam.commands import launch as launch_cmds
 from sunbeam.commands import node as node_cmds
 from sunbeam.commands import openrc as openrc_cmds
 from sunbeam.commands import prepare_node as prepare_node_cmds
+from sunbeam.commands import refresh as refresh_cmds
 from sunbeam.commands import resize as resize_cmds
 from sunbeam.commands import utils as utils_cmds
 from sunbeam.jobs.plugin import PluginManager
@@ -101,6 +102,7 @@ def main():
     cluster.add_command(node_cmds.join)
     cluster.add_command(node_cmds.list)
     cluster.add_command(node_cmds.remove)
+    cluster.add_command(refresh_cmds.refresh)
     cluster.add_command(resize_cmds.resize)
 
     cli.add_command(enable)

--- a/sunbeam-python/sunbeam/plugins/dns/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/dns/plugin.py
@@ -30,6 +30,7 @@ from sunbeam.plugins.interface.v1.openstack import (
     OpenStackControlPlanePlugin,
     TerraformPlanLocation,
 )
+from sunbeam.versions import OPENSTACK_CHANNEL
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -171,3 +172,20 @@ class DnsPlugin(OpenStackControlPlanePlugin):
                 }
             )
         return commands
+
+    @property
+    def k8s_application_data(self):
+        return {
+            "designate": {
+                "channel": OPENSTACK_CHANNEL,
+                "tfvars_channel_var": None,
+            },
+            "bind": {
+                "channel": "9/edge",
+                "tfvars_channel_var": None,
+            },
+        }
+
+    @property
+    def tfvars_channel_var(self):
+        return "designate-channel"

--- a/sunbeam-python/sunbeam/plugins/dns/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/dns/plugin.py
@@ -26,6 +26,7 @@ from sunbeam.commands.terraform import TerraformHelper, TerraformInitStep
 from sunbeam.jobs.common import run_plan
 from sunbeam.jobs.juju import JujuHelper, run_sync
 from sunbeam.plugins.interface.v1.openstack import (
+    ApplicationChannelData,
     EnableOpenStackApplicationStep,
     OpenStackControlPlanePlugin,
     TerraformPlanLocation,
@@ -176,14 +177,14 @@ class DnsPlugin(OpenStackControlPlanePlugin):
     @property
     def k8s_application_data(self):
         return {
-            "designate": {
-                "channel": OPENSTACK_CHANNEL,
-                "tfvars_channel_var": None,
-            },
-            "bind": {
-                "channel": "9/edge",
-                "tfvars_channel_var": None,
-            },
+            "designate": ApplicationChannelData(
+                channel=OPENSTACK_CHANNEL,
+                tfvars_channel_var=None,
+            ),
+            "bind": ApplicationChannelData(
+                channel="9/edge",
+                tfvars_channel_var=None,
+            ),
         }
 
     @property

--- a/sunbeam-python/sunbeam/plugins/interface/v1/base.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/base.py
@@ -107,7 +107,7 @@ class BasePlugin(ABC):
         """
         pass
 
-    def upgrade_hook(self) -> None:
+    def upgrade_hook(self, upgrade_release: bool = False) -> None:
         """Upgrade hook for the plugin.
 
         snap-openstack upgrade hook handler invokes this function on all the

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OPENSTACK_CHANNEL = "2023.2/edge"
+OVN_CHANNEL = "23.09/edge"
+RABBITMQ_CHANNEL = "3.12/edge"
+TRAEFIK_CHANNEL = "1.0/edge"
+MICROCEPH_CHANNEL = "latest/edge"
+SUNBEAM_MACHINE_CHANNEL = "latest/edge"
+MICROK8S_CHANNEL = "legacy/stable"
+MYSQL_CHANNEL = "8.0/candidate"
+CERT_AUTH_CHANNEL = "latest/beta"
+
+# The lists of services are needed for switching charm channels outside
+# of the terraform provider. If it ok to upgrade in one big-bang and
+# the juju terraform provider supports it then the upgrades can be
+# done by simply updating the tfvars and these lists are not needed.
+OPENSTACK_SERVICES_K8S = {
+    "cinder-ceph": OPENSTACK_CHANNEL,
+    "cinder": OPENSTACK_CHANNEL,
+    "glance": "2023.2/candidate",
+    "horizon": OPENSTACK_CHANNEL,
+    "keystone": OPENSTACK_CHANNEL,
+    "neutron": OPENSTACK_CHANNEL,
+    "nova": OPENSTACK_CHANNEL,
+    "placement": OPENSTACK_CHANNEL,
+}
+OVN_SERVICES_K8S = {
+    "ovn-central": OVN_CHANNEL,
+    "ovn-relay": OVN_CHANNEL,
+}
+MYSQL_SERVICES_K8S = {
+    "mysql": MYSQL_CHANNEL,
+    "cinder-ceph-mysql-router": MYSQL_CHANNEL,
+    "cinder-mysql-router": MYSQL_CHANNEL,
+    "glance-mysql-router": MYSQL_CHANNEL,
+    "horizon-mysql-router": MYSQL_CHANNEL,
+    "keystone-mysql-router": MYSQL_CHANNEL,
+    "neutron-mysql-router": MYSQL_CHANNEL,
+    "nova-api-mysql-router": MYSQL_CHANNEL,
+    "nova-cell-mysql-router": MYSQL_CHANNEL,
+    "nova-mysql-router": MYSQL_CHANNEL,
+    "placement-mysql-router": MYSQL_CHANNEL,
+}
+MISC_SERVICES_K8S = {
+    "certificate-authority": CERT_AUTH_CHANNEL,
+    "rabbitmq": RABBITMQ_CHANNEL,
+    "traefik": TRAEFIK_CHANNEL,
+    "traefik-public": TRAEFIK_CHANNEL,
+}
+MACHINE_SERVICES = {
+    "microceph": MICROCEPH_CHANNEL,
+    "microk8s": MICROK8S_CHANNEL,
+    "openstack-hypervisor": OPENSTACK_CHANNEL,
+    "sunbeam-machine": SUNBEAM_MACHINE_CHANNEL,
+}
+
+K8S_SERVICES = {}
+K8S_SERVICES |= OPENSTACK_SERVICES_K8S
+K8S_SERVICES |= OVN_SERVICES_K8S
+K8S_SERVICES |= MYSQL_SERVICES_K8S
+K8S_SERVICES |= MISC_SERVICES_K8S
+
+CHARM_VERSIONS = {}
+CHARM_VERSIONS |= K8S_SERVICES
+CHARM_VERSIONS |= MACHINE_SERVICES

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -30,7 +30,7 @@ CERT_AUTH_CHANNEL = "latest/beta"
 OPENSTACK_SERVICES_K8S = {
     "cinder-ceph": OPENSTACK_CHANNEL,
     "cinder": OPENSTACK_CHANNEL,
-    "glance": "2023.2/candidate",
+    "glance": OPENSTACK_CHANNEL,
     "horizon": OPENSTACK_CHANNEL,
     "keystone": OPENSTACK_CHANNEL,
     "neutron": OPENSTACK_CHANNEL,

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_juju.py
@@ -51,6 +51,90 @@ def mock_open():
         yield p
 
 
+class TestJujuStepHelper:
+    def test_get_available_charm_revision(self, check_output, mocker):
+        jsh = juju.JujuStepHelper()
+        cmd_out = {
+            "channels": {
+                "legacy": {
+                    "edge": [
+                        {
+                            "track": "legacy",
+                            "risk": "stable",
+                            "version": "121",
+                            "revision": 121,
+                            "released-at": "2023-08-17T12:06:46.206939+00:00",
+                            "size": 7074285,
+                            "architectures": ["amd64"],
+                            "bases": [
+                                {"name": "ubuntu", "channel": "20.04"},
+                                {"name": "ubuntu", "channel": "22.04"},
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+
+        with patch.object(juju.JujuStepHelper, "_juju_cmd", return_value=cmd_out):
+            assert jsh.get_available_charm_revision("microk8s", "legacy", "edge") == 121
+
+    def test_revision_update_needed(self, mocker):
+        jsh = juju.JujuStepHelper()
+        CHARMREV = {"nova-k8s": 31, "cinder-k8s": 51, "another-k8s": 70}
+
+        def _get_available_charm_revision(charm_name, track, risk):
+            return CHARMREV[charm_name]
+
+        _status = {
+            "applications": {
+                "nova": {
+                    "charm": "ch:amd64/jammy/nova-k8s-30",
+                    "charm-channel": "2023.2/edge/gnuoy",
+                },
+                "cinder": {
+                    "charm": "ch:amd64/jammy/cinder-k8s-50",
+                    "charm-channel": "2023.2/edge",
+                },
+                "another": {
+                    "charm": "ch:amd64/jammy/another-k8s-70",
+                    "charm-channel": "edge",
+                },
+            }
+        }
+        with patch.object(
+            juju.JujuStepHelper,
+            "get_available_charm_revision",
+            side_effect=_get_available_charm_revision,
+        ):
+            assert jsh.revision_update_needed("cinder", "openstack", _status)
+            assert not jsh.revision_update_needed("nova", "openstack", _status)
+            assert not jsh.revision_update_needed("another", "openstack", _status)
+
+    def test_normalise_channel(self):
+        jsh = juju.JujuStepHelper()
+        assert jsh.normalise_channel("2023.2/edge") == "2023.2/edge"
+        assert jsh.normalise_channel("edge") == "latest/edge"
+
+    def test_extract_charm_name(self):
+        jsh = juju.JujuStepHelper()
+        assert jsh._extract_charm_name("ch:amd64/jammy/cinder-k8s-50") == "cinder-k8s"
+
+    def test_extract_charm_revision(self):
+        jsh = juju.JujuStepHelper()
+        assert jsh._extract_charm_revision("ch:amd64/jammy/cinder-k8s-50") == "50"
+
+    def test_channel_update_needed(self):
+        jsh = juju.JujuStepHelper()
+        assert jsh.channel_update_needed("2023.1/stable", "2023.2/stable")
+        assert jsh.channel_update_needed("2023.1/stable", "2023.1/edge")
+        assert jsh.channel_update_needed("latest/stable", "latest/edge")
+        assert not jsh.channel_update_needed("2023.1/stable", "2023.1/stable")
+        assert not jsh.channel_update_needed("2023.2/stable", "2023.1/stable")
+        assert not jsh.channel_update_needed("latest/stable", "latest/stable")
+        assert not jsh.channel_update_needed("foo/stable", "ba/stable")
+
+
 class TestWriteJujuStatusStep:
     def test_is_skip(self, jhelper):
         with tempfile.NamedTemporaryFile() as tmpfile:

--- a/sunbeam-python/tests/unit/sunbeam/commands/upgrades/test_base.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/upgrades/test_base.py
@@ -1,0 +1,94 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock, Mock, patch
+
+from sunbeam.commands.upgrades.inter_channel import BaseUpgrade
+from sunbeam.versions import (
+    MYSQL_SERVICES_K8S,
+    OPENSTACK_SERVICES_K8S,
+    OVN_SERVICES_K8S,
+)
+
+
+class TestBaseUpgrade:
+    def setup_method(self):
+        self.jhelper = AsyncMock()
+        self.tfhelper = Mock()
+        self.upgrade_service = (
+            list(MYSQL_SERVICES_K8S.keys())  # noqa
+            + list(OVN_SERVICES_K8S.keys())  # noqa
+            + list(OPENSTACK_SERVICES_K8S.keys())  # noqa
+        )
+
+    def test_upgrade_applications(self):
+        def _get_new_channel_mock(app_name, model):
+            channels = {"nova": "2023.2/edge", "neutron": None}
+            return channels[app_name]
+
+        upgrader = BaseUpgrade(
+            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+        )
+        get_new_channel_mock = Mock()
+        get_new_channel_mock.side_effect = _get_new_channel_mock
+        with patch.object(BaseUpgrade, "get_new_channel", get_new_channel_mock):
+            upgrader.upgrade_applications(["nova"], "openstack")
+        self.jhelper.update_applications_channel.assert_called_once_with(
+            "openstack",
+            {
+                "nova": {
+                    "channel": "2023.2/edge",
+                    "expected_status": {"workload": ["blocked", "active"]},
+                }
+            },
+        )
+
+    def test_get_new_channel_os_service(self, mocker):
+        self.jhelper.get_charm_channel.return_value = "2023.1/edge"
+        upgrader = BaseUpgrade(
+            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+        )
+        new_channel = upgrader.get_new_channel("cinder", "openstack")
+        assert new_channel == "2023.2/edge"
+
+    def test_get_new_channel_os_service_same(self, mocker):
+        self.jhelper.get_charm_channel.return_value = "2023.2/edge"
+        upgrader = BaseUpgrade(
+            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+        )
+        new_channel = upgrader.get_new_channel("cinder", "openstack")
+        assert new_channel is None
+
+    def test_get_new_channel_os_downgrade(self, mocker):
+        self.jhelper.get_charm_channel.return_value = "2023.2/edge"
+        upgrader = BaseUpgrade(
+            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+        )
+        new_channel = upgrader.get_new_channel("cinder", "openstack")
+        assert new_channel is None
+
+    def test_get_new_channel_nonos_service(self, mocker):
+        self.jhelper.get_charm_channel.return_value = "3.8/stable"
+        upgrader = BaseUpgrade(
+            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+        )
+        new_channel = upgrader.get_new_channel("rabbitmq", "openstack")
+        assert new_channel == "3.12/edge"
+
+    def test_get_new_channel_unknown(self, mocker):
+        upgrader = BaseUpgrade(
+            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+        )
+        new_channel = upgrader.get_new_channel("foo", "openstack")
+        assert new_channel is None

--- a/sunbeam-python/tests/unit/sunbeam/conftest.py
+++ b/sunbeam-python/tests/unit/sunbeam/conftest.py
@@ -59,6 +59,12 @@ def check_call():
 
 
 @pytest.fixture
+def check_output():
+    with patch("subprocess.check_output") as p:
+        yield p
+
+
+@pytest.fixture
 def environ():
     with patch("os.environ") as p:
         yield p


### PR DESCRIPTION
## Possible issues

* The code assumes the Juju terraform provider does not support upgrading channels. When this feature gap is fixed the code can be simplified. 
 
## What's new 
                                                                                                                                                                   
This PR adds the ability to refresh/upgrade the sunbeam deployment. The two
modes of operation are:
                                              
```bash                                                                                     
sunbeam cluster refresh                                                                     
```                                         
                                              
This will upgrade all charm to the latest revision in the current track.

```bash                          
sunbeam cluster refresh --upgrade-release
```                                                                                         
                                                                                            
This will switch all charms to the new channel. The snap now has an sunbeam.versions file that contains all the application channels for the core charms. When a refresh is run with the **--upgrade-release** option then each application channel is checked against the snaps version file and updated if needed.

                                                                                            
## Structure                                                                                
                                                                                            
When a refresh is requested a coordinator class is selected to handle
the upgrade. The coordinator class contains the plan for the upgrade,
the plan contains each step. For a typical upgrade between channels
the might look like: 

```python 
    plan = [
        ValidationCheck(self.jhelper, self.tfhelper),      
        LatestInChannel(self.jhelper),                                                      
        UpgradeControlPlane2023_2(                                                          
            self.jhelper, self.tfhelper, self.channel, "openstack"
        ),                                   
        UpgradeMachineCharms2023_2(                                                         
            self.jhelper, self.tfhelper, self.channel, "controller"
        ),
        UpgradePlugins(self.jhelper, self.tfhelper, self.channel),
    ]
```

In this plan the following will happen:

1. Check if the upgrade is possible
2. Upgrade all charms to the latest version in the current channel
3. Upgrade the control plane charms to the new channel
4. Upgrade machine charms to the new channel
5. Upgrade plugins


## Refresh without channel switch

If a refresh is requested without a channel switch then the
**LatestInChannelCoordinator** class is called. The plan for
this coordinator has a single step **LatestInChannel**. This
will iterate over all the charms in the deployment and see
if a newer version is available in the current channel. If it
is then the charm is upgraded.

## Refresh with channel switch

If a refresh is requested with a channel switch then the **ChannelUpgradeCoordinator** is used.

## Plugins

The **UpgradePlugins** looks after calling the upgrade hook
in the plugins. For plugins derived from the **OpenStackControlPlanePlugin**
this is achieved by running the UpgradeApplicationStep step
plugin class. To support refreshes between channels using the the UpgradeApplicationStep a plugin needs to define the  channels and corresponding tfvars property (if there is one) for each application. This is done using the new **k8s_application_data** method in the plugin class. For example:

```
    @property
    def k8s_application_data(self):
        return {
            "designate": {
                "channel": OPENSTACK_CHANNEL,
                "tfvars_channel_var": None,
            },
            "bind": {
                "channel": "9/edge",
                "tfvars_channel_var": None,
            },
        }
```
