### PR TITLE
Add space map/unmap command

### DIFF
--- a/sunbeam-python/sunbeam/commands/deployment.py
+++ b/sunbeam-python/sunbeam/commands/deployment.py
@@ -71,6 +71,11 @@ def add_deployment(path: Path, new_deployment: Deployment) -> None:
     deployments.append(new_deployment)
     config["deployments"] = deployments
     config["active"] = new_deployment["name"]
+    write_deployment_config(path, config)
+
+
+def write_deployment_config(path: Path, config: DeploymentsConfig) -> None:
+    """Write deployment configuration."""
     with path.open("w") as fd:
         yaml.safe_dump(config, fd)
     path.chmod(0o600)
@@ -123,3 +128,17 @@ def get_active_deployment(path: Path) -> Deployment:
         if deployment["name"] == active:
             return deployment
     raise ValueError(f"Active deployment {active} not found in configuration.")
+
+
+def update_deployment(path: Path, deployment: Deployment):
+    """Update deployment in deployments configuration."""
+    config = deployment_config(path)
+    deployments = config.get("deployments", [])
+    for dep in deployments:
+        if dep["name"] == deployment["name"]:
+            dep.update(deployment)
+            break
+    else:
+        raise ValueError(f"Deployment {deployment['name']} not found in deployments.")
+    config["deployments"] = deployments
+    write_deployment_config(path, config)


### PR DESCRIPTION
Allow mapping network (sunbeam notion) to spaces (maas notion). Multiple networks can be bound to the same space.


### Mapping a network to a space

Mapping a network to a space will take the space name and network name as argument

```bash
$ sunbeam deployment space map -h
Usage: sunbeam deployment space map [OPTIONS] SPACE {public|storage|storage-
                                    cluster|internal|data}

  Map space to network.

Options:
  -h, --help  Show this message and exit.
```

```bash
$ sunbeam deployment space map internal storage-cluster
Space internal mapped to network storage-cluster.
```

### Unmapping a network from a space

Unmapping a network from a space will take the network name as argument

```bash
sunbeam deployment space unmap -h
Usage: sunbeam deployment space unmap [OPTIONS] {public|storage|storage-
                                      cluster|internal|data}

  Unmap space from network.

Options:
  -h, --help  Show this message and exit.
```

```bash
sunbeam deployment space unmap storage-cluster
Space unmapped from network storage-cluster.
```

