### PR TITLE
Add manifest override for juju bootstrap args

### DIFF
--- a/sunbeam-python/sunbeam/commands/bootstrap.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap.py
@@ -167,6 +167,7 @@ def bootstrap(
 
     cloud_type = snap.config.get("juju.cloud.type")
     cloud_name = snap.config.get("juju.cloud.name")
+    juju_bootstrap_args = manifest_obj.juju.bootstrap_args
 
     data_location = snap.paths.user_data
 
@@ -194,6 +195,7 @@ def bootstrap(
             cloud_name,
             cloud_type,
             CONTROLLER,
+            bootstrap_args=juju_bootstrap_args,
             accept_defaults=accept_defaults,
             preseed_file=preseed,
         )

--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -268,6 +268,7 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
         cloud_name: str,
         cloud_type: str,
         controller: str,
+        bootstrap_args: list = [],
         preseed_file: Optional[Path] = None,
         accept_defaults: bool = False,
     ):
@@ -276,6 +277,7 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
         self.cloud = cloud_name
         self.cloud_type = cloud_type
         self.controller = controller
+        self.bootstrap_args = bootstrap_args
         self.preseed_file = preseed_file
         self.accept_defaults = accept_defaults
         self.juju_clouds = []
@@ -356,12 +358,9 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
                 if not result:
                     return Result(ResultType.FAILED, "Not able to create cloud")
 
-            cmd = [
-                self._get_juju_binary(),
-                "bootstrap",
-                self.cloud,
-                self.controller,
-            ]
+            cmd = [self._get_juju_binary(), "bootstrap"]
+            cmd.extend(self.bootstrap_args)
+            cmd.extend([self.cloud, self.controller])
             LOG.debug(f'Running command {" ".join(cmd)}')
             process = subprocess.run(cmd, capture_output=True, text=True, check=True)
             LOG.debug(

--- a/sunbeam-python/sunbeam/jobs/manifest.py
+++ b/sunbeam-python/sunbeam/jobs/manifest.py
@@ -61,8 +61,14 @@ class MissingTerraformInfoException(Exception):
 
 @dataclass
 class JujuManifest:
+    # Setting Field alias not supported in pydantic 1.10.0
+    # Old version of pydantic is used due to dependencies
+    # with older version of paramiko from python-libjuju
+    # Newer version of pydantic can be used once the below
+    # PR is released
+    # https://github.com/juju/python-libjuju/pull/1005
     bootstrap_args: List[str] = Field(
-        alias="bootstrap-args", description="Extra args for juju bootstrap"
+        default=[], description="Extra args for juju bootstrap"
     )
 
 
@@ -151,7 +157,7 @@ class Manifest:
     @classmethod
     def get_default_manifest_as_dict(cls) -> dict:
         snap = Snap()
-        m = {"juju": None, "charms": {}, "terraform": {}}
+        m = {"juju": {"bootstrap_args": []}, "charms": {}, "terraform": {}}
         m["charms"] = {
             charm: {"channel": channel}
             for charm, channel in MANIFEST_CHARM_VERSIONS.items()

--- a/sunbeam-python/tests/unit/sunbeam/jobs/test_manifest.py
+++ b/sunbeam-python/tests/unit/sunbeam/jobs/test_manifest.py
@@ -27,6 +27,9 @@ from sunbeam.jobs.common import ResultType
 from sunbeam.versions import OPENSTACK_CHANNEL, TERRAFORM_DIR_NAMES
 
 test_manifest = """
+juju:
+  bootstrap_args:
+    - --agent-version=3.2.4
 charms:
   keystone:
     channel: 2023.1/stable
@@ -116,6 +119,11 @@ class TestManifest:
 
         # Assert defaults does not exist
         assert "nova" not in manifest_obj.charms.keys()
+
+        test_manifest_dict = yaml.safe_load(test_manifest)
+        assert manifest_obj.juju.bootstrap_args == test_manifest_dict.get(
+            "juju", {}
+        ).get("bootstrap_args", [])
 
     def test_load_on_default(self, mocker, snap, cclient, pluginmanager, tmpdir):
         mocker.patch.object(manifest, "Snap", return_value=snap)


### PR DESCRIPTION
Add bootstrap args from the manifest to the
juju bootstrap command. The bootstrap args
will be appended to the juju bootstrap command.

Manifest for juju bootstrap args looks like:
juju:
  bootstrap_args:
    - --agent-version=3.2.4