### PR TITLE
MAAS: import/export a deployment

### DIFF
--- a/sunbeam-python/sunbeam/commands/deployment.py
+++ b/sunbeam-python/sunbeam/commands/deployment.py
@@ -21,29 +21,64 @@ from typing import Type
 
 import pydantic
 import yaml
+from juju.controller import Controller
 from rich.console import Console
 from snaphelpers import Snap
 
-from sunbeam.jobs.common import SHARE_PATH
+from sunbeam.jobs.common import SHARE_PATH, BaseStep
+from sunbeam.jobs.juju import JujuAccount, JujuController
 
 LOG = logging.getLogger(__name__)
 console = Console()
 
 DEPLOYMENT_CONFIG = SHARE_PATH / "deployment.yaml"
 
+_cls_registry: dict[str, Type["Deployment"]] = {}
+
+
+def register_deployment_type(type_: str, cls: Type["Deployment"]):
+    global _cls_registry
+    _cls_registry[type_] = cls
+
+
+def get_deployment_class(type_: str) -> Type["Deployment"]:
+    global _cls_registry
+    return _cls_registry[type_]
+
 
 class Deployment(pydantic.BaseModel):
     name: str
     url: str
     type: str
+    juju_account: JujuAccount | None = None
+    juju_controller: JujuController | None = None
 
+    @classmethod
+    def load(cls, deployment: dict) -> "Deployment":
+        """Load deployment from dict."""
+        if type_ := deployment.get("type"):
+            return _cls_registry.get(type_, Deployment)(**deployment)
+        raise ValueError("Deployment type not set.")
 
-_cls_registry: dict[str, Type[Deployment]] = {}
+    @classmethod
+    def import_step(cls) -> Type[BaseStep]:
+        """Return a step for importing a deployment.
 
+        This step will be used to make sure the deployment is valid.
+        The step must take as constructor arguments: DeploymentsConfig, Deployment.
+        The Deployment must be of the type that the step is registered for.
+        """
+        return NotImplemented  # type: ignore
 
-def register_deployment_type(type_: str, cls: Type[Deployment]):
-    global _cls_registry
-    _cls_registry[type_] = cls
+    def get_connected_controller(self) -> Controller:
+        """Return connected controller."""
+        if self.juju_account is None:
+            raise ValueError(f"No juju account configured for deployment {self.name}.")
+        if self.juju_controller is None:
+            raise ValueError(
+                f"No juju controller configured for deployment {self.name}."
+            )
+        return self.juju_controller.to_controller(self.juju_account)
 
 
 class DeploymentsConfig(pydantic.BaseModel):
@@ -56,9 +91,7 @@ class DeploymentsConfig(pydantic.BaseModel):
         if isinstance(deployment, Deployment):
             return deployment
         if isinstance(deployment, dict):
-            if type_ := deployment.get("type"):
-                return _cls_registry.get(type_, Deployment)(**deployment)
-            raise ValueError("Deployment type not set.")
+            return Deployment.load(deployment)
         raise ValueError(f"Invalid deployment {deployment}.")
 
     @classmethod
@@ -168,6 +201,16 @@ def deployment_path(snap: Snap) -> Path:
     if not path.exists():
         path.touch(0o600)
         path.write_text("{}")
+    return path
+
+
+def store_deployment_as_yaml(snap: Snap, deployment: Deployment) -> Path:
+    """Store a deployment as YAML and return the path."""
+    openstack = snap.paths.real_home / SHARE_PATH
+    openstack.mkdir(parents=True, exist_ok=True)
+    path = openstack / (deployment.name + ".yaml")
+    path.write_text(yaml.safe_dump(deployment.dict()))
+    path.chmod(0o600)
     return path
 
 

--- a/sunbeam-python/sunbeam/provider/maas.py
+++ b/sunbeam-python/sunbeam/provider/maas.py
@@ -233,7 +233,7 @@ def bootstrap(
     if deployment.juju_controller is None:
         raise ValueError("Controller should have been saved in previous step.")
 
-    jhelper = JujuHelper(Path())
+    jhelper = JujuHelper(None, Path())  # type: ignore
     jhelper.controller = deployment.get_connected_controller()
     plan2 = []
     plan2.append(DeploySunbeamClusterdApplicationStep(jhelper))
@@ -271,7 +271,14 @@ def add_maas(name: str, token: str, url: str, resource_pool: str) -> None:
     path = deployment_path(snap)
     deployments = DeploymentsConfig.load(path)
     plan = []
-    plan.append(AddMaasDeployment(deployments, name, token, url, resource_pool))
+    plan.append(
+        AddMaasDeployment(
+            deployments,
+            MaasDeployment(
+                name=name, token=token, url=url, resource_pool=resource_pool
+            ),
+        )
+    )
     run_plan(plan, console)
     click.echo(f"MAAS deployment {name} added.")
 

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_maas.py
@@ -43,11 +43,13 @@ class TestAddMaasDeployment:
     @pytest.fixture
     def add_maas_deployment(self):
         return AddMaasDeployment(
-            deployment="test_deployment",
-            token="test_token",
-            url="test_url",
-            resource_pool="test_resource_pool",
-            deployments_config=Mock(),
+            Mock(),
+            MaasDeployment(
+                name="test_deployment",
+                token="test_token",
+                url="test_url",
+                resource_pool="test_resource_pool",
+            ),
         )
 
     def test_is_skip_with_existing_deployment(self, add_maas_deployment):


### PR DESCRIPTION
Add the commands to import / export a deployment.

Deployments must implement the method `import_step`, that will return a Step able to verify an imported deployment actually works.

here for example, the maas import step will perform the same check as Add deployment +:
- Check the spaces in network mapping exist
- If connection details to the controller exist, check that it works