### PR TITLE
Implement deployment and machine validation

### DIFF
--- a/sunbeam-python/sunbeam/commands/maas.py
+++ b/sunbeam-python/sunbeam/commands/maas.py
@@ -20,6 +20,7 @@ import collections
 import enum
 import logging
 import ssl
+import textwrap
 from pathlib import Path
 from typing import Optional, TypeGuard
 
@@ -27,6 +28,7 @@ from maas.client import bones, connect
 from rich.console import Console
 from rich.status import Status
 from snaphelpers import Snap
+import yaml
 
 from sunbeam.commands.deployment import (
     Deployment,
@@ -37,7 +39,8 @@ from sunbeam.commands.deployment import (
     get_active_deployment,
     update_deployment,
 )
-from sunbeam.jobs.common import BaseStep, Result, ResultType
+from sunbeam.jobs.checks import DiagnosticsCheck, DiagnosticsResult
+from sunbeam.jobs.common import RAM_32_GB_IN_MB, BaseStep, Result, ResultType
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -63,6 +66,9 @@ class Networks(enum.Enum):
         """Return list of tag values."""
         return [tag.value for tag in cls]
 
+    def __repr__(self) -> str:
+        return self.value
+
 
 def is_maas_deployment(deployment: Deployment) -> TypeGuard[MaasDeployment]:
     """Check if deployment is a MAAS deployment."""
@@ -73,12 +79,36 @@ class RoleTags(enum.Enum):
     CONTROL = "control"
     COMPUTE = "compute"
     STORAGE = "storage"
-    JUJU = "juju"
+    JUJU_CONTROLLER = "juju-controller"
 
     @classmethod
     def values(cls) -> list[str]:
         """Return list of tag values."""
         return [tag.value for tag in cls]
+
+
+ROLE_NETWORK_MAPPING = {
+    RoleTags.CONTROL: [
+        Networks.INTERNAL,
+        Networks.PUBLIC,
+        Networks.STORAGE,
+    ],
+    RoleTags.COMPUTE: [
+        Networks.DATA,
+        Networks.INTERNAL,
+        Networks.STORAGE,
+    ],
+    RoleTags.STORAGE: [
+        Networks.DATA,
+        Networks.INTERNAL,
+        Networks.STORAGE,
+        Networks.STORAGE_CLUSTER,
+    ],
+    RoleTags.JUJU_CONTROLLER: [
+        Networks.INTERNAL,
+        # TODO(gboutry): missing public access network to reach charmhub...
+    ],
+}
 
 
 class StorageTags(enum.Enum):
@@ -127,14 +157,6 @@ class MaasClient:
             raise ValueError(f"Machine {machine!r} not unique.")
         return machines[0]
 
-    def list_machines_by_zone(self) -> dict[str, list[dict]]:
-        """List machines by zone."""
-        result = collections.defaultdict(list)
-        machines = self.list_machines()
-        for machine in machines:
-            result[machine["zone"]["name"]].append(machine)
-        return dict(result)
-
     def list_spaces(self) -> list[dict]:
         """List spaces."""
         return self._client.spaces.list.__self__._handler.read()  # type: ignore
@@ -168,6 +190,8 @@ def _convert_raw_machine(machine_raw: dict) -> dict:
         "status": machine_raw["status_name"],
         "storage": dict(storage_tags),
         "spaces": list(set(spaces)),
+        "cores": machine_raw["cpu_count"],
+        "memory": machine_raw["memory"],
     }
 
 
@@ -187,16 +211,18 @@ def get_machine(client: MaasClient, machine: str) -> dict:
     return _convert_raw_machine(machine_raw)
 
 
+def _group_machines_by_zone(machines: list[dict]) -> dict[str, list[dict]]:
+    """Helper to list machines by zone, return consumable dict."""
+    result = collections.defaultdict(list)
+    for machine in machines:
+        result[machine["zone"]].append(machine)
+    return dict(result)
+
+
 def list_machines_by_zone(client: MaasClient) -> dict[str, list[dict]]:
     """List machines by zone, return consumable dict."""
-    zone_machine_raw = client.list_machines_by_zone()
-    machines = collections.defaultdict(list)
-
-    for zone, machines_raw in zone_machine_raw.items():
-        for machine in machines_raw:
-            machines[zone].append(_convert_raw_machine(machine))
-
-    return dict(machines)
+    machines_raw = list_machines(client)
+    return _group_machines_by_zone(machines_raw)
 
 
 def list_spaces(client: MaasClient) -> list[dict]:
