### PR TITLE
Allow untrusted access to config and nodes endpoint

### DIFF
--- a/sunbeam-microcluster/api/config.go
+++ b/sunbeam-microcluster/api/config.go
@@ -18,9 +18,9 @@ import (
 var configCmd = rest.Endpoint{
 	Path: "config/{key}",
 
-	Get:    rest.EndpointAction{Handler: cmdConfigGet, ProxyTarget: true},
-	Put:    rest.EndpointAction{Handler: cmdConfigPut, ProxyTarget: true},
-	Delete: rest.EndpointAction{Handler: cmdConfigDelete, ProxyTarget: true},
+	Get:    rest.EndpointAction{Handler: cmdConfigGet, ProxyTarget: true, AllowUntrusted: true},
+	Put:    rest.EndpointAction{Handler: cmdConfigPut, ProxyTarget: true, AllowUntrusted: true},
+	Delete: rest.EndpointAction{Handler: cmdConfigDelete, ProxyTarget: true, AllowUntrusted: true},
 }
 
 func cmdConfigGet(s *state.State, r *http.Request) response.Response {

--- a/sunbeam-microcluster/api/nodes.go
+++ b/sunbeam-microcluster/api/nodes.go
@@ -19,17 +19,17 @@ import (
 var nodesCmd = rest.Endpoint{
 	Path: "nodes",
 
-	Get:  rest.EndpointAction{Handler: cmdNodesGetAll, ProxyTarget: true},
-	Post: rest.EndpointAction{Handler: cmdNodesPost, ProxyTarget: true},
+	Get:  rest.EndpointAction{Handler: cmdNodesGetAll, ProxyTarget: true, AllowUntrusted: true},
+	Post: rest.EndpointAction{Handler: cmdNodesPost, ProxyTarget: true, AllowUntrusted: true},
 }
 
 // /1.0/nodes/<name> endpoint.
 var nodeCmd = rest.Endpoint{
 	Path: "nodes/{name}",
 
-	Get:    rest.EndpointAction{Handler: cmdNodesGet, ProxyTarget: true},
-	Put:    rest.EndpointAction{Handler: cmdNodesPut, ProxyTarget: true},
-	Delete: rest.EndpointAction{Handler: cmdNodesDelete, ProxyTarget: true},
+	Get:    rest.EndpointAction{Handler: cmdNodesGet, ProxyTarget: true, AllowUntrusted: true},
+	Put:    rest.EndpointAction{Handler: cmdNodesPut, ProxyTarget: true, AllowUntrusted: true},
+	Delete: rest.EndpointAction{Handler: cmdNodesDelete, ProxyTarget: true, AllowUntrusted: true},
 }
 
 func cmdNodesGetAll(s *state.State, r *http.Request) response.Response {


### PR DESCRIPTION
This is only allowed while developping the maas feature

This should be reverted when TLS enablement work has been done