### PR TITLE
Remove wait for heat-api-cfn application

### DIFF
--- a/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
@@ -37,7 +37,7 @@ class OrchestrationPlugin(OpenStackControlPlanePlugin):
 
     def set_application_names(self) -> list:
         """Application names handled by the terraform plan."""
-        apps = ["heat", "heat-mysql-router", "heat-cfn", "heat-cfn-mysql-router"]
+        apps = ["heat", "heat-mysql-router"]
         if self.get_database_topology() == "multi":
             apps.extend(["heat-mysql"])
 


### PR DESCRIPTION
heat-api-cfn is not required to deployed
as separate instance of heat-k8s and runs
as a container within the heat-k8s instance
along with heat-api and heat-engine.
Remove heat-api-cfn and corresponding mysql
router app to wait for applications in
orchestrator plugin.