### PR TITLE
microk8s: Disable certificate verification

### DIFF
--- a/cloud/etc/deploy-microk8s/main.tf
+++ b/cloud/etc/deploy-microk8s/main.tf
@@ -47,5 +47,6 @@ resource "juju_application" "microk8s" {
     addons                        = join(" ", [for key, value in var.addons : "${key}:${value}"])
     disable_cert_reissue          = true
     kubelet_serialize_image_pulls = false
+    skip_verify                   = true
   }
 }


### PR DESCRIPTION
We've had numerous issues with TLS certificate verification during MicroK8S cluster join operations.

As MicroK8S is due to be swapped out for a new version based on microcluster which will work in a different way lets disable verification for now - this will be re-instated when we switch to the replatformed K8S.

Closes-Bug: LP:2045670
(cherry picked from commit 2bf6e0585f1a09f0c1f8f796f01b9cb6130e216e)