### PR TITLE
Update observability plugin to deploy grafana-agent-k8s as well.

### DIFF
--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent-k8s/main.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent-k8s/main.tf
@@ -1,0 +1,89 @@
+# Terraform manifest for deployment of Grafana Agent
+#
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "= 0.10.1"
+    }
+  }
+}
+
+data "terraform_remote_state" "cos" {
+  backend = var.cos-state-backend
+  config  = var.cos-state-config
+}
+
+resource "juju_application" "grafana-agent-k8s" {
+  name  = "grafana-agent-k8s"
+  model = var.model
+
+  # note that we need to make sure the "base" matches the environment we are
+  # deploying.
+  charm {
+    name     = "grafana-agent-k8s"
+    base     = "ubuntu@22.04"
+    channel  = var.grafana-agent-k8s-channel
+    revision = var.grafana-agent-k8s-revision
+  }
+
+  units  = 1
+  config = var.grafana-agent-k8s-config
+}
+
+# juju integrate grafana-agent-k8s:send-remote-write cos.prometheus-receive-remote-write
+resource "juju_integration" "grafana-agent-k8s-to-cos-prometheus" {
+  model = var.model
+
+  application {
+    name     = juju_application.grafana-agent-k8s.name
+    endpoint = "send-remote-write"
+  }
+
+  application {
+    offer_url = data.terraform_remote_state.cos.outputs.prometheus-receive-remote-write-offer-url
+  }
+}
+
+# juju integrate grafana-agent-k8s:logging-consumer cos.loki-logging
+resource "juju_integration" "grafana-agent-k8s-to-cos-loki" {
+  model = var.model
+
+  application {
+    name     = juju_application.grafana-agent-k8s.name
+    endpoint = "logging-consumer"
+  }
+
+  application {
+    offer_url = data.terraform_remote_state.cos.outputs.loki-logging-offer-url
+  }
+}
+
+# juju integrate grafana-agent-k8s:grafana_dashboard cos.grafana-dashboards
+resource "juju_integration" "grafana-agent-k8s-to-cos-grafana" {
+  model = var.model
+
+  application {
+    name     = juju_application.grafana-agent-k8s.name
+    endpoint = "grafana-dashboards-provider"
+  }
+
+  application {
+    offer_url = data.terraform_remote_state.cos.outputs.grafana-dashboard-offer-url
+  }
+}

--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent-k8s/variables.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent-k8s/variables.tf
@@ -1,0 +1,50 @@
+# Terraform manifest for deployment of Grafana Agent
+#
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "model" {
+  type        = string
+  default     = "openstack"
+  description = "Name of the model where the application is deployed"
+}
+
+variable "cos-state-backend" {
+  description = "Backend type used for cos state"
+  type        = string
+  default     = "http"
+}
+
+variable "cos-state-config" {
+  type = map(any)
+}
+
+variable "grafana-agent-k8s-channel" {
+  type        = string
+  default     = "latest/stable"
+  description = "Operator channel for grafana-agent-k8s deployment"
+}
+
+variable "grafana-agent-k8s-revision" {
+  type        = number
+  default     = null
+  description = "Operator channel revision for grafana-agent-k8s deployment"
+}
+
+variable "grafana-agent-k8s-config" {
+  type        = map(string)
+  default     = {}
+  description = "Operator config for grafana-agent-k8s deployment"
+}

--- a/sunbeam-python/sunbeam/plugins/observability/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/observability/plugin.py
@@ -350,10 +350,14 @@ class DeployGrafanaAgentK8sStep(BaseStep, JujuStepHelper):
 
         LOG.debug("Application monitored for readiness: %s", app)
         try:
+            # Note that grafana agent k8s will be blocked first if there's not
+            # workload "requires" relations. We will add them later in the
+            # steps.
             run_sync(
                 self.jhelper.wait_application_ready(
                     app,
                     self.model,
+                    accepted_status=["active", "blocked"],
                     timeout=OBSERVABILITY_DEPLOY_TIMEOUT,
                 )
             )

--- a/sunbeam-python/sunbeam/plugins/observability/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/observability/plugin.py
@@ -74,6 +74,7 @@ console = Console()
 OBSERVABILITY_MODEL = "observability"
 OBSERVABILITY_DEPLOY_TIMEOUT = 1200  # 20 minutes
 CONTROLLER_MODEL = CONTROLLER_MODEL.split("/")[-1]
+GRAFANA_AGENT_K8S_CHANNEL = "latest/stable"
 
 
 class FillObservabilityOffersStep(BaseStep):
@@ -334,7 +335,7 @@ class DeployGrafanaAgentK8sStep(BaseStep, JujuStepHelper):
         tfvars = {
             "cos-state-backend": cos_backend,
             "cos-state-config": cos_backend_config,
-            "grafana-agent-k8s-channel": "latest/stable",
+            "grafana-agent-k8s-channel": GRAFANA_AGENT_K8S_CHANNEL,
             "model": self.model,
         }
         config.update(tfvars)
@@ -529,7 +530,7 @@ class RemoveGrafanaAgentK8sStep(BaseStep, JujuStepHelper):
         tfvars = {
             "cos-state-backend": cos_backend,
             "cos-state-config": cos_backend_config,
-            "grafana-agent-k8s-channel": "latest/stable",
+            "grafana-agent-k8s-channel": GRAFANA_AGENT_K8S_CHANNEL,
             "model": self.model,
         }
         config.update(tfvars)

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
@@ -282,12 +282,9 @@ class TestDeployGrafanaAgentK8sStep:
 
 class TestRemoveGrafanaAgentK8sStep:
     def test_run(self, cclient, jhelper, tfhelper, observabilityplugin):
-        step = observability_plugin.RemoveGrafanaAgentK8sStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
-        )
+        step = observability_plugin.RemoveGrafanaAgentK8sStep(jhelper, tfhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_application_gone.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
@@ -297,12 +294,9 @@ class TestRemoveGrafanaAgentK8sStep:
     ):
         tfhelper.destroy.side_effect = TerraformException("destroy failed...")
 
-        step = observability_plugin.RemoveGrafanaAgentK8sStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
-        )
+        step = observability_plugin.RemoveGrafanaAgentK8sStep(jhelper, tfhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_application_gone.assert_not_called()
         assert result.result_type == ResultType.FAILED
@@ -313,12 +307,9 @@ class TestRemoveGrafanaAgentK8sStep:
     ):
         jhelper.wait_application_gone.side_effect = TimeoutException("timed out")
 
-        step = observability_plugin.RemoveGrafanaAgentK8sStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
-        )
+        step = observability_plugin.RemoveGrafanaAgentK8sStep(jhelper, tfhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_application_gone.assert_called_once()
         assert result.result_type == ResultType.FAILED


### PR DESCRIPTION
This PR add grafana-agent-k8s to the observability plugin.

- Add grafana-agent-k8s application
- Add relations to COS
  - grafana-agent-k8s:grafana-dashboards-provider                   grafana-dashboards:grafana-dashboard
  - loki-logging:logging                                                                 grafana-agent-k8s:logging-consumer
  - prometheus-receive-remote-write:receive-remote-write         grafana-agent-k8s:send-remote-write 

Currently (as of grafana-agent-k8s revision 51), if there're no workloads (which we don't in this PR) on grafana-agent-k8s, it will be in the blocked status. The workloads can be openstack-exporter-k8s / tempest-k8s (in the near future)