### PR TITLE
[manifest] support for intra channel refresh

### DIFF
--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -202,6 +202,25 @@ class JujuStepHelper:
         )
         return bool(available_revision > deployed_revision)
 
+    def get_charm_deployed_versions(self, model: str) -> dict:
+        """Return charm deployed info for all the applications in model.
+
+        For each application, return a tuple of charm name, channel and revision.
+        Example output:
+        {"keystone": ("keystone-k8s", "2023.2/stable", 234)}
+        """
+        _status = run_sync(self.jhelper.get_model_status_full(model))
+        status = json.loads(_status.to_json())
+
+        apps = {}
+        for app_name, app_status in status.get("applications", {}).items():
+            charm_name = self._extract_charm_name(app_status["charm"])
+            deployed_channel = self.normalise_channel(app_status["charm-channel"])
+            deployed_revision = int(self._extract_charm_revision(app_status["charm"]))
+            apps[app_name] = (charm_name, deployed_channel, deployed_revision)
+
+        return apps
+
     def normalise_channel(self, channel: str) -> str:
         """Expand channel if it is using abbreviation.
 

--- a/sunbeam-python/sunbeam/commands/microceph.py
+++ b/sunbeam-python/sunbeam/commands/microceph.py
@@ -66,6 +66,7 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
         client: Client,
         manifest: Manifest,
         jhelper: JujuHelper,
+        refresh: bool = False,
     ):
         super().__init__(
             client,
@@ -77,6 +78,7 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
             "microceph-plan",
             "Deploy MicroCeph",
             "Deploying MicroCeph",
+            refresh,
         )
 
     def get_application_timeout(self) -> int:

--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -96,6 +96,7 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
         jhelper: JujuHelper,
         preseed_file: Optional[Path] = None,
         accept_defaults: bool = False,
+        refresh: bool = False,
     ):
         super().__init__(
             client,
@@ -107,6 +108,7 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
             "microk8s-plan",
             "Deploy MicroK8S",
             "Deploying MicroK8S",
+            refresh,
         )
 
         self.preseed_file = preseed_file
@@ -156,6 +158,10 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
         :return: True if the step can ask the user for prompts,
                  False otherwise
         """
+        # No need to prompt for questions in case of refresh
+        if self.refresh:
+            return False
+
         return True
 
 

--- a/sunbeam-python/sunbeam/commands/sunbeam_machine.py
+++ b/sunbeam-python/sunbeam/commands/sunbeam_machine.py
@@ -41,6 +41,7 @@ class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
         client: Client,
         manifest: Manifest,
         jhelper: JujuHelper,
+        refresh: bool = False,
     ):
         super().__init__(
             client,
@@ -52,6 +53,7 @@ class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
             "sunbeam-machine-plan",
             "Deploy sunbeam-machine",
             "Deploying Sunbeam Machine",
+            refresh,
         )
 
     def extra_tfvars(self) -> dict:

--- a/sunbeam-python/sunbeam/commands/upgrades/base.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/base.py
@@ -23,6 +23,7 @@ from sunbeam.clusterd.client import Client
 from sunbeam.commands.terraform import TerraformHelper
 from sunbeam.jobs.common import BaseStep, Result, ResultType, run_plan
 from sunbeam.jobs.juju import JujuHelper
+from sunbeam.jobs.manifest import Manifest
 from sunbeam.jobs.plugin import PluginManager
 
 LOG = logging.getLogger(__name__)
@@ -62,7 +63,7 @@ class UpgradeCoordinator:
         self,
         client: Client,
         jhelper: JujuHelper,
-        tfhelper: TerraformHelper,
+        manifest: Manifest,
         channel: str | None = None,
     ):
         """Upgrade coordinator.
@@ -71,13 +72,14 @@ class UpgradeCoordinator:
 
         :client: Helper for interacting with clusterd
         :jhelper: Helper for interacting with pylibjuju
-        :tfhelper: Helper for interaction with Terraform
+        :manifest: Manifest object
         :channel: OpenStack channel to upgrade charms to
         """
         self.client = client
         self.channel = channel
         self.jhelper = jhelper