@@ -261,6 +287,13 @@ def get_network_mapping(snap: Snap) -> dict[str, str | None]:
     for network in Networks.values():
         mapping.setdefault(network, None)
     return mapping
+
+
+ROLES_NEEDED_ERROR = f"""A machine needs roles to be a part of an openstack deployment.
+Available roles are: {RoleTags.values()}.
+Roles can be assigned to a machine by applying tags in MAAS.
+More on assigning tags: https://maas.io/docs/using-machine-tags
+"""
 
 
 class AddMaasDeployment(BaseStep):
@@ -356,3 +389,411 @@ class AddMaasDeployment(BaseStep):
         )
         add_deployment(self.path, data)
         return Result(ResultType.COMPLETED)
+
+
+class MachineRolesCheck(DiagnosticsCheck):
+    """Check machine has roles assigned."""
+
+    def __init__(self, machine: dict):
+        super().__init__(
+            "Role check",
+            "Checking roles",
+        )
+        self.machine = machine
+
+    def run(self) -> DiagnosticsResult:
+        assigned_roles = self.machine["roles"]
+        LOG.debug(f"{self.machine['hostname']=!r} assigned roles: {assigned_roles!r}")
+        if not assigned_roles:
+            return DiagnosticsResult(
+                self.name,
+                False,
+                "machine has no role assigned.",
+                diagnostics=ROLES_NEEDED_ERROR,
+                machine=self.machine["hostname"],
+            )
+
+        return DiagnosticsResult(
+            self.name,
+            True,
+            ", ".join(self.machine["roles"]),
+            machine=self.machine["hostname"],
+        )
+
+
+class MachineNetworkCheck(DiagnosticsCheck):
+    """Check machine has the right networks assigned."""
+
+    def __init__(self, snap: Snap, machine: dict):
+        super().__init__(
+            "Network check",
+            "Checking networks",
+        )
+        self.snap = snap
+        self.machine = machine
+
+    def run(self) -> DiagnosticsResult:
+        """Check machine has access to required networks."""
+        network_to_space_mapping = get_network_mapping(self.snap)
+        spaces = network_to_space_mapping.values()
+        if len(spaces) != len(Networks.values()) or not all(spaces):
+            return DiagnosticsResult.fail(
+                self.name,
+                "network mapping is incomplete",
+                diagnostics=textwrap.dedent(
+                    """\
+                    A complete map of networks to spaces is required to proceed.
+                    Complete network mapping to using `sunbeam deployment space map...`.
+                    """
+                ),
+                machine=self.machine["hostname"],
+            )
+        assigned_roles = self.machine["roles"]
+        LOG.debug(f"{self.machine['hostname']=!r} assigned roles: {assigned_roles!r}")
+        if not assigned_roles:
+            return DiagnosticsResult.fail(
+                self.name,
+                "machine has no role assigned",
+                diagnostics=ROLES_NEEDED_ERROR,
+                machine=self.machine["hostname"],
+            )
+        assigned_spaces = self.machine["spaces"]
+        LOG.debug(f"{self.machine['hostname']=!r} assigned spaces: {assigned_spaces!r}")
+        required_networks: set[Networks] = set()
+        for role in assigned_roles:
+            required_networks.update(ROLE_NETWORK_MAPPING[RoleTags(role)])
+        LOG.debug(
+            f"{self.machine['hostname']=!r} required networks: {required_networks!r}"
+        )
+        required_spaces = set()
+        missing_spaces = set()
+        for network in required_networks:
+            corresponding_space = network_to_space_mapping[network.value]
+            required_spaces.add(corresponding_space)
+            if corresponding_space not in assigned_spaces:
+                missing_spaces.add(corresponding_space)
+        LOG.debug(f"{self.machine['hostname']=!r} missing spaces: {missing_spaces!r}")
+        if not assigned_spaces or missing_spaces:
+            return DiagnosticsResult.fail(
+                self.name,
+                f"missing {', '.join(missing_spaces)}",
+                diagnostics=textwrap.dedent(
+                    f"""\
+                    A machine needs to be in spaces to be a part of an openstack
+                    deployment. Given machine has roles: {', '.join(assigned_roles)},
+                    and therefore needs to be a part of the following spaces:
+                    {', '.join(required_spaces)}."""
+                ),
+                machine=self.machine["hostname"],
+            )
+        return DiagnosticsResult.success(
+            self.name,
+            ", ".join(assigned_spaces),
+            machine=self.machine["hostname"],
+        )
+
+
+class MachineStorageCheck(DiagnosticsCheck):
+    """Check machine has storage assigned if required."""
+
+    def __init__(self, machine: dict):
+        super().__init__(
+            "Storage check",
+            "Checking storage",
+        )
+        self.machine = machine
+
+    def run(self) -> DiagnosticsResult:
+        """Check machine has storage assigned if required."""
+        assigned_roles = self.machine["roles"]
+        LOG.debug(f"{self.machine['hostname']=!r} assigned roles: {assigned_roles!r}")
+        if not assigned_roles:
+            return DiagnosticsResult.fail(
+                self.name,
+                "machine has no role assigned.",
+                ROLES_NEEDED_ERROR,
+                machine=self.machine["hostname"],
+            )
+        if RoleTags.STORAGE.value not in assigned_roles:
+            self.message = "not a storage node."
+            return DiagnosticsResult.success(
+                self.name,
+                self.message,
+                machine=self.machine["hostname"],
+            )
+        # TODO(gboutry): check number of storage ?
+        if self.machine["storage"].get(StorageTags.CEPH.value, 0) < 1:
+            return DiagnosticsResult.fail(
+                self.name,
+                "storage node has no ceph storage",
+                textwrap.dedent(
+                    f"""\
+                    A storage node needs to have ceph storage to be a part of
+                    an openstack deployment. Either add ceph storage to the
+                    machine or remove the storage role. Add the tag
+                    `{StorageTags.CEPH.value}` to the storage device in MAAS.
+                    More on assigning tags: https://maas.io/docs/using-storage-tags"""
+                ),
+                machine=self.machine["hostname"],
+            )
+        return DiagnosticsResult.success(
+            self.name,
+            ", ".join(
+                f"{tag}({count})" for tag, count in self.machine["storage"].items()
+            ),
+            machine=self.machine["hostname"],
+        )
+
+
+class MachineRequirementsCheck(DiagnosticsCheck):
+    """Check machine meets requirements."""
+
+    CORES = 16
+    MEMORY = RAM_32_GB_IN_MB
+
+    def __init__(self, machine: dict):
+        super().__init__(
+            "Machine requirements check",
+            "Checking machine requirements",
+        )
+        self.machine = machine
+
+    def run(self) -> DiagnosticsResult:
+        if self.machine["memory"] < self.MEMORY or self.machine["cores"] < self.CORES:
+            return DiagnosticsResult.fail(
+                self.name,
+                "machine does not meet requirements",
+                textwrap.dedent(
+                    f"""\
+                    A machine needs to have at least {self.CORES} cores and
+                    {self.MEMORY}MB RAM to be a part of an openstack deployment.
+                    Either add more cores and memory to the machine or remove the
+                    machine from the deployment.
+                    {self.machine['hostname']}:
+                        cores: {self.machine["cores"]}
+                        memory: {self.machine["memory"]}MB"""
+                ),
+                machine=self.machine["hostname"],
+            )
+
+        return DiagnosticsResult.success(
+            self.name,
+            f"{self.machine['cores']} cores, {self.machine['memory']}MB RAM",
+            machine=self.machine["hostname"],
+        )
+
+
+def str_presenter(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+    """Return multiline string as '|' literal block.
+
+    Ref: https://stackoverflow.com/questions/8640959/how-can-i-control-what-scalar-form-pyyaml-uses-for-my-data # noqa E501
+    """
+    if data.count("\n") > 0:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+def _run_check_list(checks: list[DiagnosticsCheck]) -> list[DiagnosticsResult]:
+    check_results = []
+    for check in checks:
+        LOG.debug(f"Starting check {check.name}")
+        results = check.run()
+        if isinstance(results, DiagnosticsResult):
+            results = [results]
+        for result in results:
+            LOG.debug(f"{result.name=!r}, {result.passed=!r}, {result.message=!r}")
+            check_results.extend(results)
+    return check_results
+
+
+class DeploymentMachinesCheck(DiagnosticsCheck):
+    """Check all machines inside deployment."""
+
+    def __init__(self, snap: Snap, machines: list[dict]):
+        super().__init__(
+            "Deployment check",
+            "Checking machines, roles, networks and storage",
+        )
+        self.snap = snap
+        self.machines = machines
+
+    def run(self) -> list[DiagnosticsResult]:
+        """Run a series of checks on the machines' definition."""
+        checks = []
+        for machine in self.machines:
+            checks.append(MachineRolesCheck(machine))
+            checks.append(MachineNetworkCheck(self.snap, machine))
+            checks.append(MachineStorageCheck(machine))
+            checks.append(MachineRequirementsCheck(machine))
+        results = _run_check_list(checks)
+        results.append(
+            DiagnosticsResult(self.name, all(result.passed for result in results))
+        )
+        return results
+
+
+class DeploymentRolesCheck(DiagnosticsCheck):
+    """Check deployment as enough nodes with given role."""
+
+    def __init__(
+        self, machines: list[dict], role_name: str, role_tag: str, min_count: int = 3
+    ):
+        super().__init__(
+            "Minimum role check",
+            "Checking minimum number of machines with given role",
+        )
+        self.machines = machines
+        self.role_name = role_name
+        self.role_tag = role_tag
+        self.min_count = min_count
+
+    def run(self) -> DiagnosticsResult:
+        """Checks if there's enough machines with given role."""
+        machines = 0
+        for machine in self.machines:
+            if self.role_tag in machine["roles"]:
+                machines += 1
+        if machines < self.min_count:
+            return DiagnosticsResult.fail(
+                self.name,
+                "less than 3 " + self.role_name,
+                textwrap.dedent(
+                    """\
+                    A deployment needs to have at least {min_count} {role_name} to be
+                    a part of an openstack deployment. You need to add more {role_name}
+                    to the deployment using {role_tag} tag.
+                    More on using tags: https://maas.io/docs/using-machine-tags
+                    """.format(
+                        min_count=self.min_count,
+                        role_name=self.role_name,
+                        role_tag=self.role_tag,
+                    )
+                ),
+            )
+        return DiagnosticsResult.success(
+            self.name,
+            f"{self.role_name}: {machines}",
+        )
+
+
+class ZonesCheck(DiagnosticsCheck):
+    """Check that there either 1 zone or more than 2 zones."""
+
+    def __init__(self, zones: list[str]):
+        super().__init__(
+            "Zone check",
+            "Checking zones",
+        )
+        self.zones = zones
+
+    def run(self) -> DiagnosticsResult:
+        """Checks deployment zones."""
+        if len(self.zones) == 2:
+            return DiagnosticsResult.fail(
+                self.name,
+                "deployment has 2 zones",
+                textwrap.dedent(
+                    f"""\
+                    A deployment needs to have either 1 zone or more than 2 zones.
+                    Current zones: {', '.join(self.zones)}"""
+                ),
+            )
+        return DiagnosticsResult.success(
+            self.name,
+            f"{len(self.zones)} zone(s)",
+        )
+
+
+class ZoneBalanceCheck(DiagnosticsCheck):
+    """Check that roles are balanced throughout zones."""
+
+    def __init__(self, machines: dict[str, list[dict]]):
+        super().__init__(
+            "Zone balance check",
+            "Checking role distribution across zones",
+        )
+        self.machines = machines
+
+    def run(self) -> DiagnosticsResult:
+        """Check role distribution across zones."""
+        zone_role_counts = {}
+        for zone, machines in self.machines.items():
+            zone_role_counts.setdefault(zone, {})
+            for machine in machines:
+                for role in machine["roles"]:
+                    zone_role_counts[zone].setdefault(role, 0)
+                    zone_role_counts[zone][role] += 1
+        LOG.debug(f"{zone_role_counts=!r}")
+        unbalanced_roles = []
+        distribution = ""
+        for role in RoleTags.values():
+            counts = [zone_role_counts[zone].get(role, 0) for zone in zone_role_counts]
+            max_count = max(counts)
+            min_count = min(counts)
+            if max_count != min_count:
+                unbalanced_roles.append(role)
+            distribution += f"{role}:"
+            for zone, counts in zone_role_counts.items():
+                distribution += f"\n  {zone}={counts.get(role, 0)}"
+            distribution += "\n"
+
+        if unbalanced_roles:
+            diagnostics = textwrap.dedent(
+                """\
+                A deployment needs to have the same number of machines with the same
+                role in each zone. Either add more machines to the zones or remove the
+                zone from the deployment.
+                More on using tags: https://maas.io/docs/using-machine-tags
+                Distribution of roles across zones:
+                """
+            )
+            diagnostics += distribution
+            return DiagnosticsResult.fail(
+                self.name,
+                f"{', '.join(unbalanced_roles)} distribution is unbalanced",
+                diagnostics,
+            )
+        return DiagnosticsResult.success(
+            self.name,
+            "deployment is balanced",
+            distribution,
+        )
+
+
+class DeploymentTopologyCheck(DiagnosticsCheck):
+    """Check deployment topology."""
+
+    def __init__(self, snap: Snap, machines: list[dict]):
+        super().__init__(
+            "Topology check",
+            "Checking zone distribution",
+        )
+        self.snap = snap
+        self.machines = machines
+
+    def run(self) -> list[DiagnosticsResult]:
+        """Run a sequence of checks to validate deployment topology.""" ""
+        machines_by_zone = _group_machines_by_zone(self.machines)
+        checks = []
+        checks.append(
+            DeploymentRolesCheck(
+                self.machines, "juju controllers", RoleTags.JUJU_CONTROLLER.value
+            )
+        )
+        checks.append(
+            DeploymentRolesCheck(self.machines, "control nodes", RoleTags.CONTROL.value)
+        )
+        checks.append(
+            DeploymentRolesCheck(self.machines, "compute nodes", RoleTags.COMPUTE.value)
+        )
+        checks.append(
+            DeploymentRolesCheck(self.machines, "storage nodes", RoleTags.STORAGE.value)
+        )
+        checks.append(ZonesCheck(list(machines_by_zone.keys())))
+        checks.append(ZoneBalanceCheck(machines_by_zone))
+
+        results = _run_check_list(checks)
+        results.append(
+            DiagnosticsResult(self.name, all(result.passed for result in results))
+        )
+        return results

--- a/sunbeam-python/sunbeam/jobs/checks.py
+++ b/sunbeam-python/sunbeam/jobs/checks.py
@@ -57,6 +57,72 @@ class Check:
         return True
 
 
+class DiagnosticsResult:
+    def __init__(
+        self,
+        name: str,
+        passed: bool,
+        message: str | None = None,
+        diagnostics: str | None = None,
+        **details: dict,
+    ):
+        self.name = name
+        self.passed = passed
+        self.message = message
+        self.diagnostics = diagnostics
+        self.details = details
+
+    def to_dict(self) -> dict:
+        result = {
+            "name": self.name,
+            "passed": self.passed,
+            **self.details,
+        }
+        if self.message:
+            result["message"] = self.message
+        if self.diagnostics:
+            result["diagnostics"] = self.diagnostics
+        return result
+
+    @classmethod
+    def fail(
+        cls,
+        name: str,
+        message: str | None = None,
+        diagnostics: str | None = None,
+        **details: dict,
+    ):
+        return cls(name, False, message, diagnostics, **details)
+
+    @classmethod
+    def success(
+        cls,
+        name: str,
+        message: str | None = None,
+        diagnostics: str | None = None,
+        **details: dict,
+    ):
+        return cls(name, True, message, diagnostics, **details)
+
+
+class DiagnosticsCheck:
+    """Base class for Diagnostics checks."""
+
+    name: str
+    description: str
+
+    def __init__(self, name: str, description: str = ""):
+        self.name = name
+        self.description = description
+
+    def run(self) -> DiagnosticsResult | list[DiagnosticsResult]:
+        """Run the check logic here.
+
+        Return list of DiagnosticsResult.
+        """
+        ...
+
+
 class JujuSnapCheck(Check):
     """Check if juju snap is installed or not."""
 

--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -32,6 +32,7 @@ from sunbeam.clusterd.client import Client
 LOG = logging.getLogger(__name__)
 RAM_16_GB_IN_KB = 16 * 1024 * 1024
 RAM_32_GB_IN_KB = 32 * 1024 * 1024
+RAM_32_GB_IN_MB = 32 * 1000
 
 # Formatting related constants
 FORMAT_TABLE = "table"
@@ -41,6 +42,9 @@ FORMAT_VALUE = "value"
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 SHARE_PATH = Path(".local/share/openstack/")
+
+CLICK_OK = "[green]OK[/green]"
+CLICK_FAIL = "[red]FAIL[/red]"
 
 
 class Role(enum.Enum):

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_maas.py
@@ -20,7 +20,19 @@ from unittest.mock import Mock
 import pytest
 from maas.client.bones import CallError
 
-from sunbeam.commands.maas import AddMaasDeployment
+from sunbeam.commands.maas import (
+    AddMaasDeployment,
+    DeploymentRolesCheck,
+    MachineNetworkCheck,
+    MachineRequirementsCheck,
+    MachineRolesCheck,
+    MachineStorageCheck,
+    Networks,
+    RoleTags,
+    StorageTags,
+    ZoneBalanceCheck,
+    ZonesCheck,
+)
 from sunbeam.jobs.common import ResultType
 
 
@@ -117,3 +129,250 @@ class TestAddMaasDeployment:
         )
         result = add_maas_deployment.run()
         assert result.result_type == ResultType.FAILED
