### PR TITLE
Make -1 default value for machineid

### DIFF
--- a/sunbeam-microcluster/api/nodes.go
+++ b/sunbeam-microcluster/api/nodes.go
@@ -63,7 +63,7 @@ func cmdNodesGet(s *state.State, r *http.Request) response.Response {
 }
 
 func cmdNodesPost(s *state.State, r *http.Request) response.Response {
-	var req types.Node
+	req := types.Node{MachineID: -1}
 
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -79,7 +79,7 @@ func cmdNodesPost(s *state.State, r *http.Request) response.Response {
 }
 
 func cmdNodesPut(s *state.State, r *http.Request) response.Response {
-	var req types.Node
+	req := types.Node{MachineID: -1}
 
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {

--- a/sunbeam-microcluster/sunbeam/nodes.go
+++ b/sunbeam-microcluster/sunbeam/nodes.go
@@ -47,7 +47,7 @@ func ListNodes(s *state.State, roles []string) (types.Nodes, error) {
 
 // GetNode returns a Node with the given name
 func GetNode(s *state.State, name string) (types.Node, error) {
-	node := types.Node{}
+	node := types.Node{MachineID: -1}
 	err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		record, err := database.GetNode(ctx, tx, name)
 		if err != nil {
@@ -106,7 +106,7 @@ func UpdateNode(s *state.State, name string, role []string, machineid int) error
 		if role == nil {
 			nodeRole = node.Role
 		}
-		if machineid == 0 {
+		if machineid == -1 {
 			machineid = node.MachineID
 		}
 

--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -107,9 +107,9 @@ class MicroClusterService(service.BaseService):
 class ExtendedAPIService(service.BaseService):
     """Client for Sunbeam extended Cluster API."""
 
-    def add_node_info(self, name: str, role: List[str]) -> None:
+    def add_node_info(self, name: str, role: List[str], machineid: int = -1) -> None:
         """Add Node information to cluster database."""
-        data = {"name": name, "role": role}
+        data = {"name": name, "role": role, "machineid": machineid}
         self._post("/1.0/nodes", data=json.dumps(data))
 
     def list_nodes(self) -> list:
@@ -202,9 +202,11 @@ class ClusterService(MicroClusterService, ExtendedAPIService):
     # sucessfully run. Note: this is distinct from microcluster bootstrap.
     SUNBEAM_BOOTSTRAP_KEY = "sunbeam_bootstrapped"
 
-    def bootstrap(self, name: str, address: str, role: List[str]) -> None:
+    def bootstrap(
+        self, name: str, address: str, role: List[str], machineid: int = -1
+    ) -> None:
         self.bootstrap_cluster(name, address)
-        self.add_node_info(name, role)
+        self.add_node_info(name, role, machineid)
 
     def add_node(self, name: str) -> str:
         return self.generate_token(name)

--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -62,11 +62,12 @@ CLUSTERD_PORT = 7000
 class ClusterInitStep(BaseStep):
     """Bootstrap clustering on sunbeam clusterd."""
 
-    def __init__(self, client: Client, role: List[str]):
+    def __init__(self, client: Client, role: List[str], machineid: int):
         super().__init__("Bootstrap Cluster", "Bootstrapping Sunbeam cluster")
 
         self.port = CLUSTERD_PORT
         self.role = role
+        self.machineid = machineid
         self.client = client
         self.fqdn = utils.get_fqdn()
         self.ip = utils.get_local_ip_by_default_route()
@@ -95,7 +96,10 @@ class ClusterInitStep(BaseStep):
         """Bootstrap sunbeam cluster"""
         try:
             self.client.cluster.bootstrap(
-                name=self.fqdn, address=f"{self.ip}:{self.port}", role=self.role
+                name=self.fqdn,
+                address=f"{self.ip}:{self.port}",
+                role=self.role,
+                machineid=self.machineid,
             )
             return Result(ResultType.COMPLETED)
         except ClusterAlreadyBootstrappedException:

--- a/sunbeam-python/sunbeam/provider/local.py
+++ b/sunbeam-python/sunbeam/provider/local.py
@@ -251,7 +251,8 @@ def bootstrap(
     client: Client = ctx.obj
     plan = []
     plan.append(JujuLoginStep(data_location))
-    plan.append(ClusterInitStep(client, roles_to_str_list(roles)))
+    # bootstrapped node is always machine 0 in controller model
+    plan.append(ClusterInitStep(client, roles_to_str_list(roles), 0))
     plan.append(AddCloudJujuStep(cloud_name, cloud_definition))
     plan.append(
         BootstrapJujuStep(

--- a/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
@@ -43,7 +43,7 @@ class TestClusterdSteps:
 
     def test_init_step(self, cclient):
         role = "control"
-        init_step = ClusterInitStep(cclient, [role])
+        init_step = ClusterInitStep(cclient, [role], 0)
         init_step.client = MagicMock()
         result = init_step.run()
         assert result.result_type == ResultType.COMPLETED


### PR DESCRIPTION
machineid's default value was 0, meaning any node added without a machineid would have the 0 value. But first node in a juju cluster is 0.

This also means, if the value was initialized to -1, you couldn't update the machine id to 0.

Make -1 the default value.