### PR TITLE
MAAS: deploy on instances system ids instead of hostname

### DIFF
--- a/sunbeam-microcluster/api/nodes.go
+++ b/sunbeam-microcluster/api/nodes.go
@@ -70,7 +70,7 @@ func cmdNodesPost(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	err = sunbeam.AddNode(s, req.Name, req.Role, req.MachineID)
+	err = sunbeam.AddNode(s, req.Name, req.Role, req.MachineID, req.SystemID)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -91,7 +91,7 @@ func cmdNodesPut(s *state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	err = sunbeam.UpdateNode(s, name, req.Role, req.MachineID)
+	err = sunbeam.UpdateNode(s, name, req.Role, req.MachineID, req.SystemID)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/sunbeam-microcluster/api/types/nodes.go
+++ b/sunbeam-microcluster/api/types/nodes.go
@@ -6,7 +6,10 @@ type Nodes []Node
 
 // Node structure to hold node details like role and machine id
 type Node struct {
-	Name      string   `json:"name" yaml:"name"`
-	Role      []string `json:"role" yaml:"role"`
-	MachineID int      `json:"machineid" yaml:"machineid"`
+	Name string   `json:"name" yaml:"name"`
+	Role []string `json:"role" yaml:"role"`
+	// MachineID is the unique identifier for the node in juju
+	MachineID int `json:"machineid" yaml:"machineid"`
+	// SystemID is the unique identifier for the node in machine provider
+	SystemID string `json:"systemid" yaml:"systemid"`
 }

--- a/sunbeam-microcluster/cmd/sunbeamd/main.go
+++ b/sunbeam-microcluster/cmd/sunbeamd/main.go
@@ -69,49 +69,49 @@ func (c *cmdDaemon) Run(_ *cobra.Command, _ []string) error {
 	// Placeholder for post-action hooks that can be run by MicroCluster.
 	h := &config.Hooks{
 		// OnBootstrap is run after the daemon is initialized and bootstrapped.
-		OnBootstrap: func(s *state.State, initConfig map[string]string) error {
+		OnBootstrap: func(_ *state.State, _ map[string]string) error {
 			logger.Info("This is a hook that runs after the daemon is initialized and bootstrapped")
 
 			return nil
 		},
 
 		// OnStart is run after the daemon is started.
-		OnStart: func(s *state.State) error {
+		OnStart: func(_ *state.State) error {
 			logger.Info("This is a hook that runs after the daemon first starts")
 
 			return nil
 		},
 
 		// PostJoin is run after the daemon is initialized and joins a cluster.
-		PostJoin: func(s *state.State, initConfig map[string]string) error {
+		PostJoin: func(_ *state.State, _ map[string]string) error {
 			logger.Info("This is a hook that runs after the daemon is initialized and joins an existing cluster, after OnNewMember runs on all peers")
 
 			return nil
 		},
 
 		// PreJoin is run after the daemon is initialized and joins a cluster.
-		PreJoin: func(s *state.State, initConfig map[string]string) error {
+		PreJoin: func(_ *state.State, _ map[string]string) error {
 			logger.Info("This is a hook that runs after the daemon is initialized and joins an existing cluster, before OnNewMember runs on all peers")
 
 			return nil
 		},
 
 		// PostRemove is run after the daemon is removed from a cluster.
-		PostRemove: func(s *state.State, force bool) error {
+		PostRemove: func(s *state.State, _ bool) error {
 			logger.Infof("This is a hook that is run on peer %q after a cluster member is removed", s.Name())
 
 			return nil
 		},
 
 		// PreRemove is run before the daemon is removed from the cluster.
-		PreRemove: func(s *state.State, force bool) error {
+		PreRemove: func(s *state.State, _ bool) error {
 			logger.Infof("This is a hook that is run on peer %q just before it is removed", s.Name())
 
 			return nil
 		},
 
 		// OnHeartbeat is run after a successful heartbeat round.
-		OnHeartbeat: func(s *state.State) error {
+		OnHeartbeat: func(_ *state.State) error {
 			logger.Info("This is a hook that is run on the dqlite leader after a successful heartbeat")
 
 			return nil

--- a/sunbeam-microcluster/database/config.mapper.go
+++ b/sunbeam-microcluster/database/config.mapper.go
@@ -80,7 +80,7 @@ func getConfigItems(ctx context.Context, stmt *sql.Stmt, args ...any) ([]ConfigI
 	return objects, nil
 }
 
-// getConfigItems can be used to run handwritten query strings to return a slice of objects.
+// getConfigItemsRaw can be used to run handwritten query strings to return a slice of objects.
 func getConfigItemsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]ConfigItem, error) {
 	objects := make([]ConfigItem, 0)
 

--- a/sunbeam-microcluster/database/jujuuser.mapper.go
+++ b/sunbeam-microcluster/database/jujuuser.mapper.go
@@ -80,7 +80,7 @@ func getJujuUsers(ctx context.Context, stmt *sql.Stmt, args ...any) ([]JujuUser,
 	return objects, nil
 }
 
-// getJujuUsers can be used to run handwritten query strings to return a slice of objects.
+// getJujuUsersRaw can be used to run handwritten query strings to return a slice of objects.
 func getJujuUsersRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]JujuUser, error) {
 	objects := make([]JujuUser, 0)
 

--- a/sunbeam-microcluster/database/node.go
+++ b/sunbeam-microcluster/database/node.go
@@ -37,6 +37,7 @@ type Node struct {
 	Name      string `db:"primary=yes"`
 	Role      string
 	MachineID int
+	SystemID  string
 }
 
 // NodeFilter is a required struct for use with lxd-generate. It is used for filtering fields on database fetches.

--- a/sunbeam-microcluster/database/node.mapper.go
+++ b/sunbeam-microcluster/database/node.mapper.go
@@ -18,14 +18,14 @@ import (
 var _ = api.ServerEnvironment{}
 
 var nodeObjects = cluster.RegisterStmt(`
-SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id
+SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
   FROM nodes
   JOIN internal_cluster_members ON nodes.member_id = internal_cluster_members.id
   ORDER BY nodes.name
 `)
 
 var nodeObjectsByMember = cluster.RegisterStmt(`
-SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id
+SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
   FROM nodes
   JOIN internal_cluster_members ON nodes.member_id = internal_cluster_members.id
   WHERE ( member = ? )
@@ -33,7 +33,7 @@ SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role
 `)
 
 var nodeObjectsByName = cluster.RegisterStmt(`
-SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id
+SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
   FROM nodes
   JOIN internal_cluster_members ON nodes.member_id = internal_cluster_members.id
   WHERE ( nodes.name = ? )
@@ -41,7 +41,7 @@ SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role
 `)
 
 var nodeObjectsByRole = cluster.RegisterStmt(`
-SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id
+SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
   FROM nodes
   JOIN internal_cluster_members ON nodes.member_id = internal_cluster_members.id
   WHERE ( nodes.role = ? )
@@ -49,7 +49,7 @@ SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role
 `)
 
 var nodeObjectsByMachineID = cluster.RegisterStmt(`
-SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id
+SELECT nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
   FROM nodes
   JOIN internal_cluster_members ON nodes.member_id = internal_cluster_members.id
   WHERE ( nodes.machine_id = ? )
@@ -62,8 +62,8 @@ SELECT nodes.id FROM nodes
 `)
 
 var nodeCreate = cluster.RegisterStmt(`
-INSERT INTO nodes (member_id, name, role, machine_id)
-  VALUES ((SELECT internal_cluster_members.id FROM internal_cluster_members WHERE internal_cluster_members.name = ?), ?, ?, ?)
+INSERT INTO nodes (member_id, name, role, machine_id, system_id)
+  VALUES ((SELECT internal_cluster_members.id FROM internal_cluster_members WHERE internal_cluster_members.name = ?), ?, ?, ?, ?)
 `)
 
 var nodeDeleteByName = cluster.RegisterStmt(`
@@ -72,14 +72,14 @@ DELETE FROM nodes WHERE name = ?
 
 var nodeUpdate = cluster.RegisterStmt(`
 UPDATE nodes
-  SET member_id = (SELECT internal_cluster_members.id FROM internal_cluster_members WHERE internal_cluster_members.name = ?), name = ?, role = ?, machine_id = ?
+  SET member_id = (SELECT internal_cluster_members.id FROM internal_cluster_members WHERE internal_cluster_members.name = ?), name = ?, role = ?, machine_id = ?, system_id = ?
  WHERE id = ?
 `)
 
 // nodeColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the Node entity.
 func nodeColumns() string {
-	return "nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id"
+	return "nodes.id, internal_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id"
 }
 
 // getNodes can be used to run handwritten sql.Stmts to return a slice of objects.
@@ -88,7 +88,7 @@ func getNodes(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Node, error) 
 
 	dest := func(scan func(dest ...any) error) error {
 		n := Node{}
-		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID)
+		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID)
 		if err != nil {
 			return err
 		}
@@ -106,13 +106,13 @@ func getNodes(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Node, error) 
 	return objects, nil
 }
 
-// getNodes can be used to run handwritten query strings to return a slice of objects.
+// getNodesRaw can be used to run handwritten query strings to return a slice of objects.
 func getNodesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Node, error) {
 	objects := make([]Node, 0)
 
 	dest := func(scan func(dest ...any) error) error {
 		n := Node{}
-		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID)
+		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID)
 		if err != nil {
 			return err
 		}
@@ -340,13 +340,14 @@ func CreateNode(ctx context.Context, tx *sql.Tx, object Node) (int64, error) {
 		return -1, api.StatusErrorf(http.StatusConflict, "This \"nodes\" entry already exists")
 	}
 
-	args := make([]any, 4)
+	args := make([]any, 5)
 
 	// Populate the statement arguments.
 	args[0] = object.Member
 	args[1] = object.Name
 	args[2] = object.Role
 	args[3] = object.MachineID
+	args[4] = object.SystemID
 
 	// Prepared statement to use.
 	stmt, err := cluster.Stmt(tx, nodeCreate)
@@ -408,7 +409,7 @@ func UpdateNode(ctx context.Context, tx *sql.Tx, name string, object Node) error
 		return fmt.Errorf("Failed to get \"nodeUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Member, object.Name, object.Role, object.MachineID, id)
+	result, err := stmt.Exec(object.Member, object.Name, object.Role, object.MachineID, object.SystemID, id)
 	if err != nil {
 		return fmt.Errorf("Update \"nodes\" entry failed: %w", err)
 	}

--- a/sunbeam-microcluster/database/schema.go
+++ b/sunbeam-microcluster/database/schema.go
@@ -14,6 +14,7 @@ var SchemaExtensions = map[int]schema.Update{
 	1: NodesSchemaUpdate,
 	2: ConfigSchemaUpdate,
 	3: JujuUserSchemaUpdate,
+	4: AddSystemIDToNodes,
 }
 
 // NodesSchemaUpdate is schema for table nodes
@@ -60,6 +61,17 @@ CREATE TABLE jujuuser (
   token                         TEXT     NOT  NULL,
   UNIQUE(username)
 );
+  `
+
+	_, err := tx.Exec(stmt)
+
+	return err
+}
+
+// AddSystemIDToNodes is schema update for table nodes
+func AddSystemIDToNodes(_ context.Context, tx *sql.Tx) error {
+	stmt := `
+ALTER TABLE nodes ADD COLUMN system_id TEXT default '';
   `
 
 	_, err := tx.Exec(stmt)

--- a/sunbeam-microcluster/sunbeam/nodes.go
+++ b/sunbeam-microcluster/sunbeam/nodes.go
@@ -33,6 +33,7 @@ func ListNodes(s *state.State, roles []string) (types.Nodes, error) {
 				Name:      node.Name,
 				Role:      nodeRole,
 				MachineID: node.MachineID,
+				SystemID:  node.SystemID,
 			})
 		}
 
@@ -61,6 +62,7 @@ func GetNode(s *state.State, name string) (types.Node, error) {
 		node.Name = record.Name
 		node.Role = nodeRole
 		node.MachineID = record.MachineID
+		node.SystemID = record.SystemID
 
 		return nil
 	})
@@ -69,14 +71,14 @@ func GetNode(s *state.State, name string) (types.Node, error) {
 }
 
 // AddNode adds a node to the database
-func AddNode(s *state.State, name string, role []string, machineid int) error {
+func AddNode(s *state.State, name string, role []string, machineid int, systemid string) error {
 	nodeRole, err := roleToStr(role)
 	if err != nil {
 		return err
 	}
 	// Add node to the database.
 	err = s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
-		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid})
+		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid})
 		if err != nil {
 			return fmt.Errorf("Failed to record node: %w", err)
 		}
@@ -91,7 +93,7 @@ func AddNode(s *state.State, name string, role []string, machineid int) error {
 }
 
 // UpdateNode updates a node record in the database
-func UpdateNode(s *state.State, name string, role []string, machineid int) error {
+func UpdateNode(s *state.State, name string, role []string, machineid int, systemid string) error {
 	nodeRole, err := roleToStr(role)
 	if err != nil {
 		return err
@@ -109,8 +111,11 @@ func UpdateNode(s *state.State, name string, role []string, machineid int) error
 		if machineid == -1 {
 			machineid = node.MachineID
 		}
+		if systemid == "" {
+			systemid = node.SystemID
+		}
 
-		err = database.UpdateNode(ctx, tx, name, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid})
+		err = database.UpdateNode(ctx, tx, name, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid})
 		if err != nil {
 			return fmt.Errorf("Failed to update record node: %w", err)
 		}

--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -15,7 +15,7 @@
 
 import json
 import logging
-from typing import Any, List, Optional, Union
+from typing import Any, List, Union
 
 from requests import codes
 from requests.models import HTTPError
@@ -107,9 +107,16 @@ class MicroClusterService(service.BaseService):
 class ExtendedAPIService(service.BaseService):
     """Client for Sunbeam extended Cluster API."""
 
-    def add_node_info(self, name: str, role: List[str], machineid: int = -1) -> None:
+    def add_node_info(
+        self, name: str, role: List[str], machineid: int = -1, systemid: str = ""
+    ) -> None:
         """Add Node information to cluster database."""
-        data = {"name": name, "role": role, "machineid": machineid}
+        data = {
+            "name": name,
+            "role": role,
+            "machineid": machineid,
+            "systemid": systemid,
+        }
         self._post("/1.0/nodes", data=json.dumps(data))
 
     def list_nodes(self) -> list[dict]:
@@ -126,10 +133,14 @@ class ExtendedAPIService(service.BaseService):
         self._delete(f"1.0/nodes/{name}")
 
     def update_node_info(
-        self, name: str, role: Optional[List[str]] = None, machineid: int = -1
+        self,
+        name: str,
+        role: list[str] | None = None,
+        machineid: int = -1,
+        systemid: str = "",
     ) -> None:
         """Update role and machineid for node."""
-        data = {"role": role, "machineid": machineid}
+        data = {"role": role, "machineid": machineid, "systemid": systemid}
         self._put(f"1.0/nodes/{name}", data=json.dumps(data))
 
     def add_juju_user(self, name: str, token: str) -> None:


### PR DESCRIPTION
Since sunbeam deployments are walled-off in resource pools, use the system id for the machine instead of hostname not to get the wrong machine in MAAS. (Multiple machine could have the same name in different resource pools.)