### PR TITLE
Add update step in case of unexpected failure add_node_info

### DIFF
--- a/sunbeam-python/sunbeam/provider/local.py
+++ b/sunbeam-python/sunbeam/provider/local.py
@@ -253,6 +253,7 @@ def bootstrap(
     plan.append(JujuLoginStep(data_location))
     # bootstrapped node is always machine 0 in controller model
     plan.append(ClusterInitStep(client, roles_to_str_list(roles), 0))
+    plan.append(ClusterUpdateNodeStep(client, fqdn, machine_id=0))
     plan.append(AddCloudJujuStep(cloud_name, cloud_definition))
     plan.append(
         BootstrapJujuStep(


### PR DESCRIPTION
If there's an unexpected failure, on bootstrap re-run, ClusterInitStep will not be re-executed.