### PR TITLE
Refactor cluster client usage

### DIFF
--- a/sunbeam-python/sunbeam/clusterd/service.py
+++ b/sunbeam-python/sunbeam/clusterd/service.py
@@ -15,12 +15,9 @@
 
 import logging
 from abc import ABC
-from urllib.parse import quote
 
 from requests.exceptions import ConnectionError, HTTPError
 from requests.sessions import Session
-from requests_unixsocket import DEFAULT_SCHEME
-from snaphelpers import Snap
 
 LOG = logging.getLogger(__name__)
 
@@ -94,7 +91,7 @@ class JujuUserNotFoundException(RemoteException):
 class BaseService(ABC):
     """BaseService is the base service class for sunbeam clusterd services."""
 
-    def __init__(self, session: Session):
+    def __init__(self, session: Session, endpoint: str):
         """Creates a new BaseService for the sunbeam clusterd API
 
         The service class is used to provide convenient APIs for clients to
@@ -105,13 +102,13 @@ class BaseService(ABC):
         :type: Session
         """
         self.__session = session
-        self._socket_path = Snap().paths.common / "state" / "control.socket"
+        self._endpoint = endpoint
 
     def _request(self, method, path, **kwargs):
         if path.startswith("/"):
             path = path[1:]
-        netloc = quote(str(self._socket_path), safe="")
-        url = f"{DEFAULT_SCHEME}{netloc}/{path}"
+        netloc = self._endpoint
+        url = f"{netloc}/{path}"
 
         try:
             LOG.debug("[%s] %s, args=%s", method, url, kwargs)

--- a/sunbeam-python/sunbeam/commands/bootstrap.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap.py
@@ -24,6 +24,7 @@ from rich.console import Console
 from snaphelpers import Snap
 
 from sunbeam import utils
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.bootstrap_state import SetBootstrapped
 from sunbeam.commands.clusterd import (
     ClusterAddJujuUserStep,
@@ -124,7 +125,9 @@ snap = Snap()
         "'multi' for a database per service, "
     ),
 )
