### PR TITLE
Add manifest support to observability plugin

### DIFF
--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-cos/main.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.8.0"
+      version = "= 0.10.1"
     }
   }
 }
@@ -43,12 +43,14 @@ resource "juju_application" "traefik" {
   model = juju_model.cos.name
 
   charm {
-    name    = "traefik-k8s"
-    channel = var.cos-channel
-    series  = "focal"
+    name     = "traefik-k8s"
+    channel  = var.traefik-channel == null ? var.cos-channel : var.traefik-channel
+    revision = var.traefik-revision
+    base     = "ubuntu@20.04"
   }
 
-  units = var.ingress-scale
+  config = var.traefik-config
+  units  = var.ingress-scale
 }
 
 resource "juju_application" "alertmanager" {
@@ -57,12 +59,14 @@ resource "juju_application" "alertmanager" {
   model = juju_model.cos.name
 
   charm {
-    name    = "alertmanager-k8s"
-    channel = var.cos-channel
-    series  = "focal"
+    name     = "alertmanager-k8s"
+    channel  = var.alertmanager-channel == null ? var.cos-channel : var.alertmanager-channel
+    revision = var.alertmanager-revision
+    base     = "ubuntu@20.04"
   }
 
-  units = var.alertmanager-scale
+  config = var.alertmanager-config
+  units  = var.alertmanager-scale
 }
 
 resource "juju_application" "prometheus" {
@@ -71,12 +75,14 @@ resource "juju_application" "prometheus" {
   model = juju_model.cos.name
 
   charm {
-    name    = "prometheus-k8s"
-    channel = var.cos-channel
-    series  = "focal"
+    name     = "prometheus-k8s"
+    channel  = var.prometheus-channel == null ? var.cos-channel : var.prometheus-channel
+    revision = var.prometheus-revision
+    base     = "ubuntu@20.04"
   }
 
-  units = var.prometheus-scale
+  config = var.prometheus-config
+  units  = var.prometheus-scale
 }
 
 resource "juju_application" "grafana" {
@@ -85,12 +91,14 @@ resource "juju_application" "grafana" {
   model = juju_model.cos.name
 
   charm {
-    name    = "grafana-k8s"
-    channel = var.cos-channel
-    series  = "focal"
+    name     = "grafana-k8s"
+    channel  = var.grafana-channel == null ? var.cos-channel : var.grafana-channel
+    revision = var.grafana-revision
+    base     = "ubuntu@20.04"
   }
 
-  units = var.grafana-scale
+  config = var.grafana-config
+  units  = var.grafana-scale
 }
 
 resource "juju_application" "catalogue" {
@@ -100,15 +108,16 @@ resource "juju_application" "catalogue" {
 
   charm {
     name    = "catalogue-k8s"
-    channel = var.cos-channel
-    series  = "focal"
+    channel  = var.catalogue-channel == null ? var.cos-channel : var.catalogue-channel
+    revision = var.catalogue-revision
+    base     = "ubuntu@20.04"
   }
 
-  config = {
+  config = merge({
     title       = "Canonical Observability Stack"
     tagline     = "Model-driven Observability Stack deployed with a single command."
     description = " Canonical Observability Stack Lite, or COS Lite, is a light-weight, highly-integrated, Juju-based observability suite running on Kubernetes."
-  }
+  }, var.catalogue-config)
 
   units = var.catalogue-scale
 }
@@ -120,11 +129,13 @@ resource "juju_application" "loki" {
 
   charm {
     name    = "loki-k8s"
-    channel = var.cos-channel
-    series  = "focal"
+    channel  = var.loki-channel == null ? var.cos-channel : var.loki-channel
+    revision = var.loki-revision
+    base     = "ubuntu@20.04"
   }
 
-  units = var.loki-scale
+  config = var.loki-config
+  units  = var.loki-scale
 }
 
 # juju integrate traefik prometheus

--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-cos/variables.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-cos/variables.tf
@@ -41,6 +41,114 @@ variable "cos-channel" {
   default     = "1.0/stable"
 }
 
+variable "traefik-channel" {
+  description = "Operator channel for COS Lite Traefik deployment"
+  type        = string
+  default     = "1.0/stable"
+}
+
+variable "traefik-revision" {
+  description = "Operator channel revision for COS Lite Traefik deployment"
+  type        = number
+  default     = null
+}
+
+variable "traefik-config" {
+  description = "Operator config for COS Lite Traefik deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "alertmanager-channel" {
+  description = "Operator channel for COS Lite Alert Manager deployment"
+  type        = string
+  default     = "1.0/stable"
+}
+
+variable "alertmanager-revision" {
+  description = "Operator channel revision for COS Lite Alert Manager deployment"
+  type        = number
+  default     = null
+}
+
+variable "alertmanager-config" {
+  description = "Operator config for COS Lite Alert Manager deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "prometheus-channel" {
+  description = "Operator channel for COS Lite Prometheus deployment"
+  type        = string
+  default     = "1.0/stable"
+}
+
+variable "prometheus-revision" {
+  description = "Operator channel revision for COS Lite Prometheus deployment"
+  type        = number
+  default     = null
+}
+
+variable "prometheus-config" {
+  description = "Operator config for COS Lite Prometheus deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "grafana-channel" {
+  description = "Operator channel for COS Lite Grafana deployment"
+  type        = string
+  default     = "1.0/stable"
+}
+
+variable "grafana-revision" {
+  description = "Operator channel revision for COS Lite Grafana deployment"
+  type        = number
+  default     = null
+}
+
+variable "grafana-config" {
+  description = "Operator config for COS Lite Grafana deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "catalogue-channel" {
+  description = "Operator channel for COS Lite Catalogue deployment"
+  type        = string
+  default     = "1.0/stable"
+}
+
+variable "catalogue-revision" {
+  description = "Operator channel revision for COS Lite Catalogue deployment"
+  type        = number
+  default     = null
+}
+
+variable "catalogue-config" {
+  description = "Operator config for COS Lite Catalogue deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "loki-channel" {
+  description = "Operator channel for COS Lite Loki deployment"
+  type        = string
+  default     = "1.0/stable"
+}
+
+variable "loki-revision" {
+  description = "Operator channel revision for COS Lite Loki deployment"
+  type        = number
+  default     = null
+}
+
+variable "loki-config" {
+  description = "Operator config for COS Lite Loki deployment"
+  type        = map(string)
+  default     = {}
+}
+
 variable "ingress-scale" {
   description = "Scale of ingress deployment"
   default     = 1

--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent/main.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 0.8.0"
+      version = "= 0.10.1"
     }
   }
 }
@@ -36,10 +36,13 @@ resource "juju_application" "grafana-agent" {
   units = 0
 
   charm {
-    name = "grafana-agent"
-    channel = var.grafana-agent-channel
-    series = "jammy"
+    name     = "grafana-agent"
+    channel  = var.grafana-agent-channel
+    revision = var.grafana-agent-revision
+    base     = "ubuntu@22.04"
   }
+
+  config = var.grafana-agent-config
 }
 
 # juju integrate <principal-application>:cos-agent grafana-agent:cos-agent

--- a/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent/variables.tf
+++ b/sunbeam-python/sunbeam/plugins/observability/etc/deploy-grafana-agent/variables.tf
@@ -26,9 +26,22 @@ variable "principal-application-model" {
 
 variable "grafana-agent-channel" {
   description = "Channel to use when deploying grafana agent machine charm"
+  type        = string
   # Note: Currently, latest/stable is not available for grafana-agent. So,
   # defaulting to latest/candidate.
-  default = "latest/candidate"
+  default     = "latest/candidate"
+}
+
+variable "grafana-agent-revision" {
+  description = "Channel revision to use when deploying grafana agent machine charm"
+  type        = number
+  default     = null
+}
+
+variable "grafana-agent-config" {
+  description = "Config to use when deploying grafana agent machine charm"
+  type        = map(string)
+  default     = {}
 }
 
 variable "cos-state-backend" {

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import asyncio
-from pathlib import Path
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -40,19 +39,8 @@ def mock_run_sync(mocker):
 
 
 @pytest.fixture()
-def cclient():
-    with patch("sunbeam.plugins.interface.v1.base.Client") as p:
-        yield p
-
-
-@pytest.fixture()
 def jhelper():
     yield AsyncMock()
-
-
-@pytest.fixture()
-def tfhelper():
-    yield Mock(path=Path())
 
 
 @pytest.fixture()
@@ -62,87 +50,80 @@ def observabilityplugin():
 
 
 class TestDeployObservabilityStackStep:
-    def test_run(self, cclient, jhelper, tfhelper, observabilityplugin):
+    def test_run(self, jhelper, observabilityplugin):
         step = observability_plugin.DeployObservabilityStackStep(
-            observabilityplugin, tfhelper, jhelper
+            observabilityplugin, jhelper
         )
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
-        tfhelper.apply.assert_called_once()
+        observabilityplugin.manifest.update_tfvars_and_apply_tf.assert_called_once()
         jhelper.wait_until_active.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
-    def test_run_tf_apply_failed(self, cclient, jhelper, tfhelper, observabilityplugin):
-        tfhelper.apply.side_effect = TerraformException("apply failed...")
+    def test_run_tf_apply_failed(self, jhelper, observabilityplugin):
+        observabilityplugin.manifest.update_tfvars_and_apply_tf.side_effect = (
+            TerraformException("apply failed...")
+        )
 
         step = observability_plugin.DeployObservabilityStackStep(
-            observabilityplugin, tfhelper, jhelper
+            observabilityplugin, jhelper
         )
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
-        tfhelper.apply.assert_called_once()
+        observabilityplugin.manifest.update_tfvars_and_apply_tf.assert_called_once()
         jhelper.wait_until_active.assert_not_called()
         assert result.result_type == ResultType.FAILED
         assert result.message == "apply failed..."
 
-    def test_run_waiting_timed_out(
-        self, cclient, jhelper, tfhelper, observabilityplugin
-    ):
+    def test_run_waiting_timed_out(self, jhelper, observabilityplugin):
         jhelper.wait_until_active.side_effect = TimeoutException("timed out")
 
         step = observability_plugin.DeployObservabilityStackStep(
-            observabilityplugin, tfhelper, jhelper
+            observabilityplugin, jhelper
         )
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
-        tfhelper.apply.assert_called_once()
+        observabilityplugin.manifest.update_tfvars_and_apply_tf.assert_called_once()
         jhelper.wait_until_active.assert_called_once()
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
 
 
 class TestRemoveObservabilityStackStep:
-    def test_run(self, cclient, jhelper, tfhelper, observabilityplugin):
+    def test_run(self, jhelper, observabilityplugin):
+        tfhelper = observabilityplugin.manifest.get_tfhelper()
         step = observability_plugin.RemoveObservabilityStackStep(
-            observabilityplugin, tfhelper, jhelper
+            observabilityplugin, jhelper
         )
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_model_gone.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
-    def test_run_tf_destroy_failed(
-        self, cclient, jhelper, tfhelper, observabilityplugin
-    ):
+    def test_run_tf_destroy_failed(self, jhelper, observabilityplugin):
+        tfhelper = observabilityplugin.manifest.get_tfhelper()
         tfhelper.destroy.side_effect = TerraformException("destroy failed...")
 
         step = observability_plugin.RemoveObservabilityStackStep(
-            observabilityplugin, tfhelper, jhelper
+            observabilityplugin, jhelper
         )
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_model_gone.assert_not_called()
         assert result.result_type == ResultType.FAILED
         assert result.message == "destroy failed..."
 
-    def test_run_waiting_timed_out(
-        self, cclient, jhelper, tfhelper, observabilityplugin
-    ):
+    def test_run_waiting_timed_out(self, jhelper, observabilityplugin):
+        tfhelper = observabilityplugin.manifest.get_tfhelper()
         jhelper.wait_model_gone.side_effect = TimeoutException("timed out")
 
         step = observability_plugin.RemoveObservabilityStackStep(
-            observabilityplugin, tfhelper, jhelper
+            observabilityplugin, jhelper
         )
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_model_gone.assert_called_once()
         assert result.result_type == ResultType.FAILED
@@ -150,87 +131,68 @@ class TestRemoveObservabilityStackStep:
 
 
 class TestDeployGrafanaAgentStep:
-    def test_run(self, cclient, jhelper, tfhelper, observabilityplugin):
-        step = observability_plugin.DeployGrafanaAgentStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
-        )
+    def test_run(self, jhelper, observabilityplugin):
+        step = observability_plugin.DeployGrafanaAgentStep(observabilityplugin, jhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
-        tfhelper.apply.assert_called_once()
+        observabilityplugin.manifest.update_tfvars_and_apply_tf.assert_called_once()
         jhelper.wait_application_ready.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
-    def test_run_tf_apply_failed(self, cclient, jhelper, tfhelper, observabilityplugin):
-        tfhelper.apply.side_effect = TerraformException("apply failed...")
-
-        step = observability_plugin.DeployGrafanaAgentStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
+    def test_run_tf_apply_failed(self, jhelper, observabilityplugin):
+        observabilityplugin.manifest.update_tfvars_and_apply_tf.side_effect = (
+            TerraformException("apply failed...")
         )
+
+        step = observability_plugin.DeployGrafanaAgentStep(observabilityplugin, jhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
-        tfhelper.apply.assert_called_once()
+        observabilityplugin.manifest.update_tfvars_and_apply_tf.assert_called_once()
         jhelper.wait_application_ready.assert_not_called()
         assert result.result_type == ResultType.FAILED
         assert result.message == "apply failed..."
 
-    def test_run_waiting_timed_out(
-        self, cclient, jhelper, tfhelper, observabilityplugin
-    ):
+    def test_run_waiting_timed_out(self, jhelper, observabilityplugin):
         jhelper.wait_application_ready.side_effect = TimeoutException("timed out")
 
-        step = observability_plugin.DeployGrafanaAgentStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
-        )
+        step = observability_plugin.DeployGrafanaAgentStep(observabilityplugin, jhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
-        tfhelper.apply.assert_called_once()
+        observabilityplugin.manifest.update_tfvars_and_apply_tf.assert_called_once()
         jhelper.wait_application_ready.assert_called_once()
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
 
 
 class TestRemoveGrafanaAgentStep:
-    def test_run(self, cclient, jhelper, tfhelper, observabilityplugin):
-        step = observability_plugin.RemoveGrafanaAgentStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
-        )
+    def test_run(self, jhelper, observabilityplugin):
+        tfhelper = observabilityplugin.manifest.get_tfhelper()
+        step = observability_plugin.RemoveGrafanaAgentStep(observabilityplugin, jhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_application_gone.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
-    def test_run_tf_destroy_failed(
-        self, cclient, jhelper, tfhelper, observabilityplugin
-    ):
+    def test_run_tf_destroy_failed(self, jhelper, observabilityplugin):
+        tfhelper = observabilityplugin.manifest.get_tfhelper()
         tfhelper.destroy.side_effect = TerraformException("destroy failed...")
 
-        step = observability_plugin.RemoveGrafanaAgentStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
-        )
+        step = observability_plugin.RemoveGrafanaAgentStep(observabilityplugin, jhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_application_gone.assert_not_called()
         assert result.result_type == ResultType.FAILED
         assert result.message == "destroy failed..."
 
-    def test_run_waiting_timed_out(
-        self, cclient, jhelper, tfhelper, observabilityplugin
-    ):
+    def test_run_waiting_timed_out(self, jhelper, observabilityplugin):
+        tfhelper = observabilityplugin.manifest.get_tfhelper()
         jhelper.wait_application_gone.side_effect = TimeoutException("timed out")
 
-        step = observability_plugin.RemoveGrafanaAgentStep(
-            observabilityplugin, tfhelper, tfhelper, jhelper
-        )
+        step = observability_plugin.RemoveGrafanaAgentStep(observabilityplugin, jhelper)
         result = step.run()
 
-        tfhelper.write_tfvars.assert_called_once()
         tfhelper.destroy.assert_called_once()
         jhelper.wait_application_gone.assert_called_once()
         assert result.result_type == ResultType.FAILED


### PR DESCRIPTION
Expand terraform variables for observability
plugin to parameterise channel, revision, config.
Update manifest_default and corresponding tfvar
map in the plugin.
Update plugin to use manifest functions instead
of terraform helper functions.