### PR TITLE
Set RAM constraints in GB rather GiB

### DIFF
--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -29,8 +29,8 @@ from rich.status import Status
 from sunbeam.clusterd.client import Client
 
 LOG = logging.getLogger(__name__)
-RAM_16_GB_IN_KB = 16 * 1024 * 1024
-RAM_32_GB_IN_KB = 32 * 1024 * 1024
+RAM_16_GB_IN_KB = 16 * 1000 * 1000
+RAM_32_GB_IN_KB = 32 * 1000 * 1000
 
 # Formatting related constants
 FORMAT_TABLE = "table"


### PR DESCRIPTION
Current RAM constraints was too strict, when provisinning VM with 16GB of ram, you'll not get 16GiB. Loosen the constraints a bit by requiring 16GB/32GB instead of 16GiB/32GiB.