-        self.tfhelper = tfhelper
+        self.manifest = manifest
+        self.tfhelper = self.manifest.get_tfhelper("openstack-plan")
 
     def get_plan(self) -> list[BaseStep]:
         """Return the plan for this upgrade.

--- a/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
@@ -13,25 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import logging
 from typing import Optional
 
 from rich.console import Console
 from rich.status import Status
 
+from sunbeam.commands.hypervisor import ReapplyHypervisorTerraformPlanStep
 from sunbeam.commands.juju import JujuStepHelper
+from sunbeam.commands.microceph import DeployMicrocephApplicationStep
+from sunbeam.commands.microk8s import DeployMicrok8sApplicationStep
+from sunbeam.commands.openstack import ReapplyOpenStackTerraformPlanStep
+from sunbeam.commands.sunbeam_machine import DeploySunbeamMachineApplicationStep
+from sunbeam.commands.terraform import TerraformInitStep
 from sunbeam.commands.upgrades.base import UpgradeCoordinator, UpgradePlugins
 from sunbeam.jobs.common import BaseStep, Result, ResultType
 from sunbeam.jobs.juju import run_sync
-from sunbeam.versions import K8S_SERVICES, MACHINE_SERVICES
 
 LOG = logging.getLogger(__name__)
 console = Console()
 
 
 class LatestInChannel(BaseStep, JujuStepHelper):
-    def __init__(self, jhelper):
+    def __init__(self, jhelper, manifest):
         """Upgrade all charms to latest in current channel.
 
         :jhelper: Helper for interacting with pylibjuju
@@ -40,47 +44,73 @@ class LatestInChannel(BaseStep, JujuStepHelper):
             "In channel upgrade", "Upgrade charms to latest revision in current channel"
         )
         self.jhelper = jhelper
-
-    def get_charm_update(self, applications, model) -> list[str]:
-        """Return a list applications that need to be refreshed."""
-        candidates = []
-        _status = run_sync(self.jhelper.get_model_status_full(model))
-        status = json.loads(_status.to_json())
-        for app_name in applications:
-            if self.revision_update_needed(app_name, model, status=status):
-                candidates.append(app_name)
-            else:
-                LOG.debug(f"{app_name} already at latest version in current channel")
-        return candidates
-
-    def get_charm_update_candidates_k8s(self) -> list[str]:
-        """Return a list of all k8s charms that need to be refreshed."""
-        return self.get_charm_update(K8S_SERVICES.keys(), "openstack")
-
-    def get_charm_update_candidates_machine(self) -> list[str]:
-        """Return a list of all machine charms that need to be refreshed."""
-        return self.get_charm_update(MACHINE_SERVICES.keys(), "controller")
+        self.manifest = manifest
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Step can be skipped if nothing needs refreshing."""
-        if (
-            self.get_charm_update_candidates_k8s()
-            or self.get_charm_update_candidates_machine()  # noqa
-        ):
-            return Result(ResultType.COMPLETED)
-        else:
-            return Result(ResultType.SKIPPED)
+        return Result(ResultType.COMPLETED)
+
+    def is_track_changed_for_any_charm(self, deployed_apps: dict):
+        """Check if chanel track is same in manifest and deployed app."""
+        for app_name, (charm, channel, revision) in deployed_apps.items():
+            if not self.manifest.charms.get(charm):
+                LOG.debug(f"Charm not present in manifest: {charm}")
+                continue
+
+            channel_from_manifest = self.manifest.charms.get(charm).channel or ""
+            track_from_manifest = channel_from_manifest.split("/")[0]
+            track_from_deployed_app = channel.split("/")[0]
+            # Compare tracks
+            if track_from_manifest != track_from_deployed_app:
+                LOG.debug(
+                    "Channel track for app {app_name} different in manifest "
+                    "and actual deployed"
+                )
+                return True
+
+        return False
+
+    def refresh_apps(self, apps: dict, model: str) -> None:
+        """Refresh apps in the model.
+
+        If the charm has no revision in manifest and channel mentioned in manifest
+        and the deployed app is same, run juju refresh.
+        Otherwise ignore so that terraform plan apply will take care of charm upgrade.
+        """
+        for app_name, (charm, channel, revision) in apps.items():
+            manifest_charm = self.manifest.charms.get(charm)
+            if not manifest_charm:
+                continue
+
+            if not manifest_charm.revision and manifest_charm.channel == channel:
+                app = run_sync(self.jhelper.get_application(app_name, model))
+                LOG.debug(f"Running refresh for app {app_name}")
+                # refresh() checks for any new revision and updates if available
+                run_sync(app.refresh())
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Refresh all charms identified as needing a refresh."""
-        for app_name in self.get_charm_update_candidates_k8s():
-            LOG.debug(f"Refreshing {app_name}")
-            app = run_sync(self.jhelper.get_application(app_name, "openstack"))
-            run_sync(app.refresh())
-        for app_name in self.get_charm_update_candidates_machine():
-            LOG.debug(f"Refreshing {app_name}")
-            app = run_sync(self.jhelper.get_application(app_name, "controller"))
-            run_sync(app.refresh())
+        """Refresh all charms identified as needing a refresh.
+
+        If the manifest has charm channel and revision, terraform apply should update
+        the charms.
+        If the manifest has only charm, then juju refresh is required if channel is
+        same as deployed charm, otherwise juju upgrade charm.
+        """
+        deployed_k8s_apps = self.get_charm_deployed_versions("openstack")
+        deployed_machine_apps = self.get_charm_deployed_versions("controller")
+
+        all_deployed_apps = deployed_k8s_apps.copy()
+        all_deployed_apps.update(deployed_machine_apps)
+        LOG.debug(f"Al deployed apps: {all_deployed_apps}")
+        if self.is_track_changed_for_any_charm(all_deployed_apps):
+            error_msg = (
+                "Manifest has track values that require upgrades, rerun with "
+                "option --upgrade-release for release upgrades."
+            )
+            return Result(ResultType.FAILED, error_msg)
+
+        self.refresh_apps(deployed_k8s_apps, "openstack")
+        self.refresh_apps(deployed_machine_apps, "controller")
         return Result(ResultType.COMPLETED)
 
 
