### PR TITLE
Avoid broken macaroon, uncomment protobuf constraint

### DIFF
--- a/sunbeam-python/requirements.txt
+++ b/sunbeam-python/requirements.txt
@@ -37,4 +37,4 @@ jsonschema
 GitPython
 
 # Regression introduced in 1.3.3
-macaroonbakery<1.3.3
+macaroonbakery!=1.3.3

--- a/sunbeam-python/tox.ini
+++ b/sunbeam-python/tox.ini
@@ -20,6 +20,7 @@ setenv = OS_STDOUT_CAPTURE=1
 deps =
   -r{toxinidir}/test-requirements.txt
   -r{toxinidir}/requirements.txt
+  -c{toxinidir}/upper-constraints.txt
 commands = python -m pytest {posargs}
 allowlist_externals = stestr
 

--- a/sunbeam-python/upper-constraints.txt
+++ b/sunbeam-python/upper-constraints.txt
@@ -370,8 +370,7 @@ linecache2===1.0.0
 oauth2client===4.1.3
 idna===3.4
 yamlloader===1.1.0
-# Disable due to version conflict with macaroonbakery
-# protobuf===4.21.7
+protobuf===4.21.7
 pyhcl===0.4.4
 sushy===4.4.2
 python-neutronclient===9.0.0


### PR DESCRIPTION
pymacaroon-bakery removed upper constraints on protobuf. Avoid broken version and follow Openstack upper constraints.

Add upper constraints to tox's venv.