### PR TITLE
MAAS: implement cluster bootstrap

### DIFF
--- a/sunbeam-python/requirements.txt
+++ b/sunbeam-python/requirements.txt
@@ -41,3 +41,5 @@ macaroonbakery!=1.3.3
 
 # maas
 python-libmaas
+
+pydantic

--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -28,7 +28,8 @@ import pexpect
 import pwgen
 import yaml
 from packaging import version
-from pyroute2 import Console
+from rich.console import Console
+from rich.status import Status
 from snaphelpers import Snap
 
 from sunbeam import utils
@@ -82,9 +83,7 @@ class JujuStepHelper:
 
         LOG.debug(f'Running command {" ".join(cmd)}')
         process = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        LOG.debug(
-            f"Command finished. stdout={process.stdout}, " "stderr={process.stderr}"
-        )
+        LOG.debug(f"Command finished. stdout={process.stdout}, stderr={process.stderr}")
 
         return json.loads(process.stdout.strip())
 
@@ -100,10 +99,13 @@ class JujuStepHelper:
             LOG.debug(f"Model {model_name} not found")
             return False
 
-    def get_clouds(self, cloud_type: str) -> list:
+    def get_clouds(self, cloud_type: str, local: bool = False) -> list:
         """Get clouds based on cloud type"""
         clouds = []
-        clouds_from_juju_cmd = self._juju_cmd("clouds")
+        cmd = ["clouds"]
+        if local:
+            cmd.append("--client")
+        clouds_from_juju_cmd = self._juju_cmd(*cmd)
         LOG.debug(f"Available clouds in juju are {clouds_from_juju_cmd.keys()}")
 
         for name, details in clouds_from_juju_cmd.items():
@@ -113,6 +115,17 @@ class JujuStepHelper:
         LOG.debug(f"There are {len(clouds)} {cloud_type} clouds available: {clouds}")
 
         return clouds
+
+    def get_credentials(
+        self, cloud: str | None = None, local: bool = False
+    ) -> dict[str, dict]:
+        """Get credentials."""
+        cmd = ["credentials"]
+        if local:
+            cmd.append("--client")
+        if cloud:
+            cmd.append(cloud)
+        return self._juju_cmd(*cmd)
 
     def get_controllers(self, clouds: list) -> list:
         """Get controllers hosted on given clouds"""
@@ -142,24 +155,18 @@ class JujuStepHelper:
             LOG.debug(e)
             raise ControllerNotFoundException() from e
 
-    def add_cloud(self, cloud_type: str, cloud_name: str) -> bool:
-        """Add cloud of type cloud_type."""
-        if cloud_type != "manual":
+    def add_cloud(self, name: str, cloud: dict) -> bool:
+        """Add cloud to client clouds."""
+        if cloud["clouds"][name]["type"] not in ("manual", "maas"):
             return False
 
-        cloud_yaml = {"clouds": {}}
-        cloud_yaml["clouds"][cloud_name] = {
-            "type": "manual",
-            "endpoint": utils.get_local_ip_by_default_route(),
-        }
-
         with tempfile.NamedTemporaryFile() as temp:
-            temp.write(yaml.dump(cloud_yaml).encode("utf-8"))
+            temp.write(yaml.dump(cloud).encode("utf-8"))
             temp.flush()
             cmd = [
                 self._get_juju_binary(),
                 "add-cloud",
-                cloud_name,
+                name,
                 "--file",
                 temp.name,
                 "--client",
@@ -171,6 +178,25 @@ class JujuStepHelper:
             )
 
         return True
+
+    def add_credential(self, cloud: str, credential: dict):
+        """Add credential to client credentials."""
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(yaml.dump(credential).encode("utf-8"))
+            temp.flush()
+            cmd = [
+                self._get_juju_binary(),
+                "add-credential",
+                cloud,
+                "--file",
+                temp.name,
+                "--client",
+            ]
+            LOG.debug(f'Running command {" ".join(cmd)}')
+            process = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            LOG.debug(
+                f"Command finished. stdout={process.stdout}, stderr={process.stderr}"
+            )
 
     def revision_update_needed(
         self, application_name: str, model: str, status: dict | None = None
@@ -258,6 +284,102 @@ def bootstrap_questions():
     }
 
 
