### PR TITLE
[manifest] Support for upgrade-release

### DIFF
--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -221,6 +221,19 @@ class JujuStepHelper:
 
         return apps
 
+    def get_apps_filter_by_charms(self, model: str, charms: list) -> list:
+        """Return apps filtered by given charms.
+
+        Get all apps from the model and return only the apps deployed with
+        charms in the provided list.
+        """
+        deployed_all_apps = self.get_charm_deployed_versions(model)
+        return [
+            app_name
+            for app_name, (charm, channel, revision) in deployed_all_apps.items()
+            if charm in charms
+        ]
+
     def normalise_channel(self, channel: str) -> str:
         """Expand channel if it is using abbreviation.
 

--- a/sunbeam-python/sunbeam/commands/node.py
+++ b/sunbeam-python/sunbeam/commands/node.py
@@ -300,9 +300,11 @@ def list(ctx: click.Context, format: str) -> None:
         for name, node in nodes.items():
             table.add_row(
                 name,
-                "[green]up[/green]"
-                if node.get("status") == "ONLINE"
-                else "[red]down[/red]",
+                (
+                    "[green]up[/green]"
+                    if node.get("status") == "ONLINE"
+                    else "[red]down[/red]"
+                ),
                 "x" if "control" in node.get("roles", []) else "",
                 "x" if "compute" in node.get("roles", []) else "",
                 "x" if "storage" in node.get("roles", []) else "",

--- a/sunbeam-python/sunbeam/commands/upgrades/base.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/base.py
@@ -20,7 +20,6 @@ from rich.console import Console
 from rich.status import Status
 
 from sunbeam.clusterd.client import Client
-from sunbeam.commands.terraform import TerraformHelper
 from sunbeam.jobs.common import BaseStep, Result, ResultType, run_plan
 from sunbeam.jobs.juju import JujuHelper
 from sunbeam.jobs.manifest import Manifest
@@ -34,21 +33,15 @@ class UpgradePlugins(BaseStep):
     def __init__(
         self,
         client: Client,
-        jhelper: JujuHelper,
-        tfhelper: TerraformHelper,
         upgrade_release: bool = False,
     ):
         """Upgrade plugins.
 
         :client: Helper for interacting with clusterd
-        :jhelper: Helper for interacting with pylibjuju
-        :tfhelper: Helper for interaction with Terraform
         :upgrade_release: Whether to upgrade channel
         """
         super().__init__("Validation", "Running pre-upgrade validation")
         self.client = client
-        self.jhelper = jhelper
-        self.tfhelper = tfhelper
         self.upgrade_release = upgrade_release
 
     def run(self, status: Optional[Status] = None) -> Result:
@@ -64,7 +57,6 @@ class UpgradeCoordinator:
         client: Client,
         jhelper: JujuHelper,
         manifest: Manifest,
-        channel: str | None = None,
     ):
         """Upgrade coordinator.
 
@@ -73,10 +65,8 @@ class UpgradeCoordinator:
         :client: Helper for interacting with clusterd
         :jhelper: Helper for interacting with pylibjuju
         :manifest: Manifest object
