### PR TITLE
Fix tox test coverage target

### DIFF
--- a/sunbeam-python/.stestr.conf
+++ b/sunbeam-python/.stestr.conf
@@ -1,3 +1,0 @@
-[DEFAULT]
-test_path=${OS_TEST_PATH:-./tests/unit}
-top_dir=./

--- a/sunbeam-python/test-requirements.txt
+++ b/sunbeam-python/test-requirements.txt
@@ -6,7 +6,6 @@ fixtures>=3.0.0 # Apache-2.0/BSD
 oslotest>=3.2.0 # Apache-2.0
 requests>=2.14.2 # Apache-2.0
 requests-mock>=1.2.0 # Apache-2.0
-stestr>=1.0.0 # Apache-2.0
 testtools>=2.2.0 # MIT
 tempest>=17.1.0 # Apache-2.0
 osprofiler>=1.4.0 # Apache-2.0

--- a/sunbeam-python/tox.ini
+++ b/sunbeam-python/tox.ini
@@ -22,7 +22,6 @@ deps =
   -r{toxinidir}/requirements.txt
   -c{toxinidir}/upper-constraints.txt
 commands = python -m pytest {posargs}
-allowlist_externals = stestr
 
 [testenv:fmt]
 setenv = VIRTUAL_ENV={envdir}
@@ -90,11 +89,9 @@ commands = {posargs}
 [testenv:cover]
 setenv =
     VIRTUAL_ENV={envdir}
-    PYTHON=coverage run --source sunbeam --parallel-mode
 commands =
     coverage erase
-    stestr -q run {posargs}
-    coverage combine
+    coverage run -m pytest {posargs}
     coverage html -d cover
     coverage xml -o cover/coverage.xml
     coverage report

--- a/sunbeam-python/upper-constraints.txt
+++ b/sunbeam-python/upper-constraints.txt
@@ -310,7 +310,6 @@ platformdirs===2.5.2
 pydotplus===2.0.2
 boto3===1.24.89
 jeepney===0.8.0
-stestr===4.0.1
 oslo.serialization===5.1.1
 warlock===2.0.1
 exabgp===4.2.21


### PR DESCRIPTION
Switch to pytest instead of stestr,
because stestr doesn't support pytest tests,
and many tests here require pytest.

This ensures all tests will run during coverage
and accurate test coverage is obtained.