@@ -89,7 +119,25 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
 
     def get_plan(self) -> list[BaseStep]:
         return [
-            LatestInChannel(self.jhelper),
+            LatestInChannel(self.jhelper, self.manifest),
+            TerraformInitStep(self.manifest.get_tfhelper("openstack-plan")),
+            ReapplyOpenStackTerraformPlanStep(self.client, self.manifest, self.jhelper),
+            TerraformInitStep(self.manifest.get_tfhelper("sunbeam-machine-plan")),
+            DeploySunbeamMachineApplicationStep(
+                self.client, self.manifest, self.jhelper, refresh=True
+            ),
+            TerraformInitStep(self.manifest.get_tfhelper("microk8s-plan")),
+            DeployMicrok8sApplicationStep(
+                self.client, self.manifest, self.jhelper, refresh=True
+            ),
+            TerraformInitStep(self.manifest.get_tfhelper("microceph-plan")),
+            DeployMicrocephApplicationStep(
+                self.client, self.manifest, self.jhelper, refresh=True
+            ),
+            TerraformInitStep(self.manifest.get_tfhelper("hypervisor-plan")),
+            ReapplyHypervisorTerraformPlanStep(
+                self.client, self.manifest, self.jhelper
+            ),
             UpgradePlugins(
                 self.client, self.jhelper, self.tfhelper, upgrade_release=False
             ),

--- a/sunbeam-python/sunbeam/jobs/steps.py
+++ b/sunbeam-python/sunbeam/jobs/steps.py
@@ -50,6 +50,7 @@ class DeployMachineApplicationStep(BaseStep):
         tfplan: str,
         banner: str = "",
         description: str = "",
+        refresh: bool = False,
     ):
         super().__init__(banner, description)
         self.manifest = manifest
@@ -59,6 +60,8 @@ class DeployMachineApplicationStep(BaseStep):
         self.model = model
         self.client = client
         self.tfplan = tfplan
+        # Set refresh flag to True to redeploy the application
+        self.refresh = refresh
 
     def extra_tfvars(self) -> dict:
         return {}
