### PR TITLE
Upgrade to juju 3.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,14 +131,17 @@ parts:
     source: https://github.com/hashicorp/terraform
     source-depth: 1
     source-type: git
-    source-tag: "v1.3.7"
+    source-tag: "v1.6.6"
     build-snaps: [go]
     build-environment:
       - CGO_ENABLED: "0"
       - GOFLAGS: "-mod=readonly"
+      - LDFLAGS: "-s -w"
     override-build: |
+      export LDFLAGS="${LDFLAGS} -X 'github.com/hashicorp/terraform/version.Prerelease='"
+      export LDFLAGS="${LDFLAGS} -X 'github.com/hashicorp/terraform/version.Version=$(cat version/VERSION)'"
       go mod download
-      go build -ldflags "-s -w"
+      go build -ldflags "${LDFLAGS}"
       mkdir -p $SNAPCRAFT_PART_INSTALL/bin
       cp terraform $SNAPCRAFT_PART_INSTALL/bin/terraform
     stage:

--- a/sunbeam-python/requirements.txt
+++ b/sunbeam-python/requirements.txt
@@ -21,9 +21,8 @@ pexpect
 # YAML parsing library
 pyyaml>=6.0
 
-# Set upper bound to match Juju 3.2.x series target
-# 3.2.3 has introduced a regression
-juju>=3.2,<3.2.3
+# Set upper bound to match Juju 3.3.x series target
+juju>=3.3.0,<3.4.0
 
 # Used in the launch command to launch an instance
 petname

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -19,7 +19,7 @@ from rich.console import Console
 console = Console()
 
 
-JUJU_CHANNEL = "3.2/stable"
+JUJU_CHANNEL = "3.3/stable"
 SUPPORTED_RELEASE = "jammy"
 
 PREPARE_NODE_TEMPLATE = f"""#!/bin/bash


### PR DESCRIPTION
prepare-node: Install from 3.3/stable

Update requirements to use 3.3 compatible libjuju.