### PR TITLE
wait-until-active: retry on JujuAPIError

### DIFF
--- a/sunbeam-python/requirements.txt
+++ b/sunbeam-python/requirements.txt
@@ -34,3 +34,5 @@ lightkube-models
 # For plugin repo
 jsonschema
 GitPython
+
+tenacity


### PR DESCRIPTION
Retry wait_until_active on JujuAPIError, with a limited retry count of 5.

Recompute timeout everytime so that total duration does not exceed initial timeout.

Fixes: LP#2039126

Tentative fix for: https://bugs.launchpad.net/snap-openstack/+bug/2039126