@@ -72,6 +75,9 @@ class DeployMachineApplicationStep(BaseStep):
         :return: ResultType.SKIPPED if the Step should be skipped,
                 ResultType.COMPLETED or ResultType.FAILED otherwise
         """
+        if self.refresh:
+            return Result(ResultType.COMPLETED)
+
         try:
             run_sync(self.jhelper.get_application(self.application, self.model))
         except ApplicationNotFoundException:

--- a/sunbeam-python/sunbeam/plugins/caas/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/caas/plugin.py
@@ -124,7 +124,7 @@ class CaasPlugin(OpenStackControlPlanePlugin):
         """Manifest plugin part in dict format."""
         return {
             "charms": {
-                "magnum": {"channel": OPENSTACK_CHANNEL},
+                "magnum-k8s": {"channel": OPENSTACK_CHANNEL},
             },
             "terraform": {
                 self.configure_plan: {
@@ -138,7 +138,7 @@ class CaasPlugin(OpenStackControlPlanePlugin):
         return {
             self.tfplan: {
                 "charms": {
-                    "magnum": {
+                    "magnum-k8s": {
                         "channel": "magnum-channel",
                         "revision": "magnum-revision",
                         "config": "magnum-config",

--- a/sunbeam-python/sunbeam/plugins/dns/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/dns/plugin.py
@@ -58,8 +58,8 @@ class DnsPlugin(OpenStackControlPlanePlugin):
         """Manifest plugin part in dict format."""
         return {
             "charms": {
-                "designate": {"channel": OPENSTACK_CHANNEL},
-                "bind": {"channel": BIND_CHANNEL},
+                "designate-k8s": {"channel": OPENSTACK_CHANNEL},
+                "designate-bind-k8s": {"channel": BIND_CHANNEL},
             }
         }
 
@@ -68,12 +68,12 @@ class DnsPlugin(OpenStackControlPlanePlugin):
         return {
             self.tfplan: {
                 "charms": {
-                    "designate": {
+                    "designate-k8s": {
                         "channel": "designate-channel",
                         "revision": "designate-revision",
                         "config": "designate-config",
                     },
-                    "bind": {
+                    "designate-bind-k8s": {
                         "channel": "bind-channel",
                         "revision": "bind-revision",
                         "config": "bind-config",

--- a/sunbeam-python/sunbeam/plugins/interface/v1/base.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/base.py
@@ -198,7 +198,7 @@ class BasePlugin(ABC):
         Sample manifest:
         {
             "charms": {
-                "heat": {
+                "heat-k8s": {
                     "channel": <>.
                     "revision": <>,
                     "config": <>,
@@ -233,7 +233,7 @@ class BasePlugin(ABC):
         {
             <tf plan1>: {
                 "charms": {
-                    "heat": {
+                    "heat-k8s": {
                         "channel": <tfvar for heat channel>,
                         "revision": <tfvar for heat revision>,
                         "config": <tfvar for heat config>,

--- a/sunbeam-python/sunbeam/plugins/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/openstack.py
@@ -298,6 +298,20 @@ class OpenStackControlPlanePlugin(EnableDisablePlugin):
 
         :param upgrade_release: Whether to upgrade release
         """
