### PR TITLE
Fix regression from #91

### DIFF
--- a/sunbeam-python/sunbeam/jobs/plugin.py
+++ b/sunbeam-python/sunbeam/jobs/plugin.py
@@ -143,6 +143,7 @@ class PluginManager:
             ...
         ]
 
+        :param client: Clusterd client object.
         :param detail: If true, includes repo path and branch as well.
         :returns: List of repos.
         """
@@ -162,7 +163,7 @@ class PluginManager:
             return []
 
     @classmethod
-    def get_plugins(cls, repos: Optional[list] = []) -> dict:
+    def get_plugins(cls, client: Client, repos: Optional[list] = []) -> dict:
         """Returns list of plugin name and description.
 
         Get all plugins information for each repo specified in repos.
@@ -170,6 +171,7 @@ class PluginManager:
         including the internal plugins in snap-openstack repo. Repo name
         core is reserved for internal plugins in snap-openstack repo.
 
+        :param client: Clusterd client object.
         :param repos: List of repos
         :returns: Dictionary of repo with plugin name and description
 
@@ -185,7 +187,7 @@ class PluginManager:
         """
         if not repos:
             repos.append("core")
-            repos.extend(cls.get_all_external_repos())
+            repos.extend(cls.get_all_external_repos(client))
 
         plugins = {}
         for repo in repos:
@@ -219,13 +221,14 @@ class PluginManager:
         If repos is None or empty list, get plugins from all repos defined in
         cluster db including the internal plugins.
 
+        :param client: Clusterd client object.
         :param repos: List of repos
         :returns: List of enabled plugins
         """
         enabled_plugins = []
         if not repos:
             repos.append("core")
-            repos.extend(cls.get_all_external_repos())
+            repos.extend(cls.get_all_external_repos(client))
 
         for repo in repos:
             if repo == "core":
@@ -329,6 +332,7 @@ class PluginManager:
         upgrade hooks if the plugin is enabled and version is changed. Do not
         run any upgrade hooks if repos is empty list.
 
+        :param client: Clusterd client object.
         :param repos: List of repos
         """
         if not repos:

--- a/sunbeam-python/sunbeam/plugins/repo/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/repo/plugin.py
@@ -322,18 +322,18 @@ class RepoPlugin(BasePlugin):
             repo_names = PluginManager.get_all_external_repos(self.client)
             if include_core:
                 click.echo("Core plugins:")
-                plugins = PluginManager.get_plugins(["core"])
+                plugins = PluginManager.get_plugins(self.client, ["core"])
                 self._print_plugins_table(plugins.get("core"))
 
             for repo in repo_names:
                 click.echo(f"Plugins in repo {repo}:")
-                plugins = PluginManager.get_plugins([repo])
+                plugins = PluginManager.get_plugins(self.client, [repo])
                 self._print_plugins_table(plugins.get(repo))
 
         elif format == FORMAT_YAML:
             # Add plugins to the repos list
             if plugins:
-                plugins = PluginManager.get_plugins()
+                plugins = PluginManager.get_plugins(self.client)
                 if include_core:
                     repos.append({"name": "core"})
 


### PR DESCRIPTION
PR #91 did not add `client` argument to all function calls to `get_all_external_repos`, which causes issue like

```python
  File "/snap/openstack/x24/lib/python3.10/site-packages/sunbeam/jobs/plugin.py", line 228, in                          
enabled_plugins                                                                                                         
    repos.extend(cls.get_all_external_repos())
TypeError: PluginManager.get_all_external_repos() missing 1 required positional argument: 'client' 
````

This PR addresses the regression.