+class AddCloudJujuStep(BaseStep, JujuStepHelper):
+    """Add cloud definition to juju client."""
+
+    def __init__(self, cloud: str, definition: dict):
+        super().__init__("Add Cloud", "Adding cloud to Juju client")
+
+        self.cloud = cloud
+        self.definition = definition
+
+    def is_skip(self, status: Optional["Status"] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                 ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        cloud_type = self.definition["clouds"][self.cloud]["type"]
+        try:
+            juju_clouds = self.get_clouds(cloud_type, local=True)
+        except subprocess.CalledProcessError as e:
+            LOG.exception(
+                "Error determining whether to skip the bootstrap "
+                "process. Defaulting to not skip."
+            )
+            LOG.warning(e.stderr)
+            return Result(ResultType.FAILED, str(e))
+        if self.cloud in juju_clouds:
+            return Result(ResultType.SKIPPED)
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Optional["Status"] = None) -> Result:
+        """Run the step to completion.
+
+        Invoked when the step is run and returns a ResultType to indicate
+
+        :return:
+        """
+        try:
+            result = self.add_cloud(self.cloud, self.definition)
+            if not result:
+                return Result(ResultType.FAILED, "Unable to create cloud")
+        except subprocess.CalledProcessError as e:
+            LOG.exception("Error adding cloud to Juju")
+            LOG.warning(e.stderr)
+            return Result(ResultType.FAILED, str(e))
+        return Result(ResultType.COMPLETED)
+
+
+class AddCredentialsJujuStep(BaseStep, JujuStepHelper):
+    """Add credentials definition to juju client."""
+
+    def __init__(self, cloud: str, credentials: str, definition: dict):
+        super().__init__("Add Credentials", "Adding credentials to Juju client")
+
+        self.cloud = cloud
+        self.credentials_name = credentials
+        self.definition = definition
+
+    def is_skip(self, status: Optional["Status"] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                 ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        try:
+            credentials = self.get_credentials(self.cloud, local=True)
+        except subprocess.CalledProcessError as e:
+            LOG.exception(
+                "Error determining whether to skip the bootstrap "
+                "process. Defaulting to not skip."
+            )
+            LOG.warning(e.stderr)
+            return Result(ResultType.FAILED, str(e))
+        client_creds = credentials.get("client-credentials", {})
+        cloud_credentials = client_creds.get(self.cloud, {}).get(
+            "cloud-credentials", {}
+        )
+        if not cloud_credentials or self.credentials_name not in cloud_credentials:
+            return Result(ResultType.COMPLETED)
+        return Result(ResultType.SKIPPED)
+
+    def run(self, status: Optional["Status"] = None) -> Result:
+        """Run the step to completion.
+
+        Invoked when the step is run and returns a ResultType to indicate
+
+        :return:
+        """
+        try:
+            self.add_credential(self.cloud, self.definition)
+        except subprocess.CalledProcessError as e:
+            LOG.exception("Error adding credentials to Juju")
+            LOG.warning(e.stderr)
+            return Result(ResultType.FAILED, str(e))
+        return Result(ResultType.COMPLETED)
+
+
 class BootstrapJujuStep(BaseStep, JujuStepHelper):
     """Bootstraps the Juju controller."""
 
@@ -265,17 +387,19 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
 
     def __init__(
         self,
-        cloud_name: str,
+        cloud: str,
         cloud_type: str,
         controller: str,
+        bootstrap_args: list[str] | None = None,
         preseed_file: Optional[Path] = None,
         accept_defaults: bool = False,
     ):
         super().__init__("Bootstrap Juju", "Bootstrapping Juju onto machine")
 
-        self.cloud = cloud_name
+        self.cloud = cloud
         self.cloud_type = cloud_type
         self.controller = controller
+        self.bootstrap_args = bootstrap_args or []
         self.preseed_file = preseed_file
         self.accept_defaults = accept_defaults
         self.juju_clouds = []
@@ -328,13 +452,7 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
                  ResultType.COMPLETED or ResultType.FAILED otherwise
         """
         try:
-            self.get_controller(self.controller)
-            return Result(ResultType.SKIPPED)
-        except ControllerNotFoundException as e:
-            LOG.debug(str(e))
-        try:
             self.juju_clouds = self.get_clouds(self.cloud_type)
-            return Result(ResultType.COMPLETED)
         except subprocess.CalledProcessError as e:
             LOG.exception(
                 "Error determining whether to skip the bootstrap "
@@ -342,6 +460,17 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
             )
             LOG.warning(e.stderr)
             return Result(ResultType.FAILED, str(e))
+        if self.cloud not in self.juju_clouds:
+            return Result(
+                ResultType.FAILED,
+                f"Cloud {self.cloud} of type {self.cloud_type!r} not found.",
+            )
+        try:
+            self.get_controller(self.controller)
+            return Result(ResultType.SKIPPED)
+        except ControllerNotFoundException as e:
+            LOG.debug(str(e))
+        return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional["Status"] = None) -> Result:
         """Run the step to completion.
@@ -351,18 +480,19 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
         :return:
         """
         try:
-            if self.cloud not in self.juju_clouds:
-                result = self.add_cloud(self.cloud_type, self.cloud)
-                if not result:
-                    return Result(ResultType.FAILED, "Not able to create cloud")
-
             cmd = [
                 self._get_juju_binary(),
                 "bootstrap",
-                self.cloud,
-                self.controller,
             ]
-            LOG.debug(f'Running command {" ".join(cmd)}')
+            cmd.extend(self.bootstrap_args)
+            cmd.extend([self.cloud, self.controller])
+            hidden_cmd = []
+            for arg in cmd:
+                if "admin-secret" in arg:
+                    option, _ = arg.split("=")
+                    arg = "=".join((option, "********"))
+                hidden_cmd.append(arg)
+            LOG.debug(f'Running command {" ".join(hidden_cmd)}')
             process = subprocess.run(cmd, capture_output=True, text=True, check=True)
             LOG.debug(
                 f"Command finished. stdout={process.stdout}, stderr={process.stderr}"
@@ -373,6 +503,52 @@ class BootstrapJujuStep(BaseStep, JujuStepHelper):
             LOG.exception("Error bootstrapping Juju")
             LOG.warning(e.stderr)
             return Result(ResultType.FAILED, str(e))
+
+
+class ScaleJujuStep(BaseStep, JujuStepHelper):
+    """Enable Juju HA."""
+
+    def __init__(
+        self, controller: str, n: int = 3, extra_args: list[str] | None = None
+    ):
+        super().__init__("Juju HA", "Enable Juju High Availability")
+        self.controller = controller
+        self.n = n
+        self.extra_args = extra_args or []
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not."""
+
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Status | None = None) -> Result:
+        """Enable Juju HA."""
+        cmd = [
+            self._get_juju_binary(),
+            "enable-ha",
+            "-n",
+            str(self.n),
+            *self.extra_args,
+        ]
+        LOG.debug(f'Running command {" ".join(cmd)}')
+        process = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        LOG.debug(f"Command finished. stdout={process.stdout}, stderr={process.stderr}")
+        cmd = [
+            self._get_juju_binary(),
+            "wait-for",
+            "application",
+            "-m",
+            "controller",
+            "controller",
+            "--timeout",
+            "15m",
+        ]
+        self.update_status(status, "scaling controller")
+        LOG.debug("Waiting for HA to be enabled")
+        LOG.debug(f'Running command {" ".join(cmd)}')
+        process = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        LOG.debug(f"Command finished. stdout={process.stdout}, stderr={process.stderr}")
+        return Result(ResultType.COMPLETED)
 
 
 class CreateJujuUserStep(BaseStep, JujuStepHelper):

