### PR TITLE
Get tfhelper from manifest

### DIFF
--- a/sunbeam-python/tests/unit/sunbeam/commands/test_generate_cloud_config.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_generate_cloud_config.py
@@ -158,10 +158,7 @@ class TestConfigureCloudsYamlStep:
 """
         assert contents == expect
 
-    def test_run_with_update_false(
-        self, mocker, cclient, tfhelper, snap, environ, cprint
-    ):
-        mocker.patch.object(generate, "Snap", return_value=snap)
+    def test_run_with_update_false(self, cclient, tfhelper, environ, cprint):
         environ.copy.return_value = {}
 
         creds = {


### PR DESCRIPTION
`launch` and `generate-cloud-config` commands instantiated tfhelper manually instead of getting them from manifest.