-        :channel: OpenStack channel to upgrade charms to
         """
         self.client = client
-        self.channel = channel
         self.jhelper = jhelper
         self.manifest = manifest
         self.tfhelper = self.manifest.get_tfhelper("openstack-plan")

--- a/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
@@ -101,7 +101,7 @@ class LatestInChannel(BaseStep, JujuStepHelper):
 
         all_deployed_apps = deployed_k8s_apps.copy()
         all_deployed_apps.update(deployed_machine_apps)
-        LOG.debug(f"Al deployed apps: {all_deployed_apps}")
+        LOG.debug(f"All deployed apps: {all_deployed_apps}")
         if self.is_track_changed_for_any_charm(all_deployed_apps):
             error_msg = (
                 "Manifest has track values that require upgrades, rerun with "
@@ -138,7 +138,5 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
             ReapplyHypervisorTerraformPlanStep(
                 self.client, self.manifest, self.jhelper
             ),
-            UpgradePlugins(
-                self.client, self.jhelper, self.tfhelper, upgrade_release=False
-            ),
+            UpgradePlugins(self.client, upgrade_release=False),
         ]

--- a/sunbeam-python/sunbeam/jobs/juju.py
+++ b/sunbeam-python/sunbeam/jobs/juju.py
@@ -18,7 +18,7 @@ import base64
 import json
 import logging
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import wraps
 from pathlib import Path
 from typing import Awaitable, Dict, List, Optional, TypedDict, TypeVar, cast
@@ -719,6 +719,91 @@ class JujuHelper:
         except asyncio.TimeoutError as e:
             raise TimeoutException(
                 f"Timed out while waiting for model {model!r} to be ready"
+            ) from e
+
+    @controller
+    async def wait_until_desired_status(
+        self,
+        model: str,
+        apps: list,
+        status: list = ["active"],
+        timeout: int = 10 * 60,
+    ) -> None:
+        """Wait for all agents in model to reach desired status
+
+        :model: Name of the model to wait for readiness
+        :apps: Applications to check the status for
+        :status: Desired status list
+        :timeout: Waiting timeout in seconds
+        """
+        check_freq = 0.5
+        idle_period = 15
+        model_impl = await self.get_model(model)
+
+        timeout = timedelta(seconds=timeout)
+        idle_period = timedelta(seconds=idle_period)
+        start_time = datetime.now()
+
+        idle_times = {}
+        units_ready = set()  # The units that are in the desired state
+        last_log_time = None
+        log_interval = timedelta(seconds=30)
+
+        try:
+            while True:
+                busy = []
+                for app_name in apps:
+                    if app_name not in model_impl.applications:
+                        busy.append(app_name + " (missing)")
+                        continue
+                    app = model_impl.applications[app_name]
+                    app_status = await app.get_status()
+
+                    for unit in app.units:
+                        need_to_wait_more_for_a_particular_status = (
+                            unit.workload_status not in status
+                        )
+                        app_is_in_desired_status = app_status in status
+                        if (
+                            not need_to_wait_more_for_a_particular_status
+                            and unit.agent_status == "idle"  # noqa: W503
+                            and app_is_in_desired_status  # noqa: W503
+                        ):
+                            units_ready.add(unit.name)
+                            now = datetime.now()
+                            idle_start = idle_times.setdefault(unit.name, now)
+
+                            if now - idle_start < idle_period:
+                                busy.append(
+                                    f"{unit.name} [{unit.agent_status}] "
+                                    f"{unit.workload_status}: "
+                                    f"{unit.workload_status_message}"
+                                )
+                        else:
+                            idle_times.pop(unit.name, None)
+                            busy.append(
+                                f"{unit.name} [{unit.agent_status}] "
+                                f"{unit.workload_status}: "
+                                f"{unit.workload_status_message}"
+                            )
+
+                if not busy:
+                    break
+                busy = "\n  ".join(busy)
+                if timeout is not None and datetime.now() - start_time > timeout:
+                    raise TimeoutException(
+                        f"Timed out while waiting for model {model!r} to be ready: "
+                        f"{busy}"
+                    )
+                if (
+                    last_log_time is None
+                    or datetime.now() - last_log_time > log_interval  # noqa: W503
+                ):
+                    last_log_time = datetime.now()
+                await asyncio.sleep(check_freq)
+        except (JujuMachineError, JujuAgentError, JujuUnitError, JujuAppError) as e:
+            raise JujuWaitException(
+                f"Error while waiting for model {model!r} to be ready: {str(e)}"
             ) from e
 
     @controller

--- a/sunbeam-python/sunbeam/jobs/plugin.py
+++ b/sunbeam-python/sunbeam/jobs/plugin.py
@@ -283,6 +283,20 @@ class PluginManager:
             plugin.add_manifest_section(manifest)
 
     @classmethod
+    def get_all_charms_in_openstack_plan(cls, client: Client) -> list:
+        charms = []
+        plugins = cls.get_all_plugin_classes()
+        for klass in plugins:
+            plugin = klass(client)
+            m_dict = plugin.manifest_attributes_tfvar_map()
+            charms_from_plugin = list(
+                m_dict.get("openstack-plan", {}).get("charms", {}).keys()
+            )
+            charms.extend(charms_from_plugin)
+
+        return charms
+
+    @classmethod
     def register(
         cls,
         client: Client,

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -26,65 +26,7 @@ CERT_AUTH_CHANNEL = "latest/beta"
 BIND_CHANNEL = "9/edge"
 VAULT_CHANNEL = "latest/edge"
 
-# The lists of services are needed for switching charm channels outside
-# of the terraform provider. If it ok to upgrade in one big-bang and
-# the juju terraform provider supports it then the upgrades can be
-# done by simply updating the tfvars and these lists are not needed.
-OPENSTACK_SERVICES_K8S = {
-    "cinder-ceph": OPENSTACK_CHANNEL,
-    "cinder": OPENSTACK_CHANNEL,
-    "glance": OPENSTACK_CHANNEL,
-    "horizon": OPENSTACK_CHANNEL,
-    "keystone": OPENSTACK_CHANNEL,
-    "neutron": OPENSTACK_CHANNEL,
-    "nova": OPENSTACK_CHANNEL,
-    "placement": OPENSTACK_CHANNEL,
-}
-OVN_SERVICES_K8S = {
-    "ovn-central": OVN_CHANNEL,
-    "ovn-relay": OVN_CHANNEL,
-}
-MYSQL_SERVICES_K8S = {"mysql": MYSQL_CHANNEL}
-MYSQL_ROUTER_SERVICES_K8S = {
-    "cinder-ceph-mysql-router": MYSQL_CHANNEL,
-    "cinder-mysql-router": MYSQL_CHANNEL,
-    "glance-mysql-router": MYSQL_CHANNEL,
-    "horizon-mysql-router": MYSQL_CHANNEL,
-    "keystone-mysql-router": MYSQL_CHANNEL,
-    "neutron-mysql-router": MYSQL_CHANNEL,
-    "nova-api-mysql-router": MYSQL_CHANNEL,
-    "nova-cell-mysql-router": MYSQL_CHANNEL,
-    "nova-mysql-router": MYSQL_CHANNEL,
-    "placement-mysql-router": MYSQL_CHANNEL,
-}
-MISC_SERVICES_K8S = {
-    "certificate-authority": CERT_AUTH_CHANNEL,
-    "rabbitmq": RABBITMQ_CHANNEL,
-    "traefik": TRAEFIK_CHANNEL,
-    "traefik-public": TRAEFIK_CHANNEL,
-}
-MACHINE_SERVICES = {
-    "microceph": MICROCEPH_CHANNEL,
-    "microk8s": MICROK8S_CHANNEL,
-    "openstack-hypervisor": OPENSTACK_CHANNEL,
-    "sunbeam-machine": SUNBEAM_MACHINE_CHANNEL,
-}
-
-K8S_SERVICES = {}
-K8S_SERVICES |= OPENSTACK_SERVICES_K8S
-K8S_SERVICES |= OVN_SERVICES_K8S
-K8S_SERVICES |= MYSQL_SERVICES_K8S
-K8S_SERVICES |= MYSQL_ROUTER_SERVICES_K8S
-K8S_SERVICES |= MISC_SERVICES_K8S
-
-CHARM_VERSIONS = {}
-CHARM_VERSIONS |= K8S_SERVICES
-CHARM_VERSIONS |= MACHINE_SERVICES
-
-# Similar to CHARM_VERSIONS except this is not per service
-# but per charm. So all *-mysql-router wont be included
-# and instead only mysql-router is included. Same is the
-# case of traefik charm.
+# List of charms with default channels
 OPENSTACK_CHARMS_K8S = {
     "cinder-ceph-k8s": OPENSTACK_CHANNEL,
     "cinder-k8s": OPENSTACK_CHANNEL,

--- a/sunbeam-python/tests/unit/sunbeam/commands/upgrades/test_base.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/upgrades/test_base.py
@@ -12,116 +12,104 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock
 
+from sunbeam.commands.terraform import TerraformException
 from sunbeam.commands.upgrades.inter_channel import BaseUpgrade
-from sunbeam.versions import (
-    MYSQL_ROUTER_SERVICES_K8S,
-    MYSQL_SERVICES_K8S,
-    OPENSTACK_SERVICES_K8S,
-    OVN_SERVICES_K8S,
-)
+from sunbeam.jobs.common import ResultType
+from sunbeam.jobs.juju import TimeoutException
 
 
 class TestBaseUpgrade:
     def setup_method(self):
         self.client = Mock()
         self.jhelper = AsyncMock()
-        self.tfhelper = Mock()
-        self.upgrade_service = (
-            list(MYSQL_SERVICES_K8S.keys())  # noqa
-            + list(MYSQL_ROUTER_SERVICES_K8S.keys())  # noqa
-            + list(OVN_SERVICES_K8S.keys())  # noqa
-            + list(OPENSTACK_SERVICES_K8S.keys())  # noqa
-        )
+        self.manifest = Mock()
 
     def test_upgrade_applications(self):
-        def _get_new_channel_mock(app_name, model):
-            channels = {"nova": "2023.2/edge", "neutron": None}
-            return channels[app_name]
+        model = "openstack"
+        apps = ["nova"]
+        charms = ["nova-k8s"]
+        tfplan = "openstack-plan"
+        config = "openstackterraformvar"
+        timeout = 60
 
         upgrader = BaseUpgrade(
             "test name",
             "test description",
             self.client,
             self.jhelper,
-            self.tfhelper,
-            "openstack",
-        )
-        get_new_channel_mock = Mock()
-        get_new_channel_mock.side_effect = _get_new_channel_mock
-        with patch.object(BaseUpgrade, "get_new_channel", get_new_channel_mock):
-            upgrader.upgrade_applications(["nova"], "openstack")
-        self.jhelper.update_applications_channel.assert_called_once_with(
-            "openstack",
-            {
-                "nova": {
-                    "channel": "2023.2/edge",
-                    "expected_status": {"workload": ["blocked", "active"]},
-                }
-            },
+            self.manifest,
+            model,
         )
 
-    def test_get_new_channel_os_service(self, mocker):
-        self.jhelper.get_charm_channel.return_value = "2023.1/edge"
+        result = upgrader.upgrade_applications(
+            apps, charms, model, tfplan, config, timeout
+        )
+        self.manifest.update_partial_tfvars_and_apply_tf.assert_called_once_with(
+            charms, tfplan, config
+        )
+        self.jhelper.wait_until_desired_status.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_upgrade_applications_tf_failed(self):
+        self.manifest.update_partial_tfvars_and_apply_tf.side_effect = (
+            TerraformException("apply failed...")
+        )
+
+        model = "openstack"
+        apps = ["nova"]
+        charms = ["nova-k8s"]
+        tfplan = "openstack-plan"
+        config = "openstackterraformvar"
+        timeout = 60
+
         upgrader = BaseUpgrade(
             "test name",
             "test description",
             self.client,
             self.jhelper,
-            self.tfhelper,
-            "openstack",
+            self.manifest,
+            model,
         )
-        new_channel = upgrader.get_new_channel("cinder", "openstack")
-        assert new_channel == "2023.2/edge"
 
-    def test_get_new_channel_os_service_same(self, mocker):
-        self.jhelper.get_charm_channel.return_value = "2023.2/edge"
+        result = upgrader.upgrade_applications(
+            apps, charms, model, tfplan, config, timeout
+        )
+        self.manifest.update_partial_tfvars_and_apply_tf.assert_called_once_with(
+            charms, tfplan, config
+        )
+        self.jhelper.wait_until_desired_status.assert_not_called()
+        assert result.result_type == ResultType.FAILED
+        assert result.message == "apply failed..."
+
+    def test_upgrade_applications_waiting_timed_out(self):
+        self.jhelper.wait_until_desired_status.side_effect = TimeoutException(
+            "timed out"
+        )
+
+        model = "openstack"
+        apps = ["nova"]
+        charms = ["nova-k8s"]
+        tfplan = "openstack-plan"
+        config = "openstackterraformvar"
+        timeout = 60
+
         upgrader = BaseUpgrade(
             "test name",
             "test description",
             self.client,
             self.jhelper,
-            self.tfhelper,
-            "openstack",
+            self.manifest,
+            model,
         )
-        new_channel = upgrader.get_new_channel("cinder", "openstack")
-        assert new_channel is None
 
-    def test_get_new_channel_os_downgrade(self, mocker):
-        self.jhelper.get_charm_channel.return_value = "2023.2/edge"
-        upgrader = BaseUpgrade(
-            "test name",
-            "test description",
-            self.client,
-            self.jhelper,
-            self.tfhelper,
-            "openstack",
+        result = upgrader.upgrade_applications(
+            apps, charms, model, tfplan, config, timeout
         )
-        new_channel = upgrader.get_new_channel("cinder", "openstack")
-        assert new_channel is None
-
-    def test_get_new_channel_nonos_service(self, mocker):
-        self.jhelper.get_charm_channel.return_value = "3.8/stable"
-        upgrader = BaseUpgrade(
-            "test name",
-            "test description",
-            self.client,
-            self.jhelper,
-            self.tfhelper,
-            "openstack",
+        self.manifest.update_partial_tfvars_and_apply_tf.assert_called_once_with(
+            charms, tfplan, config
         )
-        new_channel = upgrader.get_new_channel("rabbitmq", "openstack")
-        assert new_channel == "3.12/edge"
-
-    def test_get_new_channel_unknown(self, mocker):
-        upgrader = BaseUpgrade(
-            "test name",
-            "test description",
-            self.client,
-            self.jhelper,
-            self.tfhelper,
-            "openstack",
-        )
-        new_channel = upgrader.get_new_channel("foo", "openstack")
-        assert new_channel is None
+        self.jhelper.wait_until_desired_status.assert_called_once()
+        assert result.result_type == ResultType.FAILED
+        assert result.message == "timed out"


### PR DESCRIPTION
Use manifest for Upgrade releases.
For control plane, upgrade charms in following order - mysql charms, openstack core charms, openstack plugins.
In each upgrade, only update the terraform variables corresponding to charms and apply the terraform plan.
Followed similar approach for machine charms as well. Split machine charms to individual ones as each machine charm may have pre and post steps during upgrade.
Upgrade plugins using terraform plan openstack-plan as part of control plane upgrade.