### PR TITLE
Re-run `tox -e fmt` to address lint error due to the update of black>=24.1.0.

### DIFF
--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -327,9 +327,11 @@ def list(ctx: click.Context, format: str) -> None:
         for name, node in nodes.items():
             table.add_row(
                 name,
-                "[green]up[/green]"
-                if node.get("status") == "ONLINE"
-                else "[red]down[/red]",
+                (
+                    "[green]up[/green]"
+                    if node.get("status") == "ONLINE"
+                    else "[red]down[/red]"
+                ),
                 "x" if "control" in node.get("roles", []) else "",
                 "x" if "compute" in node.get("roles", []) else "",
                 "x" if "storage" in node.get("roles", []) else "",


### PR DESCRIPTION
`black` got new release 24.1.0 in late January 2024, and introduce some format rules. This PR applies the new format rules, and reformat the codebase.