+
+
+class TestMachineRolesCheck:
+    def test_run_with_no_assigned_roles(self):
+        machine = {"hostname": "test_machine", "roles": []}
+        check = MachineRolesCheck(machine)
+        result = check.run()
+        assert result.passed is False
+        assert result.details["machine"] == "test_machine"
+
+    def test_run_with_assigned_roles(self):
+        machine = {"hostname": "test_machine", "roles": ["role1", "role2"]}
+        check = MachineRolesCheck(machine)
+        result = check.run()
+        assert result.passed is True
+        assert result.details["machine"] == "test_machine"
+
+
+class TestMachineNetworkCheck:
+    def test_run_with_incomplete_network_mapping(self, mocker):
+        snap = Mock()
+        mocker.patch("sunbeam.commands.maas.get_network_mapping", return_value={})
+        machine = {
+            "hostname": "test_machine",
+            "roles": ["role1", "role2"],
+            "spaces": [],
+        }
+        check = MachineNetworkCheck(snap, machine)
+        result = check.run()
+        assert result.passed is False
+        assert result.details["machine"] == "test_machine"
+        assert result.message and "network mapping" in result.message
+
+    def test_run_with_no_assigned_roles(self, mocker):
+        snap = Mock()
+        mocker.patch(
+            "sunbeam.commands.maas.get_network_mapping",
+            return_value={network: "alpha" for network in Networks.values()},
+        )
+        machine = {"hostname": "test_machine", "roles": [], "spaces": []}
+        check = MachineNetworkCheck(snap, machine)
+        result = check.run()
+        assert result.passed is False
+        assert result.details["machine"] == "test_machine"
+        assert result.message and "no role assigned" in result.message
+
+    def test_run_with_missing_spaces(self, mocker):
+        snap = Mock()
+        mocker.patch(
+            "sunbeam.commands.maas.get_network_mapping",
+            return_value={
+                **{network: "alpha" for network in Networks.values()},
+                **{Networks.PUBLIC.value: "beta"},
+            },
+        )
+        machine = {
+            "hostname": "test_machine",
+            "roles": [RoleTags.CONTROL.value],
+            "spaces": ["alpha"],
+        }
+        check = MachineNetworkCheck(snap, machine)
+        result = check.run()
+        assert result.passed is False
+        assert result.details["machine"] == "test_machine"
+        assert result.message and "missing beta" in result.message
+
+    def test_run_with_successful_check(self, mocker):
+        snap = Mock()
+        mocker.patch(
+            "sunbeam.commands.maas.get_network_mapping",
+            return_value={network: "alpha" for network in Networks.values()},
+        )
+        machine = {
+            "hostname": "test_machine",
+            "roles": RoleTags.values(),
+            "spaces": ["alpha"],
+        }
+        check = MachineNetworkCheck(snap, machine)
+        result = check.run()
+        assert result.passed is True
+        assert result.details["machine"] == "test_machine"
+
+
+class TestMachineStorageCheck:
+    def test_run_with_no_assigned_roles(self):
+        machine = {"hostname": "test_machine", "roles": [], "storage": {}}
+        check = MachineStorageCheck(machine)
+        result = check.run()
+        assert result.passed is False
+        assert result.details["machine"] == "test_machine"
+        assert result.message and "machine has no role assigned" in result.message
+
+    def test_run_with_not_storage_node(self):
+        machine = {
+            "hostname": "test_machine",
+            "roles": ["role1", "role2"],
+            "storage": {},
+        }
+        check = MachineStorageCheck(machine)
+        result = check.run()
+        assert result.passed is True
+        assert result.details["machine"] == "test_machine"
+        assert result.message == "not a storage node."
+
+    def test_run_with_no_ceph_storage(self):
+        machine = {
+            "hostname": "test_machine",
+            "roles": [RoleTags.STORAGE.value],
+            "storage": {},
+        }
+        check = MachineStorageCheck(machine)
+        result = check.run()
+        assert result.passed is False
+        assert result.details["machine"] == "test_machine"
+        assert result.message and "storage node has no ceph storage" in result.message
+        assert result.diagnostics
+        assert "https://maas.io/docs/using-storage-tags" in result.diagnostics
+
+    def test_run_with_ceph_storage(self):
+        machine = {
+            "hostname": "test_machine",
+            "roles": [RoleTags.STORAGE.value],
+            "storage": {StorageTags.CEPH.value: 1},
+        }
+        check = MachineStorageCheck(machine)
+        result = check.run()
+        assert result.passed is True
+        assert result.details["machine"] == "test_machine"
+        assert result.message and StorageTags.CEPH.value in result.message
+
+
+class TestMachineRequirementsCheck:
+    def test_run_with_insufficient_memory(self):
+        machine = {
+            "hostname": "test_machine",
+            "cores": 16,
+            "memory": 16384,  # 16GiB
+        }
+        check = MachineRequirementsCheck(machine)
+        result = check.run()
+        assert result.passed is False
+        assert result.details["machine"] == "test_machine"
+        assert result.message and "machine does not meet requirements" in result.message
+
+    def test_run_with_insufficient_cores(self):
+        machine = {
+            "hostname": "test_machine",
+            "cores": 8,
+            "memory": 32768,  # 32GiB
+        }
+        check = MachineRequirementsCheck(machine)
+        result = check.run()
+        assert result.passed is False
+        assert result.details["machine"] == "test_machine"
+        assert result.message and "machine does not meet requirements" in result.message
+
+    def test_run_with_sufficient_resources(self):
+        machine = {
+            "hostname": "test_machine",
+            "cores": 16,
+            "memory": 32768,  # 32GB
+        }
+        check = MachineRequirementsCheck(machine)
+        result = check.run()
+        assert result.passed is True
+        assert result.details["machine"] == "test_machine"
+
+
+class TestDeploymentRolesCheck:
+    def test_run_with_insufficient_roles(self):
+        machines = [
+            {"hostname": "machine1", "roles": ["role1", "role2"]},
+            {"hostname": "machine2", "roles": ["role1"]},
+            {"hostname": "machine3", "roles": ["role2"]},
+        ]
+        check = DeploymentRolesCheck(machines, "Role", "role1", min_count=3)
+        result = check.run()
+        assert result.passed is False
+        assert result.message and "less than 3 Role" in result.message
+
+    def test_run_with_sufficient_roles(self):
+        machines = [
+            {"hostname": "machine1", "roles": ["role1", "role2"]},
+            {"hostname": "machine2", "roles": ["role1"]},
+            {"hostname": "machine3", "roles": ["role1"]},
+        ]
+        check = DeploymentRolesCheck(machines, "Role", "role1", min_count=3)
+        result = check.run()
+        assert result.passed is True
+        assert result.message == "Role: 3"
+
+
+class TestZonesCheck:
+    def test_run_with_one_zone(self):
+        zones = ["zone1"]
+        check = ZonesCheck(zones)
+        result = check.run()
+        assert result.passed is True
+        assert result.message == "1 zone(s)"
+
+    def test_run_with_two_zones(self):
+        zones = ["zone1", "zone2"]
+        check = ZonesCheck(zones)
+        result = check.run()
+        assert result.passed is False
+        assert result.message == "deployment has 2 zones"
+
+    def test_run_with_three_zones(self):
+        zones = ["zone1", "zone2", "zone3"]
+        check = ZonesCheck(zones)
+        result = check.run()
+        assert result.passed is True
+        assert result.message == "3 zone(s)"
+
+
+class TestZoneBalanceCheck:
+    def test_run_with_balanced_roles(self):
+        machines = {
+            "zone1": [
+                {"roles": [RoleTags.CONTROL.value, RoleTags.STORAGE.value]},
+                {"roles": [RoleTags.CONTROL.value, RoleTags.COMPUTE.value]},
+            ],
+            "zone2": [
+                {"roles": [RoleTags.CONTROL.value, RoleTags.STORAGE.value]},
+                {"roles": [RoleTags.CONTROL.value, RoleTags.COMPUTE.value]},
+            ],
+        }
+        check = ZoneBalanceCheck(machines)
+        result = check.run()
+        assert result.passed is True
+        assert result.message == "deployment is balanced"
+
+    def test_run_with_unbalanced_roles(self):
+        machines = {
+            "zone1": [
+                {"roles": [RoleTags.CONTROL.value, RoleTags.STORAGE.value]},
+                {"roles": [RoleTags.CONTROL.value, RoleTags.COMPUTE.value]},
+            ],
+            "zone2": [
+                {"roles": [RoleTags.CONTROL.value, RoleTags.STORAGE.value]},
+                {"roles": [RoleTags.CONTROL.value]},
+            ],
+        }
+        check = ZoneBalanceCheck(machines)
+        result = check.run()
+        assert result.passed is False
+        assert result.message and "compute distribution is unbalanced" in result.message