+        # For Intra channel upgrade, if the plan is openstack-plan,
+        # upgrade already applied at core and not required at plugin
+        # level
+        if (
+            not upgrade_release
+            and self.tf_plan_location  # noqa W503
+            == TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO  # noqa: W503
+        ):
+            LOG.debug(
+                f"Ignore upgrade_hook for plugin {self.name}, the corresponding apps"
+                f" will be refreshed as part of Control plane refresh"
+            )
+            return
+
         data_location = self.snap.paths.user_data
         jhelper = JujuHelper(self.client, data_location)
         plan = [

--- a/sunbeam-python/sunbeam/plugins/ldap/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/ldap/plugin.py
@@ -264,14 +264,14 @@ class LDAPPlugin(OpenStackControlPlanePlugin):
 
     def manifest_defaults(self) -> dict:
         """Manifest plugin part in dict format."""
-        return {"charms": {"keystone-ldap": {"channel": OPENSTACK_CHANNEL}}}
+        return {"charms": {"keystone-ldap-k8s": {"channel": OPENSTACK_CHANNEL}}}
 
     def manifest_attributes_tfvar_map(self) -> dict:
         """Manifest attributes terraformvars map."""
         return {
             self.tfplan: {
                 "charms": {
-                    "keystone-ldap": {
+                    "keystone-ldap-k8s": {
                         "channel": "ldap-channel",
                         "revision": "ldap-revision",
                     }

--- a/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
@@ -40,14 +40,14 @@ class LoadbalancerPlugin(OpenStackControlPlanePlugin):
 
     def manifest_defaults(self) -> dict:
         """Manifest plugin part in dict format."""
-        return {"charms": {"octavia": {"channel": OPENSTACK_CHANNEL}}}
+        return {"charms": {"octavia-k8s": {"channel": OPENSTACK_CHANNEL}}}
 
     def manifest_attributes_tfvar_map(self) -> dict:
         """Manifest attributes terraformvars map."""
         return {
             self.tfplan: {
                 "charms": {
-                    "octavia": {
+                    "octavia-k8s": {
                         "channel": "octavia-channel",
                         "revision": "octavia-revision",
                         "config": "octavia-config",

--- a/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
@@ -40,14 +40,14 @@ class OrchestrationPlugin(OpenStackControlPlanePlugin):
 
     def manifest_defaults(self) -> dict:
         """Manifest plugin part in dict format."""
-        return {"charms": {"heat": {"channel": OPENSTACK_CHANNEL}}}
+        return {"charms": {"heat-k8s": {"channel": OPENSTACK_CHANNEL}}}
 
     def manifest_attributes_tfvar_map(self) -> dict:
         """Manifest attributes terraformvars map."""
         return {
             self.tfplan: {
                 "charms": {
-                    "heat": {
+                    "heat-k8s": {
                         "channel": "heat-channel",
                         "revision": "heat-revision",
                         "config": "heat-config",

--- a/sunbeam-python/sunbeam/plugins/secrets/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/secrets/plugin.py
@@ -39,14 +39,14 @@ class SecretsPlugin(OpenStackControlPlanePlugin):
 
     def manifest_defaults(self) -> dict:
         """Manifest plugin part in dict format."""
-        return {"charms": {"barbican": {"channel": OPENSTACK_CHANNEL}}}
+        return {"charms": {"barbican-k8s": {"channel": OPENSTACK_CHANNEL}}}
 
     def manifest_attributes_tfvar_map(self) -> dict:
         """Manifest attributes terraformvars map."""
         return {
             self.tfplan: {
                 "charms": {
-                    "barbican": {
+                    "barbican-k8s": {
                         "channel": "barbican-channel",
                         "revision": "barbican-revision",
                         "config": "barbican-config",

--- a/sunbeam-python/sunbeam/plugins/telemetry/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/telemetry/plugin.py
@@ -50,9 +50,9 @@ class TelemetryPlugin(OpenStackControlPlanePlugin):
         """Manifest plugin part in dict format."""
         return {
             "charms": {
-                "aodh": {"channel": OPENSTACK_CHANNEL},
-                "gnocchi": {"channel": OPENSTACK_CHANNEL},
-                "ceilometer": {"channel": OPENSTACK_CHANNEL},
+                "aodh-k8s": {"channel": OPENSTACK_CHANNEL},
+                "gnocchi-k8s": {"channel": OPENSTACK_CHANNEL},
+                "ceilometer-k8s": {"channel": OPENSTACK_CHANNEL},
             }
         }
 
@@ -61,17 +61,17 @@ class TelemetryPlugin(OpenStackControlPlanePlugin):
         return {
             self.tfplan: {
                 "charms": {
-                    "aodh": {
+                    "aodh-k8s": {
                         "channel": "aodh-channel",
                         "revision": "aodh-revision",
                         "config": "aodh-config",
                     },
-                    "gnocchi": {
+                    "gnocchi-k8s": {
                         "channel": "gnocchi-channel",
                         "revision": "gnocchi-revision",
                         "config": "gnocchi-config",
                     },
-                    "ceilometer": {
+                    "ceilometer-k8s": {
                         "channel": "ceilometer-channel",
                         "revision": "ceilometer-revision",
                         "config": "ceilometer-config",

--- a/sunbeam-python/sunbeam/plugins/vault/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/vault/plugin.py
@@ -46,14 +46,14 @@ class VaultPlugin(OpenStackControlPlanePlugin):
 
     def manifest_defaults(self) -> dict:
         """Manifest pluing part in dict format."""
-        return {"charms": {"vault": {"channel": VAULT_CHANNEL}}}
+        return {"charms": {"vault-k8s": {"channel": VAULT_CHANNEL}}}
 
     def manifest_attributes_tfvar_map(self) -> dict:
         """Manifest attrbitues to terraformvars map."""
         return {
             self.tfplan: {
                 "charms": {
-                    "vault": {
+                    "vault-k8s": {
                         "channel": "vault-channel",
                         "revision": "vault-revision",
                         "config": "vault-config",

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -85,14 +85,46 @@ CHARM_VERSIONS |= MACHINE_SERVICES
 # but per charm. So all *-mysql-router wont be included
 # and instead only mysql-router is included. Same is the
 # case of traefik charm.
+OPENSTACK_CHARMS_K8S = {
+    "cinder-ceph-k8s": OPENSTACK_CHANNEL,
+    "cinder-k8s": OPENSTACK_CHANNEL,
+    "glance-k8s": OPENSTACK_CHANNEL,
+    "horizon-k8s": OPENSTACK_CHANNEL,
+    "keystone-k8s": OPENSTACK_CHANNEL,
+    "neutron-k8s": OPENSTACK_CHANNEL,
+    "nova-k8s": OPENSTACK_CHANNEL,
+    "placement-k8s": OPENSTACK_CHANNEL,
+}
+OVN_CHARMS_K8S = {
+    "ovn-central-k8s": OVN_CHANNEL,
+    "ovn-relay-k8s": OVN_CHANNEL,
+}
+MYSQL_CHARMS_K8S = {
+    "mysql-k8s": MYSQL_CHANNEL,
+    "mysql-router-k8s": MYSQL_CHANNEL,
+}
+MISC_CHARMS_K8S = {
+    "self-signed-certificates": CERT_AUTH_CHANNEL,
+    "rabbitmq-k8s": RABBITMQ_CHANNEL,
+    "traefik-k8s": TRAEFIK_CHANNEL,
+}
+MACHINE_CHARMS = {
+    "microceph": MICROCEPH_CHANNEL,
+    "microk8s": MICROK8S_CHANNEL,
+    "openstack-hypervisor": OPENSTACK_CHANNEL,
+    "sunbeam-machine": SUNBEAM_MACHINE_CHANNEL,
+}
+
+
+K8S_CHARMS = {}
+K8S_CHARMS |= OPENSTACK_CHARMS_K8S
+K8S_CHARMS |= OVN_CHARMS_K8S
+K8S_CHARMS |= MYSQL_CHARMS_K8S
+K8S_CHARMS |= MISC_CHARMS_K8S
+
 MANIFEST_CHARM_VERSIONS = {}
-MANIFEST_CHARM_VERSIONS |= OPENSTACK_SERVICES_K8S
-MANIFEST_CHARM_VERSIONS |= OVN_SERVICES_K8S
-MANIFEST_CHARM_VERSIONS |= MYSQL_SERVICES_K8S
-MANIFEST_CHARM_VERSIONS |= MISC_SERVICES_K8S
-MANIFEST_CHARM_VERSIONS |= MACHINE_SERVICES
-MANIFEST_CHARM_VERSIONS |= {"mysql-router": MYSQL_CHANNEL}
-MANIFEST_CHARM_VERSIONS.pop("traefik-public")
+MANIFEST_CHARM_VERSIONS |= K8S_CHARMS
+MANIFEST_CHARM_VERSIONS |= MACHINE_CHARMS
 
 
 # <TF plan>: <TF Plan dir>
@@ -131,7 +163,7 @@ Example:
 {
     "openstack-plan": {
         "charms": {
-            "keystone": {
+            "keystone-k8s": {
                 "channel": "keystone-channel",
                 "revision": "keystone-revision",
                 "config": "keystone-config"
@@ -155,26 +187,20 @@ Example:
     }
 }
 """
-K8S_CHARMS = {}
-K8S_CHARMS |= OPENSTACK_SERVICES_K8S
-K8S_CHARMS |= OVN_SERVICES_K8S
-K8S_CHARMS |= MYSQL_SERVICES_K8S
-K8S_CHARMS |= MISC_SERVICES_K8S
 DEPLOY_OPENSTACK_TFVAR_MAP = {
     "charms": {
-        svc: {
-            "channel": f"{svc}-channel",
-            "revision": f"{svc}-revision",
-            "config": f"{svc}-config",
+        charm: {
+            "channel": f"{charm.removesuffix('-k8s')}-channel",
+            "revision": f"{charm.removesuffix('-k8s')}-revision",
+            "config": f"{charm.removesuffix('-k8s')}-config",
         }
-        for svc, channel in K8S_CHARMS.items()
+        for charm, channel in K8S_CHARMS.items()
     }
 }
-DEPLOY_OPENSTACK_TFVAR_MAP.get("charms").pop("traefik-public")
-DEPLOY_OPENSTACK_TFVAR_MAP["charms"]["mysql-router"] = {
-    "channel": "mysql-router-channel",
-    "revision": "mysql-router-revision",
-    "config": "mysql-router-config",
+DEPLOY_OPENSTACK_TFVAR_MAP["charms"]["self-signed-certificates"] = {
+    "channel": "certificate-authority-channel",
+    "revision": "certificate-authority-revision",
+    "config": "certificate-authority-config",
 }
 
 DEPLOY_MICROK8S_TFVAR_MAP = {

--- a/sunbeam-python/tests/unit/sunbeam/jobs/test_manifest.py
+++ b/sunbeam-python/tests/unit/sunbeam/jobs/test_manifest.py
@@ -31,12 +31,12 @@ juju:
   bootstrap_args:
     - --agent-version=3.2.4
 charms:
-  keystone:
+  keystone-k8s:
     channel: 2023.1/stable
     revision: 234
     config:
       debug: True
-  glance:
+  glance-k8s:
     channel: 2023.1/stable
     revision: 134
 terraform:
@@ -48,7 +48,7 @@ terraform:
 
 malformed_test_manifest = """
 charms:
-  keystone:
+  keystone-k8s:
     channel: 2023.1/stable
     revision: 234
     conf
@@ -56,7 +56,7 @@ charms:
 
 test_manifest_invalid_values = """
 charms:
-  keystone:
+  keystone-k8s:
     channel: 2023.1/stable
     revision: 234
     # Config value should be dictionary but provided str
@@ -65,7 +65,7 @@ charms:
 
 test_manifest_incorrect_terraform_key = """
 charms:
-  keystone:
+  keystone-k8s:
     channel: 2023.1/stable
     revision: 234
     config:
@@ -111,7 +111,7 @@ class TestManifest:
         manifest_file = tmpdir.mkdir("manifests").join("test_manifest.yaml")
         manifest_file.write(test_manifest)
         manifest_obj = manifest.Manifest.load(cclient, manifest_file)
-        ks_manifest = manifest_obj.charms.get("keystone")
+        ks_manifest = manifest_obj.charms.get("keystone-k8s")
         assert ks_manifest.channel == "2023.1/stable"
         assert ks_manifest.revision == 234
         assert ks_manifest.config == {"debug": True}
@@ -133,13 +133,13 @@ class TestManifest:
         )
 
         # Check updates from manifest file
-        ks_manifest = manifest_obj.charms.get("keystone")
+        ks_manifest = manifest_obj.charms.get("keystone-k8s")
         assert ks_manifest.channel == "2023.1/stable"
         assert ks_manifest.revision == 234
         assert ks_manifest.config == {"debug": True}
 
         # Check default ones
-        nova_manifest = manifest_obj.charms.get("nova")
+        nova_manifest = manifest_obj.charms.get("nova-k8s")
         assert nova_manifest.channel == OPENSTACK_CHANNEL
         assert nova_manifest.revision is None
         assert nova_manifest.config is None
@@ -148,13 +148,13 @@ class TestManifest:
         mocker.patch.object(manifest, "Snap", return_value=snap)
         cclient.cluster.get_latest_manifest.return_value = {"data": test_manifest}
         manifest_obj = manifest.Manifest.load_latest_from_clusterdb(cclient)
-        ks_manifest = manifest_obj.charms.get("keystone")
+        ks_manifest = manifest_obj.charms.get("keystone-k8s")
         assert ks_manifest.channel == "2023.1/stable"
         assert ks_manifest.revision == 234
         assert ks_manifest.config == {"debug": True}
 
         # Assert defaults does not exist
-        assert "nova" not in manifest_obj.charms.keys()
+        assert "nova-k8s" not in manifest_obj.charms.keys()
 
     def test_load_latest_from_clusterdb_on_default(
         self, mocker, snap, cclient, pluginmanager
@@ -164,13 +164,13 @@ class TestManifest:
         manifest_obj = manifest.Manifest.load_latest_from_clusterdb(
             cclient, include_defaults=True
         )
-        ks_manifest = manifest_obj.charms.get("keystone")
+        ks_manifest = manifest_obj.charms.get("keystone-k8s")
         assert ks_manifest.channel == "2023.1/stable"
         assert ks_manifest.revision == 234
         assert ks_manifest.config == {"debug": True}
 
         # Check default ones
-        nova_manifest = manifest_obj.charms.get("nova")
+        nova_manifest = manifest_obj.charms.get("nova-k8s")
         assert nova_manifest.channel == OPENSTACK_CHANNEL
         assert nova_manifest.revision is None
         assert nova_manifest.config is None
@@ -178,7 +178,7 @@ class TestManifest:
     def test_get_default_manifest(self, mocker, snap, cclient, pluginmanager):
         mocker.patch.object(manifest, "Snap", return_value=snap)
         default_manifest = manifest.Manifest.get_default_manifest(cclient)
-        nova_manifest = default_manifest.charms.get("nova")
+        nova_manifest = default_manifest.charms.get("nova-k8s")
         assert nova_manifest.channel == OPENSTACK_CHANNEL
         assert nova_manifest.revision is None
         assert nova_manifest.config is None

--- a/sunbeam-python/tests/unit/sunbeam/jobs/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/jobs/test_steps.py
@@ -88,6 +88,22 @@ class TestDeployMachineApplicationStep:
         jhelper.get_application.assert_called_once()
         assert result.result_type == ResultType.SKIPPED
 
+    def test_is_skip_application_refresh(self, cclient, jhelper):
+        step = DeployMachineApplicationStep(
+            cclient,
+            manifest,
+            jhelper,
+            "tfconfig",
+            "app1",
+            "model1",
+            "fake-plan",
+            refresh=True,
+        )
+        result = step.is_skip()
+
+        jhelper.get_application.assert_not_called()
+        assert result.result_type == ResultType.COMPLETED
+
     def test_run_pristine_installation(self, cclient, jhelper, manifest):
         jhelper.get_application.side_effect = ApplicationNotFoundException("not found")
 


### PR DESCRIPTION
* Use manifest for refresh intra channel updates
* Refresh the apps in openstack and controller only when channel is specified in manifest (including default values) and no revision is specified. This will take care of app refresh for new revisions on the same channel. The logic to check if there is any latest revision on the channel is removed since the juju refresh should take care of the logic.
* Add Reapply terraform plan for Control plane.
* Add flag refresh to DeployMachineApplication so that the terraform plan can be reapplied when refresh is true. This covers terraform plans for microk8s, microceph. sunbeam-machine.
* Use ReapplyHypervisorTerraformPlan for openstack-hypervisor.
* Add all the above plans to the list of plans to execute on refresh
* For the plugins, do not apply any terraform plan if the plan is part of sunbeam-terraform as the control plane refresh should take care.
* Do not apply terraform plans if there is no change in current terraform vars and updated terraform vars.