--- a/sunbeam-python/sunbeam/commands/utils.py
+++ b/sunbeam-python/sunbeam/commands/utils.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import logging
+import secrets
+import string
 
 import click
 from rich.console import Console
@@ -42,3 +44,9 @@ def juju_login() -> None:
     run_plan(plan, console)
 
     console.print("Juju re-login complete.")
+
+
+def random_string(length: int) -> str:
+    """Utility function to generate secure random string."""
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for i in range(length))

--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -33,6 +33,7 @@ LOG = logging.getLogger(__name__)
 RAM_16_GB_IN_KB = 16 * 1024 * 1024
 RAM_32_GB_IN_KB = 32 * 1024 * 1024
 RAM_32_GB_IN_MB = 32 * 1000
+RAM_4_GB_IN_MB = 4 * 1000
 
 # Formatting related constants
 FORMAT_TABLE = "table"

--- a/sunbeam-python/sunbeam/provider/base.py
+++ b/sunbeam-python/sunbeam/provider/base.py
@@ -14,9 +14,12 @@
 # limitations under the License.
 
 import abc
+from typing import Tuple, Type
 
 import click
 from rich.console import Console
+
+from sunbeam.commands.deployment import Deployment
 
 console = Console()
 
@@ -43,4 +46,8 @@ class ProviderBase(abc.ABC):
 
         Only called when the provider is enabled.
         """
+        pass
+
+    def deployment_type(self) -> Tuple[str, Type[Deployment]] | None:
+        """Return a deployment type for the provider."""
         pass

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_juju.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import subprocess
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -259,3 +260,170 @@ class TestJujuLoginStep:
         ):
             result = step.run()
         assert result.result_type == ResultType.FAILED
+
+
+class TestAddCloudJujuStep:
+    def test_is_skip(self):
+        cloud_name = "my-cloud"
+        cloud_definition = {
+            "clouds": {
+                cloud_name: {
+                    "type": "my-cloud-type",
+                    # Add other required fields for the cloud definition
+                }
+            }
+        }
+        step = juju.AddCloudJujuStep(cloud_name, cloud_definition)
+
+        with patch.object(step, "get_clouds") as mock_get_clouds:
+            mock_get_clouds.return_value = [cloud_name]
+            result = step.is_skip()
+
+        mock_get_clouds.assert_called_once_with("my-cloud-type", local=True)
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_is_skip_when_exception_raised(self):
+        cloud_name = "my-cloud"
+        cloud_definition = {
+            "clouds": {
+                "my-cloud": {
+                    "type": "my-cloud-type",
+                    # Add other required fields for the cloud definition
+                }
+            }
+        }
+        step = juju.AddCloudJujuStep(cloud_name, cloud_definition)
+
+        with patch.object(step, "get_clouds") as mock_get_clouds:
+            mock_get_clouds.side_effect = subprocess.CalledProcessError(
+                cmd="juju clouds", returncode=1, output="Error output"
+            )
+
+            result = step.is_skip()
+
+        mock_get_clouds.assert_called_once_with("my-cloud-type", local=True)
+        assert result.result_type == ResultType.FAILED
+
+    def test_run(self):
+        cloud_name = "my-cloud"
+        cloud_definition = {
+            "clouds": {
+                "my-cloud": {
+                    "type": "my-cloud-type",
+                    # Add other required fields for the cloud definition
+                }
+            }
+        }
+        step = juju.AddCloudJujuStep(cloud_name, cloud_definition)
+
+        with patch.object(step, "add_cloud") as mock_add_cloud:
+            mock_add_cloud.return_value = True
+
+            result = step.run()
+
+        mock_add_cloud.assert_called_once_with("my-cloud", cloud_definition)
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_when_exception_raised(self):
+        cloud_name = "my-cloud"
+        cloud_definition = {
+            "clouds": {
+                "my-cloud": {
+                    "type": "my-cloud-type",
+                    # Add other required fields for the cloud definition
+                }
+            }
+        }
+        step = juju.AddCloudJujuStep(cloud_name, cloud_definition)
+
+        with patch.object(step, "add_cloud") as mock_add_cloud:
+            mock_add_cloud.side_effect = subprocess.CalledProcessError(
+                cmd="juju add-cloud", returncode=1, output="Error output"
+            )
+
+            result = step.run()
+
+        mock_add_cloud.assert_called_once_with("my-cloud", cloud_definition)
+        assert result.result_type == ResultType.FAILED
+
+
+class TestAddCredentialsJujuStep:
+    def test_is_skip(self, mocker):
+        cloud = "my-cloud"
+        credentials = "my-credentials"
+        definition = {"key": "value"}
+
+        step = juju.AddCredentialsJujuStep(cloud, credentials, definition)
+
+        mocker.patch.object(step, "get_credentials", return_value={})
+        result = step.is_skip()
+
+        step.get_credentials.assert_called_once_with(cloud, local=True)
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip_when_credentials_exist(self, mocker):
+        cloud = "my-cloud"
+        credentials = "my-credentials"
+        definition = {"key": "value"}
+
+        step = juju.AddCredentialsJujuStep(cloud, credentials, definition)
+
+        mocker.patch.object(
+            step,
+            "get_credentials",
+            return_value={
+                "client-credentials": {
+                    cloud: {"cloud-credentials": {credentials: {"key": "value"}}}
+                }
+            },
+        )
+        result = step.is_skip()
+
+        step.get_credentials.assert_called_once_with(cloud, local=True)
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_run(self, mocker):
+        cloud = "my-cloud"
+        credentials = "my-credentials"
+        definition = {"key": "value"}
+
+        step = juju.AddCredentialsJujuStep(cloud, credentials, definition)
+
+        mocker.patch.object(step, "add_credential")
+        result = step.run()
+
+        step.add_credential.assert_called_once_with(cloud, definition)
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_failed(self, mocker):
+        cloud = "my-cloud"
+        credentials = "my-credentials"
+        definition = {"key": "value"}
+
+        step = juju.AddCredentialsJujuStep(cloud, credentials, definition)
+
+        mocker.patch.object(
+            step,
+            "add_credential",
+            side_effect=subprocess.CalledProcessError(1, "command"),
+        )
+        result = step.run()
+
+        step.add_credential.assert_called_once_with(cloud, definition)
+        assert result.result_type == ResultType.FAILED
+
+
+class TestScaleJujuStep:
+    def test_is_skip(self):
+        step = juju.ScaleJujuStep("controller", n=3, extra_args=["--arg1", "--arg2"])
+        result = step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+
+    @patch("subprocess.run")
+    def test_run(self, mock_run, mocker):
+        step = juju.ScaleJujuStep("controller", n=3, extra_args=["--arg1", "--arg2"])
+        mocker.patch.object(step, "_get_juju_binary", return_value="/juju-mock")
+        result = step.run()
+
+        assert mock_run.call_count == 2
+        assert result.result_type == ResultType.COMPLETED


### PR DESCRIPTION
Implement the `sunbeam cluster bootstrap` command when active deployment is MAAS.

This command will:
- Check for network mapping completeness
- Add a MAAS cloud to juju client, named as the deployment
- Add MAAS credentials for said cloud
- Bootstrap a controller, with a defined password for the admin user, controller name: deployment_name + "-controller"
- Scale the controller if enough machines are present in MAAS
- Save controller info locally (in deployment info)
- Deploy sunbeam-clusterd to controller machines

Model objects reworked as Pydantic Basemodel.

Draft until sunbeam-clusterd is published to 2023.2/edge
