### PR TITLE
Change juju terraform provider verison (in plugins) to 0.10.1

### DIFF
--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-cos/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.8.0"
+      version = "= 0.10.1"
     }
   }
 }
@@ -45,7 +45,7 @@ resource "juju_application" "traefik" {
   charm {
     name    = "traefik-k8s"
     channel = var.cos-channel
-    series  = "focal"
+    base    = "ubuntu@20.04"
   }
 
   units = var.ingress-scale
@@ -59,7 +59,7 @@ resource "juju_application" "alertmanager" {
   charm {
     name    = "alertmanager-k8s"
     channel = var.cos-channel
-    series  = "focal"
+    base    = "ubuntu@20.04"
   }
 
   units = var.alertmanager-scale
@@ -73,7 +73,7 @@ resource "juju_application" "prometheus" {
   charm {
     name    = "prometheus-k8s"
     channel = var.cos-channel
-    series  = "focal"
+    base    = "ubuntu@20.04"
   }
 
   units = var.prometheus-scale
@@ -87,7 +87,7 @@ resource "juju_application" "grafana" {
   charm {
     name    = "grafana-k8s"
     channel = var.cos-channel
-    series  = "focal"
+    base    = "ubuntu@20.04"
   }
 
   units = var.grafana-scale
@@ -101,7 +101,7 @@ resource "juju_application" "catalogue" {
   charm {
     name    = "catalogue-k8s"
     channel = var.cos-channel
-    series  = "focal"
+    base    = "ubuntu@20.04"
   }
 
   config = {
@@ -121,7 +121,7 @@ resource "juju_application" "loki" {
   charm {
     name    = "loki-k8s"
     channel = var.cos-channel
-    series  = "focal"
+    base    = "ubuntu@20.04"
   }
 
   units = var.loki-scale
@@ -129,7 +129,7 @@ resource "juju_application" "loki" {
 
 # juju integrate traefik prometheus
 resource "juju_integration" "traefik-to-prometheus" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.traefik.name
@@ -144,7 +144,7 @@ resource "juju_integration" "traefik-to-prometheus" {
 
 # juju integrate traefik loki
 resource "juju_integration" "traefik-to-loki" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.traefik.name
@@ -159,7 +159,7 @@ resource "juju_integration" "traefik-to-loki" {
 
 # juju integrate traefik grafana
 resource "juju_integration" "traefik-to-grafana" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.traefik.name
@@ -174,7 +174,7 @@ resource "juju_integration" "traefik-to-grafana" {
 
 # juju integrate traefik alertmanager
 resource "juju_integration" "traefik-to-alertmanager" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.traefik.name
@@ -189,7 +189,7 @@ resource "juju_integration" "traefik-to-alertmanager" {
 
 # juju integrate prometheus alertmanager
 resource "juju_integration" "prometheus-to-alertmanager" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.prometheus.name
@@ -204,7 +204,7 @@ resource "juju_integration" "prometheus-to-alertmanager" {
 
 # juju integrate grafana prometheus on interface grafana-source
 resource "juju_integration" "grafana-to-prometheus-on-grafana-source" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.grafana.name
@@ -219,7 +219,7 @@ resource "juju_integration" "grafana-to-prometheus-on-grafana-source" {
 
 # juju integrate grafana loki on interface grafana-source
 resource "juju_integration" "grafana-to-loki-on-grafana-source" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.grafana.name
@@ -234,7 +234,7 @@ resource "juju_integration" "grafana-to-loki-on-grafana-source" {
 
 # juju integrate grafana alertmanager on interface grafana-source
 resource "juju_integration" "grafana-to-alertmanager-on-grafana-source" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.grafana.name
@@ -249,7 +249,7 @@ resource "juju_integration" "grafana-to-alertmanager-on-grafana-source" {
 
 # juju integrate loki alertmanager
 resource "juju_integration" "loki-to-alertmanager" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.loki.name
@@ -266,7 +266,7 @@ resource "juju_integration" "loki-to-alertmanager" {
 
 # juju integrate prometheus traefik on interface metrics-endpoint
 resource "juju_integration" "prometheus-to-traefik-on-metrics-endpoint" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.prometheus.name
@@ -281,7 +281,7 @@ resource "juju_integration" "prometheus-to-traefik-on-metrics-endpoint" {
 
 # juju integrate prometheus alertmanager on interface metrics-endpoint
 resource "juju_integration" "prometheus-to-alertmanager-on-metrics-endpoint" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.prometheus.name
@@ -296,7 +296,7 @@ resource "juju_integration" "prometheus-to-alertmanager-on-metrics-endpoint" {
 
 # juju integrate prometheus loki on interface metrics-endpoint
 resource "juju_integration" "prometheus-to-loki-on-metrics-endpoint" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.prometheus.name
@@ -311,7 +311,7 @@ resource "juju_integration" "prometheus-to-loki-on-metrics-endpoint" {
 
 # juju integrate prometheus grafana on interface metrics-endpoint
 resource "juju_integration" "prometheus-to-grafana-on-metrics-endpoint" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.prometheus.name
@@ -326,7 +326,7 @@ resource "juju_integration" "prometheus-to-grafana-on-metrics-endpoint" {
 
 # juju integrate grafana to loki on interface grafana-dashboard
 resource "juju_integration" "grafana-to-loki-on-grafana-dashboard" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.grafana.name
@@ -341,7 +341,7 @@ resource "juju_integration" "grafana-to-loki-on-grafana-dashboard" {
 
 # juju integrate grafana to prometheus on interface grafana-dashboard
 resource "juju_integration" "grafana-to-prometheus-on-grafana-dashboard" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.grafana.name
@@ -356,7 +356,7 @@ resource "juju_integration" "grafana-to-prometheus-on-grafana-dashboard" {
 
 # juju integrate grafana to alertmanager on interface grafana-dashboard
 resource "juju_integration" "grafana-to-alertmanager-on-grafana-dashboard" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.grafana.name
@@ -373,7 +373,7 @@ resource "juju_integration" "grafana-to-alertmanager-on-grafana-dashboard" {
 
 # juju integrate catalogue to traefik
 resource "juju_integration" "catalogue-to-traefik" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.catalogue.name
@@ -388,7 +388,7 @@ resource "juju_integration" "catalogue-to-traefik" {
 
 # juju integrate catalogue to grafana
 resource "juju_integration" "catalogue-to-grafana" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.catalogue.name
@@ -403,7 +403,7 @@ resource "juju_integration" "catalogue-to-grafana" {
 
 # juju integrate catalogue to prometheus
 resource "juju_integration" "catalogue-to-prometheus" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.catalogue.name
@@ -418,7 +418,7 @@ resource "juju_integration" "catalogue-to-prometheus" {
 
 # juju integrate catalogue to alertmanager
 resource "juju_integration" "catalogue-to-alertmanager" {
-  model    = var.model
+  model = var.model
 
   application {
     name     = juju_application.catalogue.name

--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent/main.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent/main.tf
@@ -19,32 +19,32 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.8.0"
+      version = "= 0.10.1"
     }
   }
 }
 
 data "terraform_remote_state" "cos" {
   backend = var.cos-state-backend
-  config = var.cos-state-config
+  config  = var.cos-state-config
 }
 
 resource "juju_application" "grafana-agent" {
-  name = "grafana-agent"
+  name  = "grafana-agent"
   trust = false
   model = var.principal-application-model
   units = 0
 
   charm {
-    name = "grafana-agent"
+    name    = "grafana-agent"
     channel = var.grafana-agent-channel
-    series = "jammy"
+    base    = "ubuntu@22.04"
   }
 }
 
 # juju integrate <principal-application>:cos-agent grafana-agent:cos-agent
 resource "juju_integration" "principal-application-to-grafana-agent" {
-  model    = var.principal-application-model
+  model = var.principal-application-model
 
   application {
     name     = juju_application.grafana-agent.name
@@ -62,7 +62,7 @@ resource "juju_integration" "grafana-agent-to-cos-prometheus" {
   model = var.principal-application-model
 
   application {
-    name     = juju_application.grafana-agent.name
+    name = juju_application.grafana-agent.name
   }
 
   application {
@@ -75,7 +75,7 @@ resource "juju_integration" "grafana-agent-to-cos-loki" {
   model = var.principal-application-model
 
   application {
-    name     = juju_application.grafana-agent.name
+    name = juju_application.grafana-agent.name
   }
 
   application {
@@ -88,7 +88,7 @@ resource "juju_integration" "grafana-agent-to-cos-grafana" {
   model = var.principal-application-model
 
   application {
-    name     = juju_application.grafana-agent.name
+    name = juju_application.grafana-agent.name
   }
 
   application {

--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent/variables.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent/variables.tf
@@ -21,7 +21,7 @@ variable "principal-application" {
 
 variable "principal-application-model" {
   description = "Name of the model principal application is deployed in"
-  default = "controller"
+  default     = "controller"
 }
 
 variable "grafana-agent-channel" {
@@ -33,8 +33,8 @@ variable "grafana-agent-channel" {
 
 variable "cos-state-backend" {
   description = "Backend type used for cos state"
-  type = string
-  default = "http"
+  type        = string
+  default     = "http"
 }
 
 variable "cos-state-config" {

--- a/sunbeam-python/sunbeam/plugins/pro/etc/deploy-pro/main.tf
+++ b/sunbeam-python/sunbeam/plugins/pro/etc/deploy-pro/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.8.0"
+      version = "= 0.10.1"
     }
   }
 
@@ -39,7 +39,7 @@ resource "juju_application" "ubuntu_pro" {
   charm {
     name    = "ubuntu-advantage"
     channel = var.ubuntu-advantage-channel
-    series  = "jammy"
+    base    = "ubuntu@22.04"
   }
 
   config = {


### PR DESCRIPTION
Change juju terraform provider version to `0.10.1` in all the terraform plans in the plugins. Use `base` instead of deprecated `series` for charm resource. Also ran `terraform fmt` to write the terraform plans to a canonical format.