### PR DESCRIPTION
Add two new commands:
- sunbeam deployment validate: check active deployment is ready to deploy openstack
- sunbeam deployment machine validate <machine>: check machine is correctly configured to be part of an openstack deployment


### Machine checks:
- Role check: Check machine has roles assigned
- Network check: Check machine has networks corresponding to its roles
- Storage check: Check machine has tagged storage devices if it has storage role
- Requirements check: Check machine meets minimum requirements, (32GB ram, 16 cores) disks ?

#### Output example:
![image](https://github.com/canonical/snap-openstack/assets/4944914/b386cdf9-275a-4832-bf1e-4414f4ae83f0)

#### Report example:
```yaml
- machine: sb-n0
  message: control, compute, storage
  name: Role check
  passed: true
- machine: sb-n0
  message: storage, public, internal, data, management
  name: Network check
  passed: true
- machine: sb-n0
  message: ceph(3)
  name: Storage check
  passed: true
- diagnostics: |-
    A machine needs to have at least 16 cores and
    32000MB RAM to be a part of an openstack deployment.
    Either add more cores and memory to the machine or remove the
    machine from the deployment.
    sb-n0:
        cores: 4
        memory: 15032MB
  machine: sb-n0
  message: machine does not meet requirements
  name: Machine requirements check
  passed: false
```

### Deployment checks:
- Deployment check:
  * All previous machine checks for every machine
- Topology check:
  * Minimum role check: Check each role has a minimum of 3 machines
  * Zones check: Check deployment has either 1 zone (no ha), or at least 3
  * Zone balance check: Check that each other has the same number of machine for each given role

#### Output example:
![image](https://github.com/canonical/snap-openstack/assets/4944914/14191657-aba6-4f83-b54c-846bc895aae9)

#### Report example
```yaml
- machine: sb-n0
  message: storage, compute, control
  name: Role check
  passed: true
- machine: sb-n0
  message: internal, public, storage, data, management
  name: Network check
  passed: true
- machine: sb-n0
  message: ceph(3)
  name: Storage check
  passed: true
- diagnostics: |-
    A machine needs to have at least 16 cores and
    32000MB RAM to be a part of an openstack deployment.
    Either add more cores and memory to the machine or remove the
    machine from the deployment.
    sb-n0:
        cores: 4
        memory: 15032MB
  machine: sb-n0
  message: machine does not meet requirements
  name: Machine requirements check
  passed: false
- machine: sb-n2
  message: storage, compute, control
  name: Role check
  passed: true
- machine: sb-n2
  message: internal, public, storage, data, management
  name: Network check
  passed: true
- machine: sb-n2
  message: ceph(3)
  name: Storage check
  passed: true
- diagnostics: |-
    A machine needs to have at least 16 cores and
    32000MB RAM to be a part of an openstack deployment.
    Either add more cores and memory to the machine or remove the
    machine from the deployment.
    sb-n2:
        cores: 4
        memory: 15032MB
  machine: sb-n2
  message: machine does not meet requirements
  name: Machine requirements check
  passed: false
- machine: sb-n1
  message: storage, compute, control
  name: Role check
  passed: true
- machine: sb-n1
  message: internal, public, storage, data, management
  name: Network check
  passed: true
- machine: sb-n1
  message: ceph(3)
  name: Storage check
  passed: true
- diagnostics: |-
    A machine needs to have at least 16 cores and
    32000MB RAM to be a part of an openstack deployment.
    Either add more cores and memory to the machine or remove the
    machine from the deployment.
    sb-n1:
        cores: 4
        memory: 15032MB
  machine: sb-n1
  message: machine does not meet requirements
  name: Machine requirements check
  passed: false
- name: Deployment check
  passed: false
- diagnostics: |
    A deployment needs to have at least 3 juju controllers to be
    a part of an openstack deployment. You need to add more juju controllers
    to the deployment using juju-controller tag.
    More on using tags: https://maas.io/docs/using-machine-tags
  message: less than 3 juju controllers
  name: Minimum role check
  passed: false
- message: 'control nodes: 3'
  name: Minimum role check
  passed: true
- message: 'compute nodes: 3'
  name: Minimum role check
  passed: true
- message: 'storage nodes: 3'
  name: Minimum role check
  passed: true
- diagnostics: |-
    A deployment needs to have either 1 zone or more than 2 zones.
    Current zones: AC-DC, DP-DK
  message: deployment has 2 zones
  name: Zone check
  passed: false
- diagnostics: |
    A deployment needs to have the same number of machines with the same
    role in each zone. Either add more machines to the zones or remove the
    zone from the deployment.
    More on using tags: https://maas.io/docs/using-machine-tags
    Distribution of roles across zones:
    control:
      AC-DC=2
      DP-DK=1
    compute:
      AC-DC=2
      DP-DK=1
    storage:
      AC-DC=2
      DP-DK=1
    juju-controller:
      AC-DC=0
      DP-DK=0
  message: control, compute, storage distribution is unbalanced
  name: Zone balance check
  passed: false
- name: Topology check
  passed: false
```
