### PR TITLE
Enable horizon plugins on plugin enablement

### DIFF
--- a/sunbeam-python/sunbeam/plugins/caas/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/caas/plugin.py
@@ -100,11 +100,15 @@ class CaasPlugin(OpenStackControlPlanePlugin):
         return {
             "magnum-channel": "2023.2/edge",
             "enable-magnum": True,
+            **self.add_horizon_plugin_to_tfvars("magnum"),
         }
 
     def set_tfvars_on_disable(self) -> dict:
         """Set terraform variables to disable the application."""
-        return {"enable-magnum": False}
+        return {
+            "enable-magnum": False,
+            **self.remove_horizon_plugin_from_tfvars("magnum"),
+        }
 
     def set_tfvars_on_resize(self) -> dict:
         """Set terraform variables to resize the application."""

--- a/sunbeam-python/sunbeam/plugins/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/openstack.py
@@ -252,6 +252,38 @@ class OpenStackControlPlanePlugin(EnableDisablePlugin):
         """Disable plugin command."""
         super().disable_plugin()
 
+    def add_horizon_plugin_to_tfvars(self, plugin: str) -> dict[str, list[str]]:
+        """Tf vars to have the given plugin enabled.
+
+        Return of the function is expected to be passed to set_tfvars_on_enable.
+        """
+        try:
+            tfvars = read_config(self.client, self.get_tfvar_config_key())
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        horizon_plugins = tfvars.get("horizon-plugins", [])
+        if plugin not in horizon_plugins:
+            horizon_plugins.append(plugin)
+
+        return {"horizon-plugins": sorted(horizon_plugins)}
+
+    def remove_horizon_plugin_from_tfvars(self, plugin: str) -> dict[str, list[str]]:
+        """TF vars to have the given plugin disabled.
+
+        Return of the function is expected to be passed to set_tfvars_on_disable.
+        """
+        try:
+            tfvars = read_config(self.client, self.get_tfvar_config_key())
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        horizon_plugins = tfvars.get("horizon-plugins", [])
+        if plugin in horizon_plugins:
+            horizon_plugins.remove(plugin)
+
+        return {"horizon-plugins": sorted(horizon_plugins)}
+
 
 class EnableOpenStackApplicationStep(BaseStep, JujuStepHelper):
     """Generic step to enable OpenStack application using Terraform"""

--- a/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
@@ -48,11 +48,15 @@ class LoadbalancerPlugin(OpenStackControlPlanePlugin):
         return {
             "octavia-channel": "2023.2/edge",
             "enable-octavia": True,
+            **self.add_horizon_plugin_to_tfvars("octavia"),
         }
 
     def set_tfvars_on_disable(self) -> dict:
         """Set terraform variables to disable the application."""
-        return {"enable-octavia": False}
+        return {
+            "enable-octavia": False,
+            **self.remove_horizon_plugin_from_tfvars("octavia"),
+        }
 
     def set_tfvars_on_resize(self) -> dict:
         """Set terraform variables to resize the application."""

--- a/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
@@ -48,11 +48,15 @@ class OrchestrationPlugin(OpenStackControlPlanePlugin):
         return {
             "heat-channel": "2023.2/edge",
             "enable-heat": True,
+            **self.add_horizon_plugin_to_tfvars("heat"),
         }
 
     def set_tfvars_on_disable(self) -> dict:
         """Set terraform variables to disable the application."""
-        return {"enable-heat": False}
+        return {
+            "enable-heat": False,
+            **self.remove_horizon_plugin_from_tfvars("heat"),
+        }
 
     def set_tfvars_on_resize(self) -> dict:
         """Set terraform variables to resize the application."""


### PR DESCRIPTION
If a plugin has an horizon plugin associated, enable it.

Also disable it when it's removed.

Depends-on:
- [ ] https://github.com/canonical/sunbeam-terraform/pull/42