+@click.pass_context
 def bootstrap(
+    ctx: click.Context,
     roles: List[Role],
     topology: str,
     database: str,
@@ -153,6 +156,7 @@ def bootstrap(
     cloud_name = snap.config.get("juju.cloud.name")
 
     data_location = snap.paths.user_data
+    client: Client = ctx.obj
 
     # NOTE: install to user writable location
     tfplan_dirs = ["deploy-sunbeam-machine"]
@@ -187,9 +191,10 @@ def bootstrap(
 
     plan = []
     plan.append(JujuLoginStep(data_location))
-    plan.append(ClusterInitStep(roles_to_str_list(roles)))
+    plan.append(ClusterInitStep(client, roles_to_str_list(roles)))
     plan.append(
         BootstrapJujuStep(
+            client,
             cloud_name,
             cloud_type,
             CONTROLLER,
@@ -201,13 +206,13 @@ def bootstrap(
 
     plan2 = []
     plan2.append(CreateJujuUserStep(fqdn))
-    plan2.append(ClusterUpdateJujuControllerStep(CONTROLLER))
+    plan2.append(ClusterUpdateJujuControllerStep(client, CONTROLLER))
     plan2_results = run_plan(plan2, console)
 
     token = get_step_message(plan2_results, CreateJujuUserStep)
 
     plan3 = []
-    plan3.append(ClusterAddJujuUserStep(fqdn, token))
+    plan3.append(ClusterAddJujuUserStep(client, fqdn, token))
     plan3.append(BackupBootstrapUserStep(fqdn, data_location))
     plan3.append(SaveJujuUserLocallyStep(fqdn, data_location))
     run_plan(plan3, console)
@@ -242,33 +247,47 @@ def bootstrap(
         backend="http",
         data_location=data_location,
     )
-    jhelper = JujuHelper(data_location)
+    jhelper = JujuHelper(client, data_location)
 
     plan4 = []
-    plan4.append(RegisterJujuUserStep(fqdn, CONTROLLER, data_location, replace=True))
+    plan4.append(
+        RegisterJujuUserStep(client, fqdn, CONTROLLER, data_location, replace=True)
+    )
     # Deploy sunbeam machine charm
     plan4.append(TerraformInitStep(tfhelper_sunbeam_machine))
-    plan4.append(DeploySunbeamMachineApplicationStep(tfhelper_sunbeam_machine, jhelper))
-    plan4.append(AddSunbeamMachineUnitStep(fqdn, jhelper))
+    plan4.append(
+        DeploySunbeamMachineApplicationStep(client, tfhelper_sunbeam_machine, jhelper)
+    )
+    plan4.append(AddSunbeamMachineUnitStep(client, fqdn, jhelper))
     # Deploy Microk8s application during bootstrap irrespective of node role.
     plan4.append(TerraformInitStep(tfhelper))
     plan4.append(
         DeployMicrok8sApplicationStep(
-            tfhelper, jhelper, accept_defaults=accept_defaults, preseed_file=preseed
+            client,
+            tfhelper,
+            jhelper,
+            accept_defaults=accept_defaults,
+            preseed_file=preseed,
         )
     )
-    plan4.append(AddMicrok8sUnitStep(fqdn, jhelper))
-    plan4.append(StoreMicrok8sConfigStep(jhelper))
-    plan4.append(AddMicrok8sCloudStep(jhelper))
+    plan4.append(AddMicrok8sUnitStep(client, fqdn, jhelper))
+    plan4.append(StoreMicrok8sConfigStep(client, jhelper))
+    plan4.append(AddMicrok8sCloudStep(client, jhelper))
     # Deploy Microceph application during bootstrap irrespective of node role.
     plan4.append(TerraformInitStep(tfhelper_microceph_deploy))
-    plan4.append(DeployMicrocephApplicationStep(tfhelper_microceph_deploy, jhelper))
+    plan4.append(
+        DeployMicrocephApplicationStep(client, tfhelper_microceph_deploy, jhelper)
+    )
 
     if is_storage_node:
-        plan4.append(AddMicrocephUnitStep(fqdn, jhelper))
+        plan4.append(AddMicrocephUnitStep(client, fqdn, jhelper))
         plan4.append(
             ConfigureMicrocephOSDStep(
-                fqdn, jhelper, accept_defaults=accept_defaults, preseed_file=preseed
+                client,
+                fqdn,
+                jhelper,
+                accept_defaults=accept_defaults,
+                preseed_file=preseed,
             )
         )
 
@@ -276,7 +295,7 @@ def bootstrap(
         plan4.append(TerraformInitStep(tfhelper_openstack_deploy))
         plan4.append(
             DeployControlPlaneStep(
-                tfhelper_openstack_deploy, jhelper, topology, database
+                client, tfhelper_openstack_deploy, jhelper, topology, database
             )
         )
 
@@ -286,7 +305,7 @@ def bootstrap(
 
     if is_control_node:
         plan5.append(ConfigureMySQLStep(jhelper))
-        plan5.append(PatchLoadBalancerServicesStep())
+        plan5.append(PatchLoadBalancerServicesStep(client))
 
     # NOTE(jamespage):
     # As with MicroCeph, always deploy the openstack-hypervisor charm
@@ -294,13 +313,16 @@ def bootstrap(
     plan5.append(TerraformInitStep(tfhelper_hypervisor_deploy))
     plan5.append(
         DeployHypervisorApplicationStep(
-            tfhelper_hypervisor_deploy, tfhelper_openstack_deploy, jhelper
+            client,
+            tfhelper_hypervisor_deploy,
+            tfhelper_openstack_deploy,
+            jhelper,
         )
     )
     if is_compute_node:
-        plan5.append(AddHypervisorUnitStep(fqdn, jhelper))
+        plan5.append(AddHypervisorUnitStep(client, fqdn, jhelper))
 
-    plan5.append(SetBootstrapped())
+    plan5.append(SetBootstrapped(client))
     run_plan(plan5, console)
 
     click.echo(f"Node has been bootstrapped with roles: {pretty_roles}")

--- a/sunbeam-python/sunbeam/commands/bootstrap_state.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap_state.py
@@ -26,9 +26,9 @@ LOG = logging.getLogger(__name__)
 class SetBootstrapped(BaseStep):
     """Post Deployment step to update bootstrap flag in cluster DB."""
 
-    def __init__(self):
+    def __init__(self, client: Client):
         super().__init__("Mark bootstrapped", "Mark deployment bootstrapped")
-        self.client = Client()
+        self.client = client
 
     def run(self, status: Optional[Status] = None) -> Result:
         LOG.debug("Setting deployment as bootstrapped")

--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -19,7 +19,7 @@ import re
 from typing import List, Optional, Union
 
 from sunbeam import utils
-from sunbeam.clusterd.client import Client as clusterClient
+from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import (
     ClusterAlreadyBootstrappedException,
     ClusterServiceUnavailableException,
@@ -44,12 +44,12 @@ LOG = logging.getLogger(__name__)
 class ClusterInitStep(BaseStep):
     """Bootstrap clustering on sunbeam clusterd."""
 
-    def __init__(self, role: List[str]):
+    def __init__(self, client: Client, role: List[str]):
         super().__init__("Bootstrap Cluster", "Bootstrapping Sunbeam cluster")
 
         self.port = CLUSTERD_PORT
         self.role = role
-        self.client = clusterClient()
+        self.client = client
         self.fqdn = utils.get_fqdn()
         self.ip = utils.get_local_ip_by_default_route()
 
@@ -90,14 +90,14 @@ class ClusterInitStep(BaseStep):
 class ClusterAddNodeStep(BaseStep):
     """Generate token for new node to join in cluster."""
 
-    def __init__(self, name: str):
+    def __init__(self, client: Client, name: str):
         super().__init__(
             "Add Node Cluster",
             "Generating token for new node to join cluster",
         )
 
         self.node_name = name
-        self.client = clusterClient()
+        self.client = client
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -138,11 +138,11 @@ class ClusterAddNodeStep(BaseStep):
 class ClusterJoinNodeStep(BaseStep):
     """Join node to the sunbeam cluster."""
 
-    def __init__(self, token: str, role: List[str]):
+    def __init__(self, client: Client, token: str, role: List[str]):
         super().__init__("Join node to Cluster", "Adding node to Sunbeam cluster")
 
         self.port = CLUSTERD_PORT
-        self.client = clusterClient()
+        self.client = client
         self.token = token
         self.role = role
         self.fqdn = utils.get_fqdn()
@@ -187,9 +187,9 @@ class ClusterJoinNodeStep(BaseStep):
 class ClusterListNodeStep(BaseStep):
     """List nodes in the sunbeam cluster."""
 
-    def __init__(self):
+    def __init__(self, client: Client):
         super().__init__("List nodes of Cluster", "Listing nodes in Sunbeam cluster")
-        self.client = clusterClient()
+        self.client = client
 
     def run(self, status: Optional[Status] = None) -> Result:
         """List nodes in the sunbeam cluster"""
@@ -216,10 +216,14 @@ class ClusterUpdateNodeStep(BaseStep):
     """Update node info in the cluster database."""
 
     def __init__(
-        self, name: str, role: Optional[List[str]] = None, machine_id: int = -1
+        self,
+        client: Client,
+        name: str,
+        role: Optional[List[str]] = None,
+        machine_id: int = -1,
     ):
         super().__init__("Update node info", "Updating node info in cluster database")
-        self.client = clusterClient()
+        self.client = client
         self.name = name
         self.role = role
         self.machine_id = machine_id
@@ -237,12 +241,12 @@ class ClusterUpdateNodeStep(BaseStep):
 class ClusterRemoveNodeStep(BaseStep):
     """Remove node from the sunbeam cluster."""
 
-    def __init__(self, name: str):
+    def __init__(self, client: Client, name: str):
         super().__init__(
             "Remove node from Cluster", "Removing node from Sunbeam cluster"
         )
         self.node_name = name
-        self.client = clusterClient()
+        self.client = client
 
     def run(self, status: Optional[Status] = None) -> Result:
         """Remove node from sunbeam cluster"""
@@ -264,7 +268,7 @@ class ClusterRemoveNodeStep(BaseStep):
 class ClusterAddJujuUserStep(BaseStep):
     """Add Juju user in cluster database."""
 
-    def __init__(self, name: str, token: str):
+    def __init__(self, client: Client, name: str, token: str):
         super().__init__(
             "Add Juju user to cluster DB",
             "Adding Juju user to cluster database",
@@ -272,7 +276,7 @@ class ClusterAddJujuUserStep(BaseStep):
 
         self.username = name
         self.token = token
-        self.client = clusterClient()
+        self.client = client
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -304,13 +308,13 @@ class ClusterAddJujuUserStep(BaseStep):
 class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
     """Save Juju controller in cluster database."""
 
-    def __init__(self, controller: str):
+    def __init__(self, client: Client, controller: str):
         super().__init__(
             "Add Juju controller to cluster DB",
             "Adding Juju controller to cluster database",
         )
 
-        self.client = clusterClient()
+        self.client = client
         self.controller = controller
 
     def _extract_ip(self, ip) -> Union[ipaddress.IPv4Address, ipaddress.IPv6Address]:

--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -289,7 +289,7 @@ class SetHypervisorCharmConfigStep(BaseStep):
 
     IPVANYNETWORK_UNSET = "0.0.0.0/0"
 
-    def __init__(self, jhelper, ext_network: Path):
+    def __init__(self, client: Client, jhelper: JujuHelper, ext_network: Path):
         super().__init__(
             "Update charm config",
             "Updating openstack-hypervisor charm configuration",
@@ -298,7 +298,7 @@ class SetHypervisorCharmConfigStep(BaseStep):
         # File path with external_network details in json format
         self.ext_network_file = ext_network
         self.ext_network = {}
-        self.client = Client()
+        self.client = client
         self.jhelper = jhelper
         self.charm_config = {}
 
@@ -356,14 +356,14 @@ class SetHypervisorCharmConfigStep(BaseStep):
 class UserOpenRCStep(BaseStep):
     """Generate openrc for created cloud user."""
 
-    def __init__(self, auth_url: str, auth_version: str, openrc: Path):
+    def __init__(self, client: Client, auth_url: str, auth_version: str, openrc: Path):
         super().__init__(
             "Generate admin openrc", "Generating openrc for cloud admin usage"
         )
         self.auth_url = auth_url
         self.auth_version = auth_version
         self.openrc = openrc
-        self.client = Client()
+        self.client = client
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -430,16 +430,17 @@ class UserQuestions(BaseStep):
 
     def __init__(
         self,
+        client: Client,
         answer_file: str,
-        preseed_file: str = None,
+        preseed_file: str | None = None,
         accept_defaults: bool = False,
     ):
         super().__init__(
             "Collect cloud configuration", "Collecting cloud configuration"
         )
+        self.client = client
         self.accept_defaults = accept_defaults
         self.preseed_file = preseed_file
-        self.client = Client()
         self.answer_file = answer_file
 
     def has_prompts(self) -> bool:
@@ -558,6 +559,7 @@ class DemoSetup(BaseStep):
 
     def __init__(
         self,
+        client: Client,
         tfhelper: TerraformHelper,
         answer_file: str,
     ):
@@ -567,7 +569,7 @@ class DemoSetup(BaseStep):
         )
         self.answer_file = answer_file
         self.tfhelper = tfhelper
-        self.client = Client()
+        self.client = client
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -600,11 +602,12 @@ class DemoSetup(BaseStep):
 class TerraformDemoInitStep(TerraformInitStep):
     def __init__(
         self,
+        client: Client,
         tfhelper: TerraformHelper,
     ):
         super().__init__(tfhelper)
         self.tfhelper = tfhelper
-        self.client = Client()
+        self.client = client
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -623,16 +626,21 @@ class TerraformDemoInitStep(TerraformInitStep):
 
 class SetLocalHypervisorOptions(BaseStep):
     def __init__(
-        self, name, jhelper, join_mode: bool = False, preseed_file: Path = None
+        self,
+        client: Client,
+        name: str,
+        jhelper: JujuHelper,
+        join_mode: bool = False,
+        preseed_file: Path | None = None,
     ):
         super().__init__(
             "Apply local hypervisor settings", "Applying local hypervisor settings"
         )
+        self.client = client
         self.name = name
         self.jhelper = jhelper
         self.join_mode = join_mode
         self.preseed_file = preseed_file
-        self.client = Client()
         self.preseed_file = preseed_file
 
     def has_prompts(self) -> bool:
@@ -718,13 +726,14 @@ class SetLocalHypervisorOptions(BaseStep):
 
 
 def _configure(
+    client: Client,
     openrc: Optional[Path] = None,
     preseed: Optional[Path] = None,
     accept_defaults: bool = False,
 ):
     preflight_checks = []
     preflight_checks.append(DaemonGroupCheck())
-    preflight_checks.append(VerifyBootstrappedCheck())
+    preflight_checks.append(VerifyBootstrappedCheck(client))
     run_preflight_checks(preflight_checks, console)
 
     name = utils.get_fqdn()
@@ -740,7 +749,7 @@ def _configure(
     shutil.copytree(src, dst, dirs_exist_ok=True)
 
     data_location = snap.paths.user_data
-    jhelper = JujuHelper(data_location)
+    jhelper = JujuHelper(client, data_location)
     try:
         run_sync(jhelper.get_model(OPENSTACK_MODEL))
     except ModelNotFoundException:
@@ -758,28 +767,32 @@ def _configure(
     plan = [
         JujuLoginStep(data_location),
         UserQuestions(
+            client,
             answer_file=answer_file,
             preseed_file=preseed,
             accept_defaults=accept_defaults,
         ),
-        TerraformDemoInitStep(tfhelper),
+        TerraformDemoInitStep(client, tfhelper),
         DemoSetup(
+            client=client,
             tfhelper=tfhelper,
             answer_file=answer_file,
         ),
         UserOpenRCStep(
+            client=client,
             auth_url=admin_credentials["OS_AUTH_URL"],
             auth_version=admin_credentials["OS_AUTH_VERSION"],
             openrc=openrc,
         ),
-        SetHypervisorCharmConfigStep(jhelper, ext_network=answer_file),
+        SetHypervisorCharmConfigStep(client, jhelper, ext_network=answer_file),
     ]
     compute_nodenames = [
-        node["name"] for node in Client().cluster.list_nodes_by_role("compute")
+        node["name"] for node in client.cluster.list_nodes_by_role("compute")
     ]
     if name in compute_nodenames:
         plan.append(
             SetLocalHypervisorOptions(
+                client,
                 name,
                 jhelper,
                 # Accept preseed file but do not allow 'accept_defaults' as nic
@@ -815,7 +828,8 @@ def configure(
     """Configure cloud with some sensible defaults."""
     if ctx.invoked_subcommand is not None:
         return
-    _configure(openrc, preseed, accept_defaults)
+    client: Client = ctx.obj
+    _configure(client, openrc, preseed, accept_defaults)
     for name, command in configure.commands.items():
         LOG.debug("Running configure %r", name)
         cmd_ctx = click.Context(

--- a/sunbeam-python/sunbeam/commands/dashboard_url.py
+++ b/sunbeam-python/sunbeam/commands/dashboard_url.py
@@ -19,6 +19,7 @@ import click
 from rich.console import Console
 from snaphelpers import Snap
 
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.jobs import juju
 from sunbeam.jobs.checks import VerifyBootstrappedCheck
@@ -30,13 +31,15 @@ snap = Snap()
 
 
 @click.command()
-def dashboard_url() -> None:
+@click.pass_context
+def dashboard_url(ctx: click.Context) -> None:
     """Retrieve OpenStack Dashboard URL."""
+    client: Client = ctx.obj
     preflight_checks = []
-    preflight_checks.append(VerifyBootstrappedCheck())
+    preflight_checks.append(VerifyBootstrappedCheck(client))
     run_preflight_checks(preflight_checks, console)
     data_location = snap.paths.user_data
-    jhelper = juju.JujuHelper(data_location)
+    jhelper = juju.JujuHelper(client, data_location)
 
     with console.status("Retrieving dashboard URL from Horizon service ... "):
         # Retrieve config from juju actions

--- a/sunbeam-python/sunbeam/commands/generate_preseed.py
+++ b/sunbeam-python/sunbeam/commands/generate_preseed.py
@@ -66,10 +66,11 @@ def show_questions(
 
 
 @click.command()
-def generate_preseed() -> None:
+@click.pass_context
+def generate_preseed(ctx: click.Context) -> None:
     """Generate preseed file."""
     name = utils.get_fqdn()
-    client = Client()
+    client: Client = ctx.obj
     try:
         variables = sunbeam.jobs.questions.load_answers(client, BOOTSTRAP_CONFIG_KEY)
     except ClusterServiceUnavailableException:

--- a/sunbeam-python/sunbeam/commands/hypervisor.py
+++ b/sunbeam-python/sunbeam/commands/hypervisor.py
@@ -53,6 +53,7 @@ class DeployHypervisorApplicationStep(BaseStep, JujuStepHelper):
 
     def __init__(
         self,
+        client: Client,
         tfhelper: TerraformHelper,
         tfhelper_openstack: TerraformHelper,
         jhelper: JujuHelper,
@@ -64,7 +65,7 @@ class DeployHypervisorApplicationStep(BaseStep, JujuStepHelper):
         self.tfhelper = tfhelper
         self.tfhelper_openstack = tfhelper_openstack
         self.jhelper = jhelper
-        self.client = Client()
+        self.client = client
         self.hypervisor_model = CONTROLLER_MODEL.split("/")[-1]
         self.openstack_model = OPENSTACK_MODEL
 
@@ -132,7 +133,7 @@ class DeployHypervisorApplicationStep(BaseStep, JujuStepHelper):
 
 
 class AddHypervisorUnitStep(BaseStep, JujuStepHelper):
-    def __init__(self, name: str, jhelper: JujuHelper):
+    def __init__(self, client: Client, name: str, jhelper: JujuHelper):
         super().__init__(
             "Add OpenStack Hypervisor unit",
             "Adding OpenStack Hypervisor unit to machine",
@@ -141,7 +142,7 @@ class AddHypervisorUnitStep(BaseStep, JujuStepHelper):
         self.name = name
         self.jhelper = jhelper
         self.machine_id = ""
-        self.client = Client()
+        self.client = client
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -213,7 +214,13 @@ class AddHypervisorUnitStep(BaseStep, JujuStepHelper):
 
 
 class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
-    def __init__(self, name: str, jhelper: JujuHelper, force: bool = False):
+    def __init__(
+        self,
+        client: Client,
+        name: str,
+        jhelper: JujuHelper,
+        force: bool = False,
+    ):
         super().__init__(
             "Remove openstack-hypervisor unit",
             "Remove openstack-hypervisor unit from machine",
@@ -223,7 +230,7 @@ class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
         self.force = force
         self.unit = None
         self.machine_id = ""
-        self.client = Client()
+        self.client = client
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -319,6 +326,7 @@ class ReapplyHypervisorTerraformPlanStep(BaseStep):
 
     def __init__(
         self,
+        client: Client,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
         extra_tfvars: dict = {},
@@ -330,7 +338,7 @@ class ReapplyHypervisorTerraformPlanStep(BaseStep):
         self.tfhelper = tfhelper
         self.jhelper = jhelper
         self.extra_tfvars = extra_tfvars
-        self.client = Client()
+        self.client = client
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.

--- a/sunbeam-python/sunbeam/commands/inspect.py
+++ b/sunbeam-python/sunbeam/commands/inspect.py
@@ -55,9 +55,9 @@ def inspect(ctx: click.Context) -> None:
 
     if ctx.invoked_subcommand is not None:
         return
-
+    client: Client = ctx.obj
     data_location = snap.paths.user_data
-    jhelper = JujuHelper(data_location)
+    jhelper = JujuHelper(client, data_location)
 
     time_stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     file_name = f"sunbeam-inspection-report-{time_stamp}.tar.gz"
@@ -98,9 +98,10 @@ def inspect(ctx: click.Context) -> None:
     default=FORMAT_TABLE,
     help="Output format.",
 )
-def plans(format: str):
+@click.pass_context
+def plans(ctx: click.Context, format: str):
     """List terraform plans and their lock status."""
-    client = Client()
+    client: Client = ctx.obj
     plans = client.cluster.list_terraform_plans()
     locks = client.cluster.list_terraform_locks()
     if format == FORMAT_TABLE:
@@ -128,9 +129,10 @@ def plans(format: str):
     help="Name of the terraform plan to unlock.",
 )
 @click.option("--force", is_flag=True, default=False, help="Force unlock the plan.")
-def unlock_plan(plan: str, force: bool):
+@click.pass_context
+def unlock_plan(ctx: click.Context, plan: str, force: bool):
     """Unlock a terraform plan."""
-    client = Client()
+    client: Client = ctx.obj
     try:
         lock = client.cluster.get_terraform_lock(plan)
     except ConfigItemNotFoundException as e:

--- a/sunbeam-python/sunbeam/commands/launch.py
+++ b/sunbeam-python/sunbeam/commands/launch.py
@@ -25,6 +25,7 @@ import petname
 from rich.console import Console
 from snaphelpers import Snap
 
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.configure import retrieve_admin_credentials
 from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.jobs.juju import JujuHelper, ModelNotFoundException, run_sync
@@ -49,11 +50,18 @@ Creates a new key in ~/snap/openstack/current/ if the key does not exist in Open
 """,
 )
 @click.option("-n", "--name", help="The name for the instance.")
-def launch(image_name: str, key: str, name: Optional[str] = None) -> None:
+@click.pass_context
+def launch(
+    ctx: click.Context,
+    image_name: str,
+    key: str,
+    name: Optional[str] = None,
+) -> None:
     """Launch an OpenStack instance on demo setup"""
 
     data_location = snap.paths.user_data
-    jhelper = JujuHelper(data_location)
+    client: Client = ctx.obj
+    jhelper = JujuHelper(client, data_location)
     with console.status("Fetching user credentials ... "):
         try:
             run_sync(jhelper.get_model(OPENSTACK_MODEL))

--- a/sunbeam-python/sunbeam/commands/microceph.py
+++ b/sunbeam-python/sunbeam/commands/microceph.py
@@ -63,10 +63,12 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
 
     def __init__(
         self,
+        client: Client,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
     ):
         super().__init__(
+            client,
             tfhelper,
             jhelper,
             CONFIG_KEY,
@@ -83,8 +85,9 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
 class AddMicrocephUnitStep(AddMachineUnitStep):
     """Add Microceph Unit."""
 
-    def __init__(self, name: str, jhelper: JujuHelper):
+    def __init__(self, client: Client, name: str, jhelper: JujuHelper):
         super().__init__(
+            client,
             name,
             jhelper,
             CONFIG_KEY,
@@ -101,8 +104,9 @@ class AddMicrocephUnitStep(AddMachineUnitStep):
 class RemoveMicrocephUnitStep(RemoveMachineUnitStep):
     """Remove Microceph Unit."""
 
-    def __init__(self, name: str, jhelper: JujuHelper):
+    def __init__(self, client: Client, name: str, jhelper: JujuHelper):
         super().__init__(
+            client,
             name,
             jhelper,
             CONFIG_KEY,
@@ -123,17 +127,18 @@ class ConfigureMicrocephOSDStep(BaseStep):
 
     def __init__(
         self,
+        client: Client,
         name: str,
         jhelper: JujuHelper,
         preseed_file: Optional[Path] = None,
         accept_defaults: bool = False,
     ):
         super().__init__("Configure MicroCeph storage", "Configuring MicroCeph storage")
+        self.client = client
         self.name = name
         self.jhelper = jhelper
         self.preseed_file = preseed_file
         self.accept_defaults = accept_defaults
-        self.client = Client()
         self.variables = {}
         self.machine_id = ""
         self.disks = ""

--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -25,6 +25,7 @@ from rich.table import Table
 from snaphelpers import Snap
 
 from sunbeam import utils
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.clusterd import (
     ClusterAddJujuUserStep,
     ClusterAddNodeStep,
@@ -108,18 +109,20 @@ def remove_trailing_dot(value: str) -> str:
     default=FORMAT_DEFAULT,
     help="Output format.",
 )
-def add(name: str, format: str) -> None:
+@click.pass_context
+def add(ctx: click.Context, name: str, format: str) -> None:
     """Generate a token for a new node to join the cluster."""
     preflight_checks = [DaemonGroupCheck(), VerifyFQDNCheck(name)]
     run_preflight_checks(preflight_checks, console)
 
     name = remove_trailing_dot(name)
     data_location = snap.paths.user_data
-    jhelper = JujuHelper(data_location)
+    client: Client = ctx.obj
+    jhelper = JujuHelper(client, data_location)
 
     plan1 = [
         JujuLoginStep(data_location),
-        ClusterAddNodeStep(name),
+        ClusterAddNodeStep(client, name),
         CreateJujuUserStep(name),
         JujuGrantModelAccessStep(jhelper, name, OPENSTACK_MODEL),
     ]
@@ -128,7 +131,7 @@ def add(name: str, format: str) -> None:
 
     user_token = get_step_message(plan1_results, CreateJujuUserStep)
 
-    plan2 = [ClusterAddJujuUserStep(name, user_token)]
+    plan2 = [ClusterAddJujuUserStep(client, name, user_token)]
     run_plan(plan2, console)
 
     def _print_output(token):
@@ -168,7 +171,9 @@ def add(name: str, format: str) -> None:
     callback=validate_roles,
     help="Specify which roles the node will be assigned in the cluster.",
 )
+@click.pass_context
 def join(
+    ctx: click.Context,
     token: str,
     roles: List[Role],
     preseed: Optional[Path] = None,
@@ -206,6 +211,7 @@ def join(
 
     controller = CONTROLLER
     data_location = snap.paths.user_data
+    client: Client = ctx.obj
 
     # NOTE: install to user writable location
     tfplan_dirs = ["deploy-sunbeam-machine"]
@@ -231,13 +237,13 @@ def join(
         backend="http",
         data_location=data_location,
     )
-    jhelper = JujuHelper(data_location)
+    jhelper = JujuHelper(client, data_location)
 
     plan1 = [
         JujuLoginStep(data_location),
-        ClusterJoinNodeStep(token, roles_str),
+        ClusterJoinNodeStep(client, token, roles_str),
         SaveJujuUserLocallyStep(name, data_location),
-        RegisterJujuUserStep(name, controller, data_location),
+        RegisterJujuUserStep(client, name, controller, data_location),
         AddJujuMachineStep(ip),
     ]
     plan1_results = run_plan(plan1, console)
@@ -247,21 +253,25 @@ def join(
     if machine_id_result is not None:
         machine_id = int(machine_id_result)
 
-    jhelper = JujuHelper(data_location)
+    jhelper = JujuHelper(client, data_location)
     plan2 = []
-    plan2.append(ClusterUpdateNodeStep(name, machine_id=machine_id))
+    plan2.append(ClusterUpdateNodeStep(client, name, machine_id=machine_id))
     plan2.append(
-        AddSunbeamMachineUnitStep(name, jhelper),
+        AddSunbeamMachineUnitStep(client, name, jhelper),
     )
 
     if is_control_node:
-        plan2.append(AddMicrok8sUnitStep(name, jhelper))
+        plan2.append(AddMicrok8sUnitStep(client, name, jhelper))
 
     if is_storage_node:
-        plan2.append(AddMicrocephUnitStep(name, jhelper))
+        plan2.append(AddMicrocephUnitStep(client, name, jhelper))
         plan2.append(
             ConfigureMicrocephOSDStep(
-                name, jhelper, accept_defaults=accept_defaults, preseed_file=preseed
+                client,
+                name,
+                jhelper,
+                accept_defaults=accept_defaults,
+                preseed_file=preseed,
             )
         )
 
@@ -270,11 +280,14 @@ def join(
             [
                 TerraformInitStep(tfhelper_hypervisor_deploy),
                 DeployHypervisorApplicationStep(
-                    tfhelper_hypervisor_deploy, tfhelper_openstack_deploy, jhelper
+                    client,
+                    tfhelper_hypervisor_deploy,
+                    tfhelper_openstack_deploy,
+                    jhelper,
                 ),
-                AddHypervisorUnitStep(name, jhelper),
+                AddHypervisorUnitStep(client, name, jhelper),
                 SetLocalHypervisorOptions(
-                    name, jhelper, join_mode=True, preseed_file=preseed
+                    client, name, jhelper, join_mode=True, preseed_file=preseed
                 ),
             ]
         )
@@ -292,12 +305,13 @@ def join(
     default=FORMAT_TABLE,
     help="Output format.",
 )
-def list(format: str) -> None:
+@click.pass_context
+def list(ctx: click.Context, format: str) -> None:
     """List nodes in the cluster."""
     preflight_checks = [DaemonGroupCheck()]
     run_preflight_checks(preflight_checks, console)
-
-    plan = [ClusterListNodeStep()]
+    client: Client = ctx.obj
+    plan = [ClusterListNodeStep(client)]
     results = run_plan(plan, console)
 
     list_node_step_result = results.get("ClusterListNodeStep")
@@ -333,24 +347,26 @@ def list(format: str) -> None:
     is_flag=True,
 )
 @click.option("--name", type=str, prompt=True, help="Fully qualified node name")
-def remove(name: str, force: bool) -> None:
+@click.pass_context
+def remove(ctx: click.Context, name: str, force: bool) -> None:
     """Remove a node from the cluster."""
     data_location = snap.paths.user_data
-    jhelper = JujuHelper(data_location)
+    client: Client = ctx.obj
+    jhelper = JujuHelper(client, data_location)
 
     preflight_checks = [DaemonGroupCheck()]
     run_preflight_checks(preflight_checks, console)
 
     plan = [
-        RemoveSunbeamMachineStep(name, jhelper),
-        RemoveMicrok8sUnitStep(name, jhelper),
-        RemoveMicrocephUnitStep(name, jhelper),
-        RemoveHypervisorUnitStep(name, jhelper, force),
-        RemoveJujuMachineStep(name),
+        RemoveSunbeamMachineStep(client, name, jhelper),
+        RemoveMicrok8sUnitStep(client, name, jhelper),
+        RemoveMicrocephUnitStep(client, name, jhelper),
+        RemoveHypervisorUnitStep(client, name, jhelper, force),
+        RemoveJujuMachineStep(client, name),
         # Cannot remove user as the same user name cannot be resued,
         # so commenting the RemoveJujuUserStep
         # RemoveJujuUserStep(name),
-        ClusterRemoveNodeStep(name),
+        ClusterRemoveNodeStep(client, name),
     ]
     run_plan(plan, console)
     click.echo(f"Removed node {name} from the cluster")

--- a/sunbeam-python/sunbeam/commands/openrc.py
+++ b/sunbeam-python/sunbeam/commands/openrc.py
@@ -19,6 +19,7 @@ import click
 from rich.console import Console
 from snaphelpers import Snap
 
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.jobs import juju
 from sunbeam.jobs.checks import DaemonGroupCheck, VerifyBootstrappedCheck
@@ -30,15 +31,17 @@ snap = Snap()
 
 
 @click.command()
-def openrc() -> None:
+@click.pass_context
+def openrc(ctx: click.Context) -> None:
     """Retrieve openrc for cloud admin account."""
+    client: Client = ctx.obj
     preflight_checks = []
     preflight_checks.append(DaemonGroupCheck())
-    preflight_checks.append(VerifyBootstrappedCheck())
+    preflight_checks.append(VerifyBootstrappedCheck(client))
     run_preflight_checks(preflight_checks, console)
 
     data_location = snap.paths.user_data
-    jhelper = juju.JujuHelper(data_location)
+    jhelper = juju.JujuHelper(client, data_location)
 
     with console.status("Retrieving openrc from Keystone service ... "):
         # Retrieve config from juju actions

--- a/sunbeam-python/sunbeam/commands/sunbeam_machine.py
+++ b/sunbeam-python/sunbeam/commands/sunbeam_machine.py
@@ -15,6 +15,7 @@
 
 import logging
 
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.terraform import TerraformHelper
 from sunbeam.jobs.juju import MODEL, JujuHelper
 from sunbeam.jobs.steps import (
@@ -37,10 +38,12 @@ class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
 
     def __init__(
         self,
+        client: Client,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
     ):
         super().__init__(
+            client,
             tfhelper,
             jhelper,
             CONFIG_KEY,
@@ -60,8 +63,9 @@ class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
 class AddSunbeamMachineUnitStep(AddMachineUnitStep):
     """Add Sunbeam machine Unit."""
 
-    def __init__(self, name: str, jhelper: JujuHelper):
+    def __init__(self, client: Client, name: str, jhelper: JujuHelper):
         super().__init__(
+            client,
             name,
             jhelper,
             CONFIG_KEY,
@@ -78,8 +82,9 @@ class AddSunbeamMachineUnitStep(AddMachineUnitStep):
 class RemoveSunbeamMachineStep(RemoveMachineUnitStep):
     """Remove Sunbeam machine Unit."""
 
-    def __init__(self, name: str, jhelper: JujuHelper):
+    def __init__(self, client: Client, name: str, jhelper: JujuHelper):
         super().__init__(
+            client,
             name,
             jhelper,
             CONFIG_KEY,

--- a/sunbeam-python/sunbeam/commands/terraform.py
+++ b/sunbeam-python/sunbeam/commands/terraform.py
@@ -26,7 +26,7 @@ from rich.status import Status
 from snaphelpers import Snap
 
 from sunbeam import utils
-from sunbeam.clusterd.client import Client as clusterClient
+from sunbeam.clusterd.client import Client
 from sunbeam.jobs.common import BaseStep, Result, ResultType
 from sunbeam.jobs.juju import JujuAccount, JujuController
 
@@ -134,9 +134,9 @@ class TerraformHelper:
         os_env = {}
         if self.data_location:
             LOG.debug("Updating terraform env variables related to juju credentials")
-            client = clusterClient()
             account = JujuAccount.load(self.data_location)
-            controller = JujuController.load(client)
+            # TODO(gboutry): refactor when Manifest support lands
+            controller = JujuController.load(Client.from_socket())
             os_env.update(
                 JUJU_USERNAME=account.user,
                 JUJU_PASSWORD=account.password,

--- a/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
@@ -90,5 +90,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
     def get_plan(self) -> list[BaseStep]:
         return [
             LatestInChannel(self.jhelper),
-            UpgradePlugins(self.jhelper, self.tfhelper, upgrade_release=False),
+            UpgradePlugins(
+                self.client, self.jhelper, self.tfhelper, upgrade_release=False
+            ),
         ]

--- a/sunbeam-python/sunbeam/commands/utils.py
+++ b/sunbeam-python/sunbeam/commands/utils.py
@@ -19,6 +19,7 @@ import click
 from rich.console import Console
 from snaphelpers import Snap
 
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.juju import JujuLoginStep
 from sunbeam.jobs.checks import VerifyBootstrappedCheck
 from sunbeam.jobs.common import run_plan, run_preflight_checks
@@ -29,9 +30,11 @@ snap = Snap()
 
 
 @click.command()
-def juju_login() -> None:
+@click.pass_context
+def juju_login(ctx: click.Context) -> None:
     """Login to the controller with current host user."""
-    preflight_checks = [VerifyBootstrappedCheck()]
+    client: Client = ctx.obj
+    preflight_checks = [VerifyBootstrappedCheck(client)]
     run_preflight_checks(preflight_checks, console)
 
     data_location = snap.paths.user_data

--- a/sunbeam-python/sunbeam/jobs/checks.py
+++ b/sunbeam-python/sunbeam/jobs/checks.py
@@ -270,12 +270,12 @@ class SystemRequirementsCheck(Check):
 class VerifyBootstrappedCheck(Check):
     """Check deployment has been bootstrapped."""
 
-    def __init__(self):
+    def __init__(self, client: Client):
         super().__init__(
             "Check bootstrapped",
             "Checking the deployment has been bootstrapped",
         )
-        self.client = Client()
+        self.client = client
 
     def run(self) -> bool:
         bootstrapped = self.client.cluster.check_sunbeam_bootstrapped()

--- a/sunbeam-python/sunbeam/jobs/plugin.py
+++ b/sunbeam-python/sunbeam/jobs/plugin.py
@@ -130,7 +130,7 @@ class PluginManager:
         return plugins
 
     @classmethod
-    def get_all_external_repos(cls, detail: bool = False) -> list:
+    def get_all_external_repos(cls, client: Client, detail: bool = False) -> list:
         """Return all external repos stored in DB.
 
         Returns just names by default, the format will be
@@ -147,7 +147,6 @@ class PluginManager:
         :returns: List of repos.
         """
         try:
-            client = Client()
             config = read_config(client, EXTERNAL_REPO_PLUGIN_KEY)
             if detail:
                 return config.get("repos", [])
@@ -211,7 +210,7 @@ class PluginManager:
         return plugins
 
     @classmethod
-    def enabled_plugins(cls, repos: Optional[list] = []) -> list:
+    def enabled_plugins(cls, client: Client, repos: Optional[list] = []) -> list:
         """Returns plugin names that are enabled.
 
         Get all plugins from the list of repos and return plugins that have enabled
@@ -246,7 +245,7 @@ class PluginManager:
                 continue
 
             for plugin in cls.get_plugin_classes(plugin_file):
-                p = plugin()
+                p = plugin(client)
                 if hasattr(plugin, "enabled") and p.enabled:
                     enabled_plugins.append(p.name)
 
@@ -254,7 +253,11 @@ class PluginManager:
         return enabled_plugins
 
     @classmethod
-    def register(cls, cli: click.Group) -> None:
+    def register(
+        cls,
+        client: Client,
+        cli: click.Group,
+    ) -> None:
         """Register the plugins.
 
         Register both the core plugins in snap-openstack repo and the plugins
@@ -263,13 +266,14 @@ class PluginManager:
         sunbeam cli.
 
         :param cli: Main click group for sunbeam cli.
+        :param client: Clusterd client object.
         """
         LOG.debug("Registering core plugins")
         core_plugin_file = cls.get_core_plugins_path() / PLUGIN_YAML
         for plugin in cls.get_plugin_classes(core_plugin_file):
-            plugin().register(cli)
+            plugin(client).register(cli)
 
-        repos = cls.get_all_external_repos()
+        repos = cls.get_all_external_repos(client)
         LOG.debug(f"Registering external repo plugins {repos}")
         for repo in repos:
             plugin_file = cls.get_external_plugins_base_path() / repo / PLUGIN_YAML
@@ -282,7 +286,7 @@ class PluginManager:
                 continue
 
             for plugin in cls.get_plugin_classes(plugin_file):
-                plugin().register(cli)
+                plugin(client).register(cli)
 
     @classmethod
     def resolve_plugin(cls, repo: str, plugin: str) -> Optional[type]:
@@ -317,7 +321,7 @@ class PluginManager:
 
     @classmethod
     def update_plugins(
-        cls, repos: Optional[list] = [], upgrade_release: bool = False
+        cls, client: Client, repos: Optional[list] = [], upgrade_release: bool = False
     ) -> None:
         """Call plugin upgrade hooks.
 
@@ -345,7 +349,7 @@ class PluginManager:
                 continue
 
             for plugin in cls.get_plugin_classes(plugin_file):
-                p = plugin()
+                p = plugin(client)
                 LOG.debug(f"Object created {p.name}")
                 if hasattr(plugin, "enabled"):
                     LOG.debug(f"enabled - {p.enabled}")

--- a/sunbeam-python/sunbeam/jobs/steps.py
+++ b/sunbeam-python/sunbeam/jobs/steps.py
@@ -40,6 +40,7 @@ class DeployMachineApplicationStep(BaseStep):
 
     def __init__(
         self,
+        client: Client,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
         config: str,
@@ -49,12 +50,12 @@ class DeployMachineApplicationStep(BaseStep):
         description: str = "",
     ):
         super().__init__(banner, description)
+        self.client = client
         self.tfhelper = tfhelper
         self.jhelper = jhelper
         self.config = config
         self.application = application
         self.model = model
-        self.client = Client()
 
     def extra_tfvars(self) -> dict:
         return {}
@@ -122,6 +123,7 @@ class AddMachineUnitStep(BaseStep):
 
     def __init__(
         self,
+        client: Client,
         name: str,
         jhelper: JujuHelper,
         config: str,
@@ -131,12 +133,12 @@ class AddMachineUnitStep(BaseStep):
         description: str = "",
     ):
         super().__init__(banner, description)
+        self.client = client
         self.name = name
         self.jhelper = jhelper
         self.config = config
         self.application = application
         self.model = model
-        self.client = Client()
         self.machine_id = ""
 
     def get_unit_timeout(self) -> int:
@@ -220,6 +222,7 @@ class RemoveMachineUnitStep(BaseStep):
 
     def __init__(
         self,
+        client: Client,
         name: str,
         jhelper: JujuHelper,
         config: str,
@@ -229,12 +232,12 @@ class RemoveMachineUnitStep(BaseStep):
         description: str = "",
     ):
         super().__init__(banner, description)
+        self.client = client
         self.name = name
         self.jhelper = jhelper
         self.config = config
         self.application = application
         self.model = model
-        self.client = Client()
         self.machine_id = ""
         self.unit = None
 

--- a/sunbeam-python/sunbeam/main.py
+++ b/sunbeam-python/sunbeam/main.py
@@ -19,6 +19,7 @@ import click
 from snaphelpers import Snap
 
 from sunbeam import log
+from sunbeam.clusterd.client import Client
 from sunbeam.commands import bootstrap as bootstrap_cmds
 from sunbeam.commands import configure as configure_cmds
 from sunbeam.commands import dashboard_url as dasboard_url_cmds
@@ -111,10 +112,11 @@ def main():
     cli.add_command(utils)
     utils.add_command(utils_cmds.juju_login)
 
+    client = Client.from_socket()
     # Register the plugins after all groups,commands are registered
-    PluginManager.register(cli)
+    PluginManager.register(client, cli)
 
-    cli()
+    cli(obj=client)
 
 
 if __name__ == "__main__":

--- a/sunbeam-python/sunbeam/plugins/caas/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/caas/plugin.py
@@ -23,10 +23,8 @@ from packaging.version import Version
 from rich.console import Console
 from rich.status import Status
 
-from sunbeam.clusterd.service import (
-    ClusterServiceUnavailableException,
-    ConfigItemNotFoundException,
-)
+from sunbeam.clusterd.client import Client
+from sunbeam.clusterd.service import ClusterServiceUnavailableException
 from sunbeam.commands.configure import retrieve_admin_credentials
 from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.commands.terraform import (
@@ -34,15 +32,13 @@ from sunbeam.commands.terraform import (
     TerraformHelper,
     TerraformInitStep,
 )
-from sunbeam.jobs.common import BaseStep, Result, ResultType, read_config, run_plan
+from sunbeam.jobs.common import BaseStep, Result, ResultType, run_plan
 from sunbeam.jobs.juju import JujuHelper
 from sunbeam.plugins.interface.v1.base import PluginRequirement
 from sunbeam.plugins.interface.v1.openstack import (
     OpenStackControlPlanePlugin,
     TerraformPlanLocation,
 )
-from sunbeam.plugins.orchestration.plugin import OrchestrationPlugin
-from sunbeam.plugins.secrets.plugin import SecretsPlugin
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -80,9 +76,10 @@ class CaasPlugin(OpenStackControlPlanePlugin):
         PluginRequirement("loadbalancer", optional=True),
     }
 
-    def __init__(self) -> None:
+    def __init__(self, client: Client) -> None:
         super().__init__(
-            name="caas",
+            "caas",
+            client,
             tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO,
         )
         self.configure_plan = "caas-setup"
@@ -114,32 +111,6 @@ class CaasPlugin(OpenStackControlPlanePlugin):
         """Set terraform variables to resize the application."""
         return {}
 
-    def pre_enable(self) -> None:
-        """Check required plugins are enabled."""
-        super().pre_enable()
-        # TODO(gboutry): Remove this when plugin dependency is implemented
-        try:
-            secrets_info = read_config(self.client, SecretsPlugin().plugin_key)
-            enabled = secrets_info.get("enabled", False)
-            if enabled == "false":
-                raise ValueError("Secrets plugin is not enabled")
-        except (ConfigItemNotFoundException, ValueError) as e:
-            raise click.ClickException(
-                "OpenStack CaaS plugin requires Secrets plugin to be enabled"
-            ) from e
-        try:
-            orchestration_info = read_config(
-                self.client, OrchestrationPlugin().plugin_key
-            )
-            enabled = orchestration_info.get("enabled", False)
-            if enabled == "false":
-                raise ValueError("Orchestration plugin is not enabled")
-        except (ConfigItemNotFoundException, ValueError) as e:
-            raise click.ClickException(
-                "OpenStack Container as a Service plugin requires Orchestration"
-                " plugin to be enabled"
-            ) from e
-
     @click.command()
     def enable_plugin(self) -> None:
         """Enable Container as a Service plugin."""
@@ -159,7 +130,7 @@ class CaasPlugin(OpenStackControlPlanePlugin):
         shutil.copytree(src, dst, dirs_exist_ok=True)
 
         data_location = self.snap.paths.user_data
-        jhelper = JujuHelper(data_location)
+        jhelper = JujuHelper(self.client, data_location)
         admin_credentials = retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)
         tfhelper = TerraformHelper(
             path=self.snap.paths.user_common / "etc" / self.configure_plan,

--- a/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
@@ -18,6 +18,7 @@ import logging
 import click
 from packaging.version import Version
 
+from sunbeam.clusterd.client import Client
 from sunbeam.plugins.interface.v1.openstack import (
     OpenStackControlPlanePlugin,
     TerraformPlanLocation,
@@ -29,9 +30,10 @@ LOG = logging.getLogger(__name__)
 class LoadbalancerPlugin(OpenStackControlPlanePlugin):
     version = Version("0.0.1")
 
-    def __init__(self) -> None:
+    def __init__(self, client: Client) -> None:
         super().__init__(
-            name="loadbalancer",
+            "loadbalancer",
+            client,
             tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO,
         )
 

--- a/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
@@ -18,6 +18,7 @@ import logging
 import click
 from packaging.version import Version
 
+from sunbeam.clusterd.client import Client
 from sunbeam.plugins.interface.v1.openstack import (
     OpenStackControlPlanePlugin,
     TerraformPlanLocation,
@@ -29,9 +30,10 @@ LOG = logging.getLogger(__name__)
 class OrchestrationPlugin(OpenStackControlPlanePlugin):
     version = Version("0.0.1")
 
-    def __init__(self) -> None:
+    def __init__(self, client: Client) -> None:
         super().__init__(
-            name="orchestration",
+            "orchestration",
+            client,
             tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO,
         )
 

--- a/sunbeam-python/sunbeam/plugins/pro/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/pro/plugin.py
@@ -26,6 +26,7 @@ from rich.console import Console
 from rich.status import Status
 from snaphelpers import Snap
 
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.juju import JujuStepHelper
 from sunbeam.commands.terraform import (
     TerraformException,
@@ -147,8 +148,8 @@ class DisableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
 class ProPlugin(EnableDisablePlugin):
     version = Version("0.0.1")
 
-    def __init__(self) -> None:
-        super().__init__(name="pro")
+    def __init__(self, client: Client) -> None:
+        super().__init__("pro", client)
         self.token = None
         self.snap = Snap()
         self.tfplan = f"deploy-{self.name}"
@@ -167,7 +168,7 @@ class ProPlugin(EnableDisablePlugin):
             backend="http",
             data_location=data_location,
         )
-        jhelper = JujuHelper(data_location)
+        jhelper = JujuHelper(self.client, data_location)
         plan = [
             TerraformInitStep(tfhelper),
             EnableUbuntuProApplicationStep(tfhelper, jhelper, self.token),

--- a/sunbeam-python/sunbeam/plugins/secrets/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/secrets/plugin.py
@@ -16,14 +16,12 @@
 import click
 from packaging.version import Version
 
-from sunbeam.clusterd.service import ConfigItemNotFoundException
-from sunbeam.jobs.common import read_config
+from sunbeam.clusterd.client import Client
 from sunbeam.plugins.interface.v1.base import PluginRequirement
 from sunbeam.plugins.interface.v1.openstack import (
     OpenStackControlPlanePlugin,
     TerraformPlanLocation,
 )
-from sunbeam.plugins.vault.plugin import VaultPlugin
 
 
 class SecretsPlugin(OpenStackControlPlanePlugin):
@@ -31,9 +29,10 @@ class SecretsPlugin(OpenStackControlPlanePlugin):
 
     requires = {PluginRequirement("vault")}
 
-    def __init__(self) -> None:
+    def __init__(self, client: Client) -> None:
         super().__init__(
-            name="secrets",
+            "secrets",
+            client,
             tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO,
         )
 
@@ -59,20 +58,6 @@ class SecretsPlugin(OpenStackControlPlanePlugin):
     def set_tfvars_on_resize(self) -> dict:
         """Set terraform variables to resize the application."""
         return {}
-
-    def pre_enable(self) -> None:
-        """Check Vault is deployed"""
-        super().pre_enable()
-        # TODO(gboutry): Remove this when plugin dependency is implemented
-        try:
-            vault_info = read_config(self.client, VaultPlugin().plugin_key)
-            enabled = vault_info.get("enabled", False)
-            if enabled == "false":
-                raise ValueError("Vault plugin is not enabled")
-        except (ConfigItemNotFoundException, ValueError) as e:
-            raise click.ClickException(
-                "OpenStack Secrets plugin requires Vault plugin to be enabled"
-            ) from e
 
     @click.command()
     def enable_plugin(self) -> None:

--- a/sunbeam-python/sunbeam/plugins/vault/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/vault/plugin.py
@@ -24,6 +24,7 @@ import logging
 import click
 from packaging.version import Version
 
+from sunbeam.clusterd.client import Client
 from sunbeam.plugins.interface.v1.openstack import (
     OpenStackControlPlanePlugin,
     TerraformPlanLocation,
@@ -35,9 +36,10 @@ LOG = logging.getLogger(__name__)
 class VaultPlugin(OpenStackControlPlanePlugin):
     version = Version("0.0.1")
 
-    def __init__(self) -> None:
+    def __init__(self, client: Client) -> None:
         super().__init__(
-            name="vault",
+            "vault",
+            client,
             tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO,
         )
 

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_generate_cloud_config.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_generate_cloud_config.py
@@ -40,8 +40,7 @@ def mock_run_sync(mocker):
 
 @pytest.fixture()
 def cclient():
-    with patch("sunbeam.commands.generate_cloud_config.Client") as p:
-        yield p
+    yield Mock()
 
 
 @pytest.fixture()
@@ -62,7 +61,7 @@ class TestConfigureCloudsYamlStep:
         load_answers.return_value = {"user": {"run_demo_setup": True}}
         admin_credentials = {"OS_AUTH_URL": "http://keystone:5000"}
         step = generate.GenerateCloudConfigStep(
-            admin_credentials, "sunbeam", False, True, clouds_yaml
+            cclient, admin_credentials, "sunbeam", False, True, clouds_yaml
         )
         result = step.is_skip()
         assert result.result_type == ResultType.COMPLETED
@@ -72,7 +71,7 @@ class TestConfigureCloudsYamlStep:
         load_answers.return_value = {"user": {"run_demo_setup": False}}
         admin_credentials = {"OS_AUTH_URL": "http://keystone:5000"}
         step = generate.GenerateCloudConfigStep(
-            admin_credentials, "sunbeam", False, True, clouds_yaml
+            cclient, admin_credentials, "sunbeam", False, True, clouds_yaml
         )
         result = step.is_skip()
         assert result.result_type == ResultType.SKIPPED
@@ -81,7 +80,7 @@ class TestConfigureCloudsYamlStep:
         clouds_yaml = tmp_path / ".config" / "openstack" / "clouds.yaml"
         admin_credentials = {"OS_AUTH_URL": "http://keystone:5000"}
         step = generate.GenerateCloudConfigStep(
-            admin_credentials, "sunbeam", True, True, clouds_yaml
+            cclient, admin_credentials, "sunbeam", True, True, clouds_yaml
         )
         result = step.is_skip()
         assert result.result_type == ResultType.COMPLETED
@@ -106,7 +105,7 @@ class TestConfigureCloudsYamlStep:
         run.return_value = runout_mock
         admin_credentials = {"OS_AUTH_URL": "http://keystone:5000"}
         step = generate.GenerateCloudConfigStep(
-            admin_credentials, "sunbeam", False, True, clouds_yaml
+            cclient, admin_credentials, "sunbeam", False, True, clouds_yaml
         )
         step.run()
 
@@ -141,7 +140,7 @@ class TestConfigureCloudsYamlStep:
             "OS_PROJECT_NAME": "projectname",
         }
         step = generate.GenerateCloudConfigStep(
-            admin_credentials, "sunbeam", True, True, clouds_yaml
+            cclient, admin_credentials, "sunbeam", True, True, clouds_yaml
         )
         step.run()
 
@@ -177,7 +176,7 @@ class TestConfigureCloudsYamlStep:
         run.return_value = runout_mock
         admin_credentials = {"OS_AUTH_URL": "http://keystone:5000"}
         step = generate.GenerateCloudConfigStep(
-            admin_credentials, "sunbeam", False, False, None
+            cclient, admin_credentials, "sunbeam", False, False, None
         )
         step.run()
 

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_microceph.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_microceph.py
@@ -14,7 +14,7 @@
 
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -41,29 +41,21 @@ def mock_run_sync(mocker):
 class TestConfigureMicrocephOSDStep(unittest.TestCase):
     def __init__(self, methodName: str = "runTest") -> None:
         super().__init__(methodName)
-        self.clientMock = Mock()
-        self.client = patch(
-            "sunbeam.commands.microceph.Client", return_value=self.clientMock
-        )
 
     def setUp(self):
-        self.client.start()
+        self.client = Mock()
         self.jhelper = AsyncMock()
         self.name = "test-0"
 
-    def tearDown(self):
-        self.client.stop()
-        self.clientMock.reset_mock()
-
     def test_is_skip(self):
-        step = ConfigureMicrocephOSDStep(self.name, self.jhelper)
+        step = ConfigureMicrocephOSDStep(self.client, self.name, self.jhelper)
         step.disks = "/dev/sdb,/dev/sdc"
         result = step.is_skip()
 
         assert result.result_type == ResultType.COMPLETED
 
     def test_run(self):
-        step = ConfigureMicrocephOSDStep(self.name, self.jhelper)
+        step = ConfigureMicrocephOSDStep(self.client, self.name, self.jhelper)
         step.disks = "/dev/sdb,/dev/sdc"
         result = step.run()
 
@@ -73,7 +65,7 @@ class TestConfigureMicrocephOSDStep(unittest.TestCase):
     def test_run_action_failed(self):
         self.jhelper.run_action.side_effect = ActionFailedException("Action failed...")
 
-        step = ConfigureMicrocephOSDStep(self.name, self.jhelper)
+        step = ConfigureMicrocephOSDStep(self.client, self.name, self.jhelper)
         step.disks = "/dev/sdb,/dev/sdc"
         result = step.run()
 

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
@@ -64,14 +64,16 @@ class TestDeployControlPlaneStep(unittest.TestCase):
     def setUp(self):
         self.jhelper = AsyncMock()
         self.tfhelper = Mock(path=Path())
+        self.client = Mock()
 
-    @patch("sunbeam.commands.openstack.Client")
-    def test_run_pristine_installation(self, client):
+    def test_run_pristine_installation(self):
         self.jhelper.get_application.side_effect = ApplicationNotFoundException(
             "not found"
         )
 
-        step = DeployControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, DATABASE)
+        step = DeployControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, DATABASE
+        )
         with patch(
             "sunbeam.commands.openstack.read_config",
             Mock(return_value={}),
@@ -82,11 +84,12 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         self.tfhelper.apply.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
-    @patch("sunbeam.commands.openstack.Client")
-    def test_run_tf_apply_failed(self, client):
+    def test_run_tf_apply_failed(self):
         self.tfhelper.apply.side_effect = TerraformException("apply failed...")
 
-        step = DeployControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, DATABASE)
+        step = DeployControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, DATABASE
+        )
         with patch(
             "sunbeam.commands.openstack.read_config",
             Mock(return_value={}),
@@ -97,11 +100,12 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         assert result.result_type == ResultType.FAILED
         assert result.message == "apply failed..."
 
-    @patch("sunbeam.commands.openstack.Client")
-    def test_run_waiting_timed_out(self, client):
+    def test_run_waiting_timed_out(self):
         self.jhelper.wait_until_active.side_effect = TimeoutException("timed out")
 
-        step = DeployControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, DATABASE)
+        step = DeployControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, DATABASE
+        )
         with patch(
             "sunbeam.commands.openstack.read_config",
             Mock(return_value={}),
@@ -112,13 +116,14 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
 
-    @patch("sunbeam.commands.openstack.Client")
-    def test_run_unit_in_error_state(self, client):
+    def test_run_unit_in_error_state(self):
         self.jhelper.wait_until_active.side_effect = JujuWaitException(
             "Unit in error: placement/0"
         )
 
-        step = DeployControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, DATABASE)
+        step = DeployControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, DATABASE
+        )
         with patch(
             "sunbeam.commands.openstack.read_config",
             Mock(return_value={}),
@@ -129,9 +134,10 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         assert result.result_type == ResultType.FAILED
         assert result.message == "Unit in error: placement/0"
 
-    @patch("sunbeam.commands.openstack.Client")
-    def test_is_skip_pristine(self, client):
-        step = DeployControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, DATABASE)
+    def test_is_skip_pristine(self):
+        step = DeployControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, DATABASE
+        )
         with patch(
             "sunbeam.commands.openstack.read_config",
             Mock(side_effect=ConfigItemNotFoundException("not found")),
@@ -140,9 +146,10 @@ class TestDeployControlPlaneStep(unittest.TestCase):
 
         assert result.result_type == ResultType.COMPLETED
 
-    @patch("sunbeam.commands.openstack.Client")
-    def test_is_skip_subsequent_run(self, client):
-        step = DeployControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, DATABASE)
+    def test_is_skip_subsequent_run(self):
+        step = DeployControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, DATABASE
+        )
         with patch(
             "sunbeam.commands.openstack.read_config",
             Mock(return_value={"topology": "single", "database": "single"}),
@@ -151,9 +158,10 @@ class TestDeployControlPlaneStep(unittest.TestCase):
 
         assert result.result_type == ResultType.COMPLETED
 
-    @patch("sunbeam.commands.openstack.Client")
-    def test_is_skip_database_changed(self, client):
-        step = DeployControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, DATABASE)
+    def test_is_skip_database_changed(self):
+        step = DeployControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, DATABASE
+        )
         with patch(
             "sunbeam.commands.openstack.read_config",
             Mock(return_value={"topology": "single", "database": "multi"}),
@@ -166,20 +174,20 @@ class TestDeployControlPlaneStep(unittest.TestCase):
 class TestResizeControlPlaneStep(unittest.TestCase):
     def __init__(self, methodName: str = "runTest") -> None:
         super().__init__(methodName)
-        self.client = patch("sunbeam.commands.openstack.Client")
         self.read_config = patch(
             "sunbeam.commands.openstack.read_config",
             Mock(return_value={"topology": "single", "database": "single"}),
         )
 
     def setUp(self):
-        self.client.start()
+        self.client = Mock(
+            cluster=Mock(list_nodes_by_role=Mock(return_value=[1, 2, 3, 4]))
+        )
         self.read_config.start()
         self.jhelper = AsyncMock()
         self.tfhelper = Mock(path=Path())
 
     def tearDown(self):
-        self.client.stop()
         self.read_config.stop()
 
     def test_run_pristine_installation(self):
@@ -187,7 +195,9 @@ class TestResizeControlPlaneStep(unittest.TestCase):
             "not found"
         )
 
-        step = ResizeControlPlaneStep(self.tfhelper, self.jhelper, "single", False)
+        step = ResizeControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, "single", False
+        )
         result = step.run()
 
         self.tfhelper.write_tfvars.assert_called_once()
@@ -197,7 +207,9 @@ class TestResizeControlPlaneStep(unittest.TestCase):
     def test_run_tf_apply_failed(self):
         self.tfhelper.apply.side_effect = TerraformException("apply failed...")
 
-        step = ResizeControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, False)
+        step = ResizeControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, False
+        )
         result = step.run()
 
         self.tfhelper.apply.assert_called_once()
@@ -207,7 +219,9 @@ class TestResizeControlPlaneStep(unittest.TestCase):
     def test_run_waiting_timed_out(self):
         self.jhelper.wait_until_active.side_effect = TimeoutException("timed out")
 
-        step = ResizeControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, False)
+        step = ResizeControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, False
+        )
         result = step.run()
 
         self.jhelper.wait_until_active.assert_called_once()
@@ -219,7 +233,9 @@ class TestResizeControlPlaneStep(unittest.TestCase):
             "Unit in error: placement/0"
         )
 
-        step = ResizeControlPlaneStep(self.tfhelper, self.jhelper, TOPOLOGY, False)
+        step = ResizeControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, TOPOLOGY, False
+        )
         result = step.run()
 
         self.jhelper.wait_until_active.assert_called_once()
@@ -227,14 +243,18 @@ class TestResizeControlPlaneStep(unittest.TestCase):
         assert result.message == "Unit in error: placement/0"
 
     def test_run_incompatible_topology(self):
-        step = ResizeControlPlaneStep(self.tfhelper, self.jhelper, "large", False)
+        step = ResizeControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, "large", False
+        )
         result = step.run()
 
         assert result.result_type == ResultType.FAILED
         assert "Cannot resize control plane to large" in result.message
 
     def test_run_force_incompatible_topology(self):
-        step = ResizeControlPlaneStep(self.tfhelper, self.jhelper, "large", True)
+        step = ResizeControlPlaneStep(
+            self.client, self.tfhelper, self.jhelper, "large", True
+        )
         result = step.run()
 
         self.jhelper.wait_until_active.assert_called_once()
@@ -246,7 +266,6 @@ class PatchLoadBalancerServicesStepTest(unittest.TestCase):
 
     def __init__(self, methodName: str = "runTest") -> None:
         super().__init__(methodName)
-        self.client = patch("sunbeam.commands.openstack.Client")
         self.read_config = patch(
             "sunbeam.commands.openstack.read_config",
             Mock(
@@ -275,11 +294,10 @@ class PatchLoadBalancerServicesStepTest(unittest.TestCase):
         )
 
     def setUp(self):
-        self.client.start()
+        self.client = Mock()
         self.read_config.start()
 
     def tearDown(self):
-        self.client.stop()
         self.read_config.stop()
 
     def test_is_skip(self):
@@ -295,7 +313,7 @@ class PatchLoadBalancerServicesStepTest(unittest.TestCase):
                 )
             ),
         ):
-            step = PatchLoadBalancerServicesStep()
+            step = PatchLoadBalancerServicesStep(self.client)
             result = step.is_skip()
         assert result.result_type == ResultType.SKIPPED
 
@@ -308,7 +326,7 @@ class PatchLoadBalancerServicesStepTest(unittest.TestCase):
                 )
             ),
         ):
-            step = PatchLoadBalancerServicesStep()
+            step = PatchLoadBalancerServicesStep(self.client)
             result = step.is_skip()
         assert result.result_type == ResultType.COMPLETED
 
@@ -317,7 +335,7 @@ class PatchLoadBalancerServicesStepTest(unittest.TestCase):
             "sunbeam.commands.openstack.read_config",
             new=Mock(side_effect=ConfigItemNotFoundException),
         ):
-            step = PatchLoadBalancerServicesStep()
+            step = PatchLoadBalancerServicesStep(self.client)
             result = step.is_skip()
         assert result.result_type == ResultType.FAILED
 
@@ -337,7 +355,7 @@ class PatchLoadBalancerServicesStepTest(unittest.TestCase):
                 )
             ),
         ):
-            step = PatchLoadBalancerServicesStep()
+            step = PatchLoadBalancerServicesStep(self.client)
             step.is_skip()
             result = step.run()
         assert result.result_type == ResultType.COMPLETED

--- a/sunbeam-python/tests/unit/sunbeam/commands/upgrades/test_base.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/upgrades/test_base.py
@@ -24,6 +24,7 @@ from sunbeam.versions import (
 
 class TestBaseUpgrade:
     def setup_method(self):
+        self.client = Mock()
         self.jhelper = AsyncMock()
         self.tfhelper = Mock()
         self.upgrade_service = (
@@ -38,7 +39,12 @@ class TestBaseUpgrade:
             return channels[app_name]
 
         upgrader = BaseUpgrade(
-            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+            "test name",
+            "test description",
+            self.client,
+            self.jhelper,
+            self.tfhelper,
+            "openstack",
         )
         get_new_channel_mock = Mock()
         get_new_channel_mock.side_effect = _get_new_channel_mock
@@ -57,7 +63,12 @@ class TestBaseUpgrade:
     def test_get_new_channel_os_service(self, mocker):
         self.jhelper.get_charm_channel.return_value = "2023.1/edge"
         upgrader = BaseUpgrade(
-            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+            "test name",
+            "test description",
+            self.client,
+            self.jhelper,
+            self.tfhelper,
+            "openstack",
         )
         new_channel = upgrader.get_new_channel("cinder", "openstack")
         assert new_channel == "2023.2/edge"
@@ -65,7 +76,12 @@ class TestBaseUpgrade:
     def test_get_new_channel_os_service_same(self, mocker):
         self.jhelper.get_charm_channel.return_value = "2023.2/edge"
         upgrader = BaseUpgrade(
-            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+            "test name",
+            "test description",
+            self.client,
+            self.jhelper,
+            self.tfhelper,
+            "openstack",
         )
         new_channel = upgrader.get_new_channel("cinder", "openstack")
         assert new_channel is None
@@ -73,7 +89,12 @@ class TestBaseUpgrade:
     def test_get_new_channel_os_downgrade(self, mocker):
         self.jhelper.get_charm_channel.return_value = "2023.2/edge"
         upgrader = BaseUpgrade(
-            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+            "test name",
+            "test description",
+            self.client,
+            self.jhelper,
+            self.tfhelper,
+            "openstack",
         )
         new_channel = upgrader.get_new_channel("cinder", "openstack")
         assert new_channel is None
@@ -81,14 +102,24 @@ class TestBaseUpgrade:
     def test_get_new_channel_nonos_service(self, mocker):
         self.jhelper.get_charm_channel.return_value = "3.8/stable"
         upgrader = BaseUpgrade(
-            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+            "test name",
+            "test description",
+            self.client,
+            self.jhelper,
+            self.tfhelper,
+            "openstack",
         )
         new_channel = upgrader.get_new_channel("rabbitmq", "openstack")
         assert new_channel == "3.12/edge"
 
     def test_get_new_channel_unknown(self, mocker):
         upgrader = BaseUpgrade(
-            "test name", "test description", self.jhelper, self.tfhelper, "openstack"
+            "test name",
+            "test description",
+            self.client,
+            self.jhelper,
+            self.tfhelper,
+            "openstack",
         )
         new_channel = upgrader.get_new_channel("foo", "openstack")
         assert new_channel is None

--- a/sunbeam-python/tests/unit/sunbeam/jobs/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/jobs/test_steps.py
@@ -47,8 +47,7 @@ def mock_run_sync(mocker):
 
 @pytest.fixture()
 def cclient():
-    with patch("sunbeam.jobs.steps.Client") as p:
-        yield p
+    yield Mock()
 
 
 @pytest.fixture()
@@ -72,7 +71,7 @@ class TestDeployMachineApplicationStep:
         jhelper.get_application.side_effect = ApplicationNotFoundException("not found")
 
         step = DeployMachineApplicationStep(
-            tfhelper, jhelper, "tfconfig", "app1", "model1"
+            cclient, tfhelper, jhelper, "tfconfig", "app1", "model1"
         )
         result = step.is_skip()
 
@@ -81,7 +80,7 @@ class TestDeployMachineApplicationStep:
 
     def test_is_skip_application_already_deployed(self, cclient, jhelper, tfhelper):
         step = DeployMachineApplicationStep(
-            tfhelper, jhelper, "tfconfig", "app1", "model1"
+            cclient, tfhelper, jhelper, "tfconfig", "app1", "model1"
         )
         result = step.is_skip()
 
@@ -92,7 +91,7 @@ class TestDeployMachineApplicationStep:
         jhelper.get_application.side_effect = ApplicationNotFoundException("not found")
 
         step = DeployMachineApplicationStep(
-            tfhelper, jhelper, "tfconfig", "app1", "model1"
+            cclient, tfhelper, jhelper, "tfconfig", "app1", "model1"
         )
         result = step.run()
 
@@ -107,7 +106,7 @@ class TestDeployMachineApplicationStep:
         jhelper.get_application.return_value = application
 
         step = DeployMachineApplicationStep(
-            tfhelper, jhelper, "tfconfig", "app1", "model1"
+            cclient, tfhelper, jhelper, "tfconfig", "app1", "model1"
         )
         result = step.run()
 
@@ -120,7 +119,7 @@ class TestDeployMachineApplicationStep:
         tfhelper.apply.side_effect = TerraformException("apply failed...")
 
         step = DeployMachineApplicationStep(
-            tfhelper, jhelper, "tfconfig", "app1", "model1"
+            cclient, tfhelper, jhelper, "tfconfig", "app1", "model1"
         )
         result = step.run()
 
@@ -132,7 +131,7 @@ class TestDeployMachineApplicationStep:
         jhelper.wait_application_ready.side_effect = TimeoutException("timed out")
 
         step = DeployMachineApplicationStep(
-            tfhelper, jhelper, "tfconfig", "app1", "model1"
+            cclient, tfhelper, jhelper, "tfconfig", "app1", "model1"
         )
         result = step.run()
 
@@ -143,20 +142,24 @@ class TestDeployMachineApplicationStep:
 
 class TestAddMachineUnitStep:
     def test_is_skip(self, cclient, jhelper):
-        step = AddMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = AddMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.is_skip()
 
         assert result.result_type == ResultType.COMPLETED
 
     def test_is_skip_node_missing(self, cclient, jhelper):
-        cclient().cluster.get_node_info.side_effect = NodeNotExistInClusterException(
+        cclient.cluster.get_node_info.side_effect = NodeNotExistInClusterException(
             "Node missing..."
         )
 
-        step = AddMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = AddMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.is_skip()
 
-        cclient().cluster.get_node_info.assert_called_once()
+        cclient.cluster.get_node_info.assert_called_once()
         assert result.result_type == ResultType.FAILED
         assert result.message == "Node missing..."
 
@@ -165,7 +168,9 @@ class TestAddMachineUnitStep:
             "Application missing..."
         )
 
-        step = AddMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = AddMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.is_skip()
 
         jhelper.get_application.assert_called_once()
@@ -174,18 +179,22 @@ class TestAddMachineUnitStep:
 
     def test_is_skip_unit_already_deployed(self, cclient, jhelper):
         id = "1"
-        cclient().cluster.get_node_info.return_value = {"machineid": id}
+        cclient.cluster.get_node_info.return_value = {"machineid": id}
         jhelper.get_application.return_value = Mock(units=[Mock(machine=Mock(id=id))])
 
-        step = AddMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = AddMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.is_skip()
 
-        cclient().cluster.get_node_info.assert_called_once()
+        cclient.cluster.get_node_info.assert_called_once()
         jhelper.get_application.assert_called_once()
         assert result.result_type == ResultType.SKIPPED
 
     def test_run(self, cclient, jhelper, read_config):
-        step = AddMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = AddMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.run()
 
         assert result.result_type == ResultType.COMPLETED
@@ -195,7 +204,9 @@ class TestAddMachineUnitStep:
             "Application missing..."
         )
 
-        step = AddMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = AddMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.run()
 
         jhelper.add_unit.assert_called_once()
@@ -205,7 +216,9 @@ class TestAddMachineUnitStep:
     def test_run_timeout(self, cclient, jhelper, read_config):
         jhelper.wait_unit_ready.side_effect = TimeoutException("timed out")
 
-        step = AddMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = AddMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.run()
 
         jhelper.wait_unit_ready.assert_called_once()
@@ -216,25 +229,29 @@ class TestAddMachineUnitStep:
 class TestRemoveMachineUnitStep:
     def test_is_skip(self, cclient, jhelper):
         id = "1"
-        cclient().cluster.get_node_info.return_value = {"machineid": id}
+        cclient.cluster.get_node_info.return_value = {"machineid": id}
         jhelper.get_application.return_value = Mock(units=[Mock(machine=Mock(id=id))])
 
-        step = RemoveMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = RemoveMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.is_skip()
 
-        cclient().cluster.get_node_info.assert_called_once()
+        cclient.cluster.get_node_info.assert_called_once()
         jhelper.get_application.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
     def test_is_skip_node_missing(self, cclient, jhelper):
-        cclient().cluster.get_node_info.side_effect = NodeNotExistInClusterException(
+        cclient.cluster.get_node_info.side_effect = NodeNotExistInClusterException(
             "Node missing..."
         )
 
-        step = RemoveMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = RemoveMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.is_skip()
 
-        cclient().cluster.get_node_info.assert_called_once()
+        cclient.cluster.get_node_info.assert_called_once()
         assert result.result_type == ResultType.SKIPPED
 
     def test_is_skip_application_missing(self, cclient, jhelper):
@@ -242,25 +259,31 @@ class TestRemoveMachineUnitStep:
             "Application missing..."
         )
 
-        step = RemoveMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = RemoveMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.is_skip()
 
         jhelper.get_application.assert_called_once()
         assert result.result_type == ResultType.SKIPPED
 
     def test_is_skip_unit_missing(self, cclient, jhelper):
-        cclient().cluster.get_node_info.return_value = {}
+        cclient.cluster.get_node_info.return_value = {}
         jhelper.get_application.return_value = Mock(units=[])
 
-        step = RemoveMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = RemoveMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.is_skip()
 
-        cclient().cluster.get_node_info.assert_called_once()
+        cclient.cluster.get_node_info.assert_called_once()
         jhelper.get_application.assert_called_once()
         assert result.result_type == ResultType.SKIPPED
 
     def test_run(self, cclient, jhelper, read_config):
-        step = RemoveMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = RemoveMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.run()
 
         assert result.result_type == ResultType.COMPLETED
@@ -270,7 +293,9 @@ class TestRemoveMachineUnitStep:
             "Application missing..."
         )
 
-        step = RemoveMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = RemoveMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.run()
 
         jhelper.remove_unit.assert_called_once()
@@ -280,7 +305,9 @@ class TestRemoveMachineUnitStep:
     def test_run_timeout(self, cclient, jhelper, read_config):
         jhelper.wait_application_ready.side_effect = TimeoutException("timed out")
 
-        step = RemoveMachineUnitStep("app1", jhelper, "tfconfig", "app1", "model1")
+        step = RemoveMachineUnitStep(
+            cclient, "app1", jhelper, "tfconfig", "app1", "model1"
+        )
         result = step.run()
 
         jhelper.wait_application_ready.assert_called_once()

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_ldap.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_ldap.py
@@ -31,8 +31,7 @@ from sunbeam.plugins.ldap.plugin import (
 
 @pytest.fixture()
 def cclient():
-    with patch("sunbeam.plugins.ldap.plugin.Client") as p:
-        yield p
+    yield Mock()
 
 
 @pytest.fixture()
@@ -90,20 +89,20 @@ class TestAddLDAPDomainStep:
 
     def test_is_skip(self, cclient):
         self.plugin = FakeLDAPPlugin()
-        step = AddLDAPDomainStep(self.tfhelper, self.jhelper, self.plugin, {})
+        step = AddLDAPDomainStep(cclient, self.tfhelper, self.jhelper, self.plugin, {})
         result = step.is_skip()
         assert result.result_type == ResultType.COMPLETED
 
     def test_has_prompts(self, cclient):
         self.plugin = FakeLDAPPlugin()
-        step = AddLDAPDomainStep(self.tfhelper, self.jhelper, self.plugin, {})
+        step = AddLDAPDomainStep(cclient, self.tfhelper, self.jhelper, self.plugin, {})
         assert not step.has_prompts()
 
     def test_enable_first_domain(self, cclient, read_config, update_config, snap):
         self.plugin = FakeLDAPPlugin()
         read_config.return_value = {}
         step = AddLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, self.charm_config
+            cclient, self.tfhelper, self.jhelper, self.plugin, self.charm_config
         )
         result = step.run()
         self.tfhelper.write_tfvars.assert_called_with(
@@ -125,7 +124,7 @@ class TestAddLDAPDomainStep:
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
         }
         step = AddLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, {"domain-name": "dom2"}
+            cclient, self.tfhelper, self.jhelper, self.plugin, {"domain-name": "dom2"}
         )
         result = step.run()
         self.tfhelper.write_tfvars.assert_called_with(
@@ -148,7 +147,7 @@ class TestAddLDAPDomainStep:
         read_config.return_value = {}
         self.tfhelper.apply.side_effect = TerraformException("apply failed...")
         step = AddLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, self.charm_config
+            cclient, self.tfhelper, self.jhelper, self.plugin, self.charm_config
         )
         result = step.run()
         self.tfhelper.apply.assert_called_once()
@@ -160,7 +159,7 @@ class TestAddLDAPDomainStep:
         self.plugin = FakeLDAPPlugin()
         read_config.return_value = {}
         step = AddLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, self.charm_config
+            cclient, self.tfhelper, self.jhelper, self.plugin, self.charm_config
         )
         result = step.run()
         self.tfhelper.write_tfvars.assert_called_with(
@@ -185,13 +184,17 @@ class TestDisableLDAPDomainStep:
 
     def test_is_skip(self, cclient):
         self.plugin = FakeLDAPPlugin()
-        step = DisableLDAPDomainStep(self.tfhelper, self.jhelper, self.plugin, "dom1")
+        step = DisableLDAPDomainStep(
+            cclient, self.tfhelper, self.jhelper, self.plugin, "dom1"
+        )
         result = step.is_skip()
         assert result.result_type == ResultType.COMPLETED
 
     def test_has_prompts(self, cclient):
         self.plugin = FakeLDAPPlugin()
-        step = DisableLDAPDomainStep(self.tfhelper, self.jhelper, self.plugin, "dom1")
+        step = DisableLDAPDomainStep(
+            cclient, self.tfhelper, self.jhelper, self.plugin, "dom1"
+        )
         assert not step.has_prompts()
 
     def test_disable(self, cclient, read_config, update_config, snap):
@@ -200,7 +203,9 @@ class TestDisableLDAPDomainStep:
             "ldap-channel": "2023.2/edge",
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
         }
-        step = DisableLDAPDomainStep(self.tfhelper, self.jhelper, self.plugin, "dom1")
+        step = DisableLDAPDomainStep(
+            cclient, self.tfhelper, self.jhelper, self.plugin, "dom1"
+        )
         step.run()
         self.tfhelper.write_tfvars.assert_called_with(
             {"ldap-channel": "2023.2/edge", "ldap-apps": {}}
@@ -214,7 +219,9 @@ class TestDisableLDAPDomainStep:
             "ldap-channel": "2023.2/edge",
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
         }
-        step = DisableLDAPDomainStep(self.tfhelper, self.jhelper, self.plugin, "dom1")
+        step = DisableLDAPDomainStep(
+            cclient, self.tfhelper, self.jhelper, self.plugin, "dom1"
+        )
         result = step.run()
         self.tfhelper.write_tfvars.assert_called_with(
             {"ldap-channel": "2023.2/edge", "ldap-apps": {}}
@@ -229,7 +236,9 @@ class TestDisableLDAPDomainStep:
             "ldap-channel": "2023.2/edge",
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
         }
-        step = DisableLDAPDomainStep(self.tfhelper, self.jhelper, self.plugin, "dom2")
+        step = DisableLDAPDomainStep(
+            cclient, self.tfhelper, self.jhelper, self.plugin, "dom2"
+        )
         result = step.run()
         assert result.result_type == ResultType.FAILED
         assert result.message == "Domain not found"
@@ -244,7 +253,7 @@ class TestUpdateLDAPDomainStep:
     def test_is_skip(self, cclient):
         self.plugin = FakeLDAPPlugin()
         step = UpdateLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, self.charm_config
+            cclient, self.tfhelper, self.jhelper, self.plugin, self.charm_config
         )
         result = step.is_skip()
         assert result.result_type == ResultType.COMPLETED
@@ -252,7 +261,7 @@ class TestUpdateLDAPDomainStep:
     def test_has_prompts(self, cclient):
         self.plugin = FakeLDAPPlugin()
         step = UpdateLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, self.charm_config
+            cclient, self.tfhelper, self.jhelper, self.plugin, self.charm_config
         )
         assert not step.has_prompts()
 
@@ -263,7 +272,7 @@ class TestUpdateLDAPDomainStep:
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
         }
         step = UpdateLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, self.charm_config
+            cclient, self.tfhelper, self.jhelper, self.plugin, self.charm_config
         )
         result = step.run()
         self.tfhelper.write_tfvars.assert_called_with(
@@ -285,7 +294,7 @@ class TestUpdateLDAPDomainStep:
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
         }
         step = UpdateLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, {"domain-name": "dom2"}
+            cclient, self.tfhelper, self.jhelper, self.plugin, {"domain-name": "dom2"}
         )
         result = step.run()
         assert result.result_type == ResultType.FAILED
@@ -299,7 +308,7 @@ class TestUpdateLDAPDomainStep:
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
         }
         step = UpdateLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, self.charm_config
+            cclient, self.tfhelper, self.jhelper, self.plugin, self.charm_config
         )
         result = step.run()
         self.tfhelper.apply.assert_called_once_with()
@@ -315,7 +324,7 @@ class TestUpdateLDAPDomainStep:
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
         }
         step = UpdateLDAPDomainStep(
-            self.tfhelper, self.jhelper, self.plugin, self.charm_config
+            cclient, self.tfhelper, self.jhelper, self.plugin, self.charm_config
         )
         result = step.run()
         self.tfhelper.apply.assert_called_once_with()

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_openstack.py
@@ -41,8 +41,7 @@ def mock_run_sync(mocker):
 
 @pytest.fixture()
 def cclient():
-    with patch("sunbeam.plugins.interface.v1.openstack.Client") as p:
-        yield p
+    yield Mock()
 
 
 @pytest.fixture()
@@ -79,7 +78,9 @@ class TestEnableOpenStackApplicationStep:
         tfhelper,
         osplugin,
     ):
-        step = openstack.EnableOpenStackApplicationStep(tfhelper, jhelper, osplugin)
+        step = openstack.EnableOpenStackApplicationStep(
+            cclient, tfhelper, jhelper, osplugin
+        )
         result = step.run()
 
         tfhelper.write_tfvars.assert_called_once()
@@ -92,7 +93,9 @@ class TestEnableOpenStackApplicationStep:
     ):
         tfhelper.apply.side_effect = TerraformException("apply failed...")
 
-        step = openstack.EnableOpenStackApplicationStep(tfhelper, jhelper, osplugin)
+        step = openstack.EnableOpenStackApplicationStep(
+            cclient, tfhelper, jhelper, osplugin
+        )
         result = step.run()
 
         tfhelper.write_tfvars.assert_called_once()
@@ -106,7 +109,9 @@ class TestEnableOpenStackApplicationStep:
     ):
         jhelper.wait_until_active.side_effect = TimeoutException("timed out")
 
-        step = openstack.EnableOpenStackApplicationStep(tfhelper, jhelper, osplugin)
+        step = openstack.EnableOpenStackApplicationStep(
+            cclient, tfhelper, jhelper, osplugin
+        )
         result = step.run()
 
         tfhelper.write_tfvars.assert_called_once()
@@ -118,7 +123,9 @@ class TestEnableOpenStackApplicationStep:
 
 class TestDisableOpenStackApplicationStep:
     def test_run(self, cclient, read_config, jhelper, tfhelper, osplugin):
-        step = openstack.DisableOpenStackApplicationStep(tfhelper, jhelper, osplugin)
+        step = openstack.DisableOpenStackApplicationStep(
+            cclient, tfhelper, jhelper, osplugin
+        )
         result = step.run()
 
         tfhelper.write_tfvars.assert_called_once()
@@ -130,7 +137,9 @@ class TestDisableOpenStackApplicationStep:
     ):
         tfhelper.apply.side_effect = TerraformException("apply failed...")
 
-        step = openstack.DisableOpenStackApplicationStep(tfhelper, jhelper, osplugin)
+        step = openstack.DisableOpenStackApplicationStep(
+            cclient, tfhelper, jhelper, osplugin
+        )
         result = step.run()
 
         tfhelper.write_tfvars.assert_called_once()

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_repo.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_repo.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -22,8 +22,7 @@ from sunbeam.jobs.common import ResultType
 
 @pytest.fixture()
 def cclient():
-    with patch("sunbeam.plugins.repo.plugin.Client") as p:
-        yield p
+    yield Mock()
 
 
 @pytest.fixture()
@@ -89,7 +88,9 @@ class TestRemovePluginRepoStep:
                 }
             ],
         }
-        step = repo_plugin.RemovePluginRepoStep(repo_name, tmp_path, repoplugin)
+        step = repo_plugin.RemovePluginRepoStep(
+            cclient, repo_name, tmp_path, repoplugin
+        )
         result = step.run()
 
         repoplugin.get_plugin_info.assert_called_once()
@@ -113,7 +114,9 @@ class TestRemovePluginRepoStep:
                 }
             ],
         }
-        step = repo_plugin.RemovePluginRepoStep(repo_name, tmp_path, repoplugin)
+        step = repo_plugin.RemovePluginRepoStep(
+            cclient, repo_name, tmp_path, repoplugin
+        )
         result = step.run()
 
         repoplugin.get_plugin_info.assert_not_called()
@@ -135,7 +138,9 @@ class TestRemovePluginRepoStep:
                 }
             ],
         }
-        step = repo_plugin.RemovePluginRepoStep(repo_name, tmp_path, repoplugin)
+        step = repo_plugin.RemovePluginRepoStep(
+            cclient, repo_name, tmp_path, repoplugin
+        )
         result = step.run()
 
         repoplugin.get_plugin_info.assert_called_once()
@@ -148,13 +153,13 @@ class TestUpdatePluginRepoStep:
         repo_name = "TEST_REPO"
         pluginmanager.get_all_external_repos.return_value = [repo_name]
         externalrepo.name = repo_name
-        step = repo_plugin.UpdatePluginRepoStep(externalrepo, repoplugin)
+        step = repo_plugin.UpdatePluginRepoStep(cclient, externalrepo, repoplugin)
         result = step.run()
 
         externalrepo.repo.git.rev_parse.assert_called_once()
         externalrepo.repo.git.pull.assert_called_once()
         externalrepo.validate_repo.assert_called_once()
-        pluginmanager.update_plugins.assert_called_once_with([repo_name])
+        pluginmanager.update_plugins.assert_called_once_with(cclient, [repo_name])
         repoplugin.update_plugin_info.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
@@ -163,7 +168,7 @@ class TestUpdatePluginRepoStep:
     ):
         pluginmanager.get_all_external_repos.return_value = ["TEST_REPO"]
         externalrepo.name = "UNKNOWN_REPO"
-        step = repo_plugin.UpdatePluginRepoStep(externalrepo, repoplugin)
+        step = repo_plugin.UpdatePluginRepoStep(cclient, externalrepo, repoplugin)
         result = step.run()
 
         externalrepo.repo.git.rev_parse.assert_not_called()
@@ -182,7 +187,7 @@ class TestUpdatePluginRepoStep:
         pluginmanager.get_all_external_repos.return_value = [repo_name]
         externalrepo.name = repo_name
         externalrepo.repo.git.rev_parse.return_value = commit_id
-        step = repo_plugin.UpdatePluginRepoStep(externalrepo, repoplugin)
+        step = repo_plugin.UpdatePluginRepoStep(cclient, externalrepo, repoplugin)
         result = step.run()
 
         externalrepo.repo.git.rev_parse.assert_called_once()


### PR DESCRIPTION
Instantiate cluster client once, (except for terraform, until manifest lands).

In the case of a maas deployment, we'll need to instantiate a cluster client differently depending on active deployment. Having only one instance (provided by the deployment type) makes using cluster client way simpler forward.