### PR TITLE
Add TLS CA plugin

### DIFF
--- a/sunbeam-python/sunbeam/plugins/ca/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/ca/plugin.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+from typing import List, Optional
+
+import click
+from packaging.version import Version
+from rich.console import Console
+from rich.status import Status
+
+from sunbeam.clusterd.client import Client
+from sunbeam.clusterd.service import (
+    ClusterServiceUnavailableException,
+    ConfigItemNotFoundException,
+)
+from sunbeam.commands.openstack import OPENSTACK_MODEL
+from sunbeam.jobs import questions
+from sunbeam.jobs.common import BaseStep, Result, ResultType, read_config, run_plan
+from sunbeam.jobs.juju import (
+    ActionFailedException,
+    JujuHelper,
+    LeaderNotFoundException,
+    run_sync,
+)
+from sunbeam.plugins.interface.utils import (
+    encode_base64_as_string,
+    get_subject_from_csr,
+    is_certificate_valid,
+    validate_ca_certificate,
+    validate_ca_chain,
+)
+from sunbeam.plugins.interface.v1.openstack import TerraformPlanLocation
+from sunbeam.plugins.interface.v1.tls import TlsPluginGroup
+
+CERTIFICATE_PLUGIN_KEY = "TlsProvider"
+CA_APP_NAME = "manual-tls-certificates"
+LOG = logging.getLogger(__name__)
+console = Console()
+
+
+def certificate_questions(unit: str, subject: str):
+    return {
+        "certificate": questions.PromptQuestion(
+            f"Base64 encoded Certificate for {unit} CSR Unique ID: {subject}",
+        ),
+    }
+
+
+class ConfigureCAStep(BaseStep):
+    """Configure CA certificates"""
+
+    _CONFIG = "PluginCACertificatesConfig"
+
+    def __init__(
+        self,
+        client: Client,
+        jhelper: JujuHelper,
+        ca_cert: str,
+        ca_chain: str,
+        deployment_preseed: dict | None = None,
+    ):
+        super().__init__("Configure CA certs", "Configuring CA certificates")
+        self.client = client
+        self.jhelper = jhelper
+        self.ca_cert = ca_cert
+        self.ca_chain = ca_chain
+        self.preseed = deployment_preseed or {}
+        self.app = CA_APP_NAME
+        self.model = OPENSTACK_MODEL
+        self.process_certs = {}
+
+    def has_prompts(self) -> bool:
+        return True
+
+    def prompt(self, console: Optional[Console] = None) -> None:
+        """Prompt the user for certificates.
+
+        Prompts the user for required information for cert configuration.
+
+        :param console: the console to prompt on
+        :type console: rich.console.Console (Optional)
+        """
+        action_cmd = "get-outstanding-certificate-requests"
+        try:
+            unit = run_sync(self.jhelper.get_leader_unit(self.app, self.model))
+        except LeaderNotFoundException as e:
+            LOG.debug(f"Unable to get {self.app} leader")
+            return Result(ResultType.FAILED, str(e))
+
+        try:
+            action_result = run_sync(
+                self.jhelper.run_action(unit, self.model, action_cmd)
+            )
+        except ActionFailedException as e:
+            LOG.debug(f"Running action {action_cmd} on {unit} failed")
+            return Result(ResultType.FAILED, str(e))
+
+        LOG.debug(f"Result from action {action_cmd}: {action_result}")
+        if action_result.get("return-code", 0) > 1:
+            raise click.ClickException(
+                "Unable to get outstanding certificate requests from CA"
+            )
+
+        certs_to_process = json.loads(action_result.get("result"))
+        if not certs_to_process:
+            LOG.debug("No outstanding certificates to process")
+            return
+
+        variables = questions.load_answers(self.client, self._CONFIG)
+        variables.setdefault("certificates", {})
+        self.preseed.setdefault("certificates", {})
+
+        for record in certs_to_process:
+            unit_name = record.get("unit_name")
+            unit_csrs = record.get("unit_csrs")
+            app = record.get("application_name")
+            relation_id = record.get("relation_id")
+
+            # Each unit can have multiple CSRs
+            for csr in unit_csrs:
+                csr = csr.get("certificate_signing_request")
+                subject = get_subject_from_csr(csr)
+                if not subject:
+                    raise click.ClickException(f"Not a valid CSR for unit {unit_name}")
+
+                cert_questions = certificate_questions(unit_name, subject)
+                certificates_bank = questions.QuestionBank(
+                    questions=cert_questions,
+                    console=console,
+                    preseed=self.preseed.get("certificates").get(subject),
+                    previous_answers=variables.get("certificates").get(subject),
+                )
+                cert = certificates_bank.certificate.ask()
+                if not is_certificate_valid(cert):
+                    raise click.ClickException("Not a valid certificate")
+
+                self.process_certs[subject] = {
+                    "app": app,
+                    "unit": unit_name,
+                    "relation_id": relation_id,
+                    "csr": csr,
+                    "certificate": cert,
+                }
+                variables["certificates"].setdefault(subject, {})
+                variables["certificates"][subject]["certificate"] = cert
+
+        questions.write_answers(self.client, self._CONFIG, variables)
+
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Run configure steps."""
+        action_cmd = "provide-certificate"
+        try:
+            unit = run_sync(self.jhelper.get_leader_unit(self.app, self.model))
+        except LeaderNotFoundException as e:
+            LOG.debug(f"Unable to get {self.app} leader")
+            return Result(ResultType.FAILED, str(e))
+
+        LOG.debug(f"Process certs: {self.process_certs}")
+        for subject, request in self.process_certs.items():
+            csr = request.get("csr")
+            csr = encode_base64_as_string(csr)
+            if not csr:
+                return Result(ResultType.FAILED)
+
+            action_params = {
+                "relation-id": request.get("relation_id"),
+                "certificate": request.get("certificate"),
+                "ca-chain": self.ca_chain,
+                "ca-certificate": self.ca_cert,
+                "certificate-signing-request": str(csr),
+                "unit-name": request.get("unit"),
+            }
+
+            LOG.debug(f"Running action {action_cmd} with params {action_params}")
+            try:
+                action_result = run_sync(
+                    self.jhelper.run_action(unit, self.model, action_cmd, action_params)
+                )
+            except ActionFailedException as e:
+                LOG.debug(f"Running action {action_cmd} on {unit} failed")
+                return Result(ResultType.FAILED, str(e))
+
+            LOG.debug(f"Result from action {action_cmd}: {action_result}")
+            if action_result.get("return-code", 0) > 1:
+                return Result(
+                    ResultType.FAILED, f"Action {action_cmd} on {unit} returned error"
+                )
+
+        return Result(ResultType.COMPLETED)
+
+
+class CaTlsPlugin(TlsPluginGroup):
+    version = Version("0.0.1")
+
+    def __init__(self, client: Client) -> None:
+        super().__init__(
+            "ca", client, tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO
+        )
+        self.endpoints = []
+
+    def manifest_defaults(self) -> dict:
+        """Manifest plugin part in dict format."""
+        return {"charms": {"manual-tls-certificates": {"channel": "latest/stable"}}}
+
+    def manifest_attributes_tfvar_map(self) -> dict:
+        """Manifest attributes terraformvars map."""
+        return {
+            self.tfplan: {
+                "charms": {
+                    "manual-tls-certificates": {
+                        "channel": "manual-tls-certificates-channel",
+                        "revision": "manual-tls-certificates-revision",
+                        "config": "manual-tls-certificates-config",
+                    }
+                }
+            }
+        }
+
+    @click.command()
+    @click.option(
+        "--endpoint",
+        "endpoints",
+        multiple=True,
+        default=["public"],
+        type=click.Choice(["public", "internal"], case_sensitive=False),
+        help="Specify endpoints to apply tls.",
+    )
+    @click.option(
+        "--ca-chain",
+        required=True,
+        type=str,
+        callback=validate_ca_chain,
+        help="Base64 encoded CA Chain certificate",
+    )
+    @click.option(
+        "--ca",
+        required=True,
+        type=str,
+        callback=validate_ca_certificate,
+        help="Base64 encoded CA certificate",
+    )
+    def enable_plugin(self, ca: str, ca_chain: str, endpoints: List[str]):
+        self.ca = ca
+        self.ca_chain = ca_chain
+        self.endpoints = endpoints
+        super().enable_plugin()
+        console.print("CA plugin enabled")
+
+    @click.command()
+    def disable_plugin(self):
+        super().disable_plugin()
+        console.print("CA plugin disabled")
+
+    def set_application_names(self) -> list:
+        """Application names handled by the terraform plan."""
+        return ["manual-tls-certificates"]
+
+    def set_tfvars_on_enable(self) -> dict:
+        """Set terraform variables to enable the application."""
+        tfvars = {"traefik-to-tls-provider": CA_APP_NAME}
+        if "public" in self.endpoints:
+            tfvars.update({"enable-tls-for-public-endpoint": True})
+        if "internal" in self.endpoints:
+            tfvars.update({"enable-tls-for-internal-endpoint": True})
+
+        return tfvars
+
+    def set_tfvars_on_disable(self) -> dict:
+        """Set terraform variables to disable the application."""
+        tfvars = {"traefik-to-tls-provider": None}
+        if "public" in self.endpoints:
+            tfvars.update({"enable-tls-for-public-endpoint": False})
+        if "internal" in self.endpoints:
+            tfvars.update({"enable-tls-for-internal-endpoint": False})
+
+        return tfvars
+
+    def set_tfvars_on_resize(self) -> dict:
+        """Set terraform variables to resize the application."""
+        return {}
+
+    @click.group()
+    def tls_group(self) -> None:
+        """Manage TLS."""
+
+    @click.group()
+    def ca_group(self) -> None:
+        """Manage CA."""
+
+    @click.command()
+    def configure(self) -> None:
+        """Configure CA certs."""
+        try:
+            config = read_config(self.client, CERTIFICATE_PLUGIN_KEY)
+        except ConfigItemNotFoundException:
+            config = {}
+        self.ca = config.get("ca")
+        self.ca_chain = config.get("chain")
+
+        data_location = self.snap.paths.user_data
+        jhelper = JujuHelper(self.client, data_location)
+        plan = [
+            ConfigureCAStep(
+                self.client,
+                jhelper,
+                self.ca,
+                self.ca_chain,
+            )
+        ]
+        run_plan(plan, console)
+        click.echo("CA certs configured")
+
+    def commands(self) -> dict:
+        try:
+            enabled = self.enabled
+        except ClusterServiceUnavailableException:
+            LOG.debug(
+                "Failed to query for plugin status, is cloud bootstrapped ?",
+                exc_info=True,
+            )
+            enabled = False
+
+        commands = super().commands()
+        commands.update(
+            {
+                "enable.tls": [{"name": self.name, "command": self.enable_plugin}],
+                "disable.tls": [{"name": self.name, "command": self.disable_plugin}],
+            }
+        )
+        if enabled:
+            commands.update(
+                {
+                    "init": [{"name": self.group, "command": self.tls_group}],
+                    "init.tls": [{"name": self.name, "command": self.ca_group}],
+                    "init.tls.ca": [{"name": "configure", "command": self.configure}],
+                }
+            )
+
+        return commands

--- a/sunbeam-python/sunbeam/plugins/dns/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/dns/plugin.py
@@ -200,7 +200,7 @@ class DnsPlugin(OpenStackControlPlanePlugin):
             commands.update(
                 {
                     "init": [{"name": "dns", "command": self.dns_groups}],
-                    "dns": [{"name": "address", "command": self.dns_address}],
+                    "init.dns": [{"name": "address", "command": self.dns_address}],
                 }
             )
         return commands

--- a/sunbeam-python/sunbeam/plugins/interface/utils.py
+++ b/sunbeam-python/sunbeam/plugins/interface/utils.py
@@ -14,9 +14,15 @@
 # limitations under the License.
 
 
+import base64
+import binascii
 import logging
+import re
 
 import click
+from cryptography.exceptions import InvalidSignature
+from cryptography.x509 import load_pem_x509_certificate, load_pem_x509_csr
+from cryptography.x509.oid import NameOID
 
 LOG = logging.getLogger()
 
@@ -55,3 +61,95 @@ def get_all_registered_groups(cli: click.Group) -> dict:
     groups = _get_all_groups(cli)
     groups["init"] = cli
     return groups
+
+
+def is_certificate_valid(certificate: bytes) -> bool:
+    try:
+        certificate_bytes = base64.b64decode(certificate)
+        load_pem_x509_certificate(certificate_bytes)
+    except (binascii.Error, TypeError, ValueError) as e:
+        LOG.debug(e)
+        return False
+
+    return True
+
+
+def validate_ca_certificate(
+    ctx: click.core.Context, param: click.core.Option, value: str
+) -> str:
+    try:
+        ca_bytes = base64.b64decode(value)
+        load_pem_x509_certificate(ca_bytes)
+        return value
+    except (binascii.Error, TypeError, ValueError) as e:
+        LOG.debug(e)
+        raise click.BadParameter(str(e))
+
+
+def validate_ca_chain(
+    ctx: click.core.Context, param: click.core.Option, value: str
+) -> str:
+    try:
+        chain_bytes = base64.b64decode(value)
+        chain_list = re.findall(
+            pattern=(
+                "(?=-----BEGIN CERTIFICATE-----)(.*?)" "(?<=-----END CERTIFICATE-----)"
+            ),
+            string=chain_bytes.decode(),
+            flags=re.DOTALL,
+        )
+        if len(chain_list) == 0:
+            LOG.debug("Empty CA Chain provided by user")
+            return value
+
+        if len(chain_list) < 2:
+            raise ValueError(
+                "Invalid CA chain: It must contain at least 2 certificates."
+            )
+
+        for cert in chain_list:
+            cert_bytes = cert.encode()
+            load_pem_x509_certificate(cert_bytes)
+
+        for ca_cert, cert in zip(chain_list, chain_list[1:]):
+            ca_cert_object = load_pem_x509_certificate(ca_cert.encode("utf-8"))
+            cert_object = load_pem_x509_certificate(cert.encode("utf-8"))
+            try:
+                # function available from cryptography 40.0.0
+                # Antelope upper constraints has cryptography < 40.0.0
+                cert_object.verify_directly_issued_by(ca_cert_object)
+            except AttributeError:
+                LOG.debug("CA Chain certs not verified")
+
+        return value
+    except (binascii.Error, TypeError, ValueError, InvalidSignature) as e:
+        LOG.debug(e)
+        raise click.BadParameter(str(e))
+
+
+def get_subject_from_csr(csr: str) -> str | None:
+    try:
+        req = load_pem_x509_csr(bytes(csr, "utf-8"))
+        uid = req.subject.get_attributes_for_oid(NameOID.X500_UNIQUE_IDENTIFIER)
+        LOG.debug(f"UID for requested csr: {uid}")
+        # Pick the first available ID
+        return uid[0].value
+    except (binascii.Error, TypeError, ValueError) as e:
+        LOG.debug(e)
+        return None
+
+
+def encode_base64_as_string(data: str) -> str:
+    try:
+        return base64.b64encode(bytes(data, "utf-8")).decode()
+    except (binascii.Error, TypeError) as e:
+        LOG.debug(f"Error in encoding data {data} : {str(e)}")
+        return None
+
+
+def decode_base64_as_string(data: str) -> str:
+    try:
+        return base64.b64decode(data).decode()
+    except (binascii.Error, TypeError) as e:
+        LOG.debug(f"Error in decoding data {data} : {str(e)}")
+        return None

--- a/sunbeam-python/sunbeam/plugins/interface/v1/base.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/base.py
@@ -431,7 +431,7 @@ class BasePlugin(ABC):
                 # commands within the plugin can be registered on group.
                 # This allows plugin to create new groups and commands in single place.
                 if isinstance(cmd, click.Group):
-                    groups[cmd_name] = cmd
+                    groups[f"{group}.{cmd_name}"] = cmd
 
 
 class PluginRequirement(Requirement):
@@ -638,8 +638,16 @@ class EnableDisablePlugin(BasePlugin):
     @abstractmethod
     def enable_plugin(self) -> None:
         """Enable plugin command."""
+        self.user_manifest = None
         current_click_context = click.get_current_context()
-        self.user_manifest = current_click_context.parent.params.get("manifest")
+        while current_click_context.parent is not None:
+            if (
+                current_click_context.parent.command.name == "enable"
+                and "manifest" in current_click_context.parent.params  # noqa: W503
+            ):
+                self.user_manifest = current_click_context.parent.params.get("manifest")
+            current_click_context = current_click_context.parent
+
         self.pre_enable()
         self.run_enable_plans()
         self.post_enable()

--- a/sunbeam-python/sunbeam/plugins/interface/v1/tls.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/tls.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Optional
+
+import click
+from packaging.version import Version
+from rich.console import Console
+from rich.status import Status
+
+from sunbeam.clusterd.client import Client
+from sunbeam.clusterd.service import ConfigItemNotFoundException
+from sunbeam.commands.openstack import OPENSTACK_MODEL
+from sunbeam.jobs.common import (
+    BaseStep,
+    Result,
+    ResultType,
+    read_config,
+    run_plan,
+    update_config,
+)
+from sunbeam.jobs.juju import (
+    ActionFailedException,
+    JujuHelper,
+    LeaderNotFoundException,
+    run_sync,
+)
+from sunbeam.plugins.interface.v1.openstack import (
+    OpenStackControlPlanePlugin,
+    TerraformPlanLocation,
+)
+
+CERTIFICATE_PLUGIN_KEY = "TlsProvider"
+LOG = logging.getLogger(__name__)
+console = Console()
+
+
+class TlsPluginGroup(OpenStackControlPlanePlugin):
+    version = Version("0.0.1")
+
+    def __init__(
+        self, name: str, client: Client, tf_plan_location: TerraformPlanLocation
+    ) -> None:
+        super().__init__(name, client, tf_plan_location)
+        self.group = "tls"
+        self.ca = None
+        self.ca_chain = None
+
+    @click.group()
+    def enable_tls(self) -> None:
+        """Enable TLS group."""
+
+    @click.group()
+    def disable_tls(self) -> None:
+        """Disable TLS group."""
+
+    def commands(self) -> dict:
+        return {
+            "enable": [{"name": self.group, "command": self.enable_tls}],
+            "disable": [{"name": self.group, "command": self.disable_tls}],
+        }
+
+    def pre_enable(self):
+        """Handler to perform tasks before enabling the plugin."""
+        super().pre_enable()
+        try:
+            config = read_config(self.client, CERTIFICATE_PLUGIN_KEY)
+        except ConfigItemNotFoundException:
+            config = {}
+
+        provider = config.get("provider")
+        if provider and provider != self.name:
+            raise Exception(f"Certificate provider already set to {provider!r}")
+
+    def post_enable(self) -> None:
+        """Handler to perform tasks after the plugin is enabled."""
+        super().post_enable()
+        data_location = self.snap.paths.user_data
+        jhelper = JujuHelper(self.client, data_location)
+        plan = [
+            AddCACertsToKeystoneStep(jhelper, self.plugin_key, self.ca, self.ca_chain)
+        ]
+        run_plan(plan, console)
+
+        config = {
+            "provider": self.name,
+            "ca": self.ca,
+            "chain": self.ca_chain,
+            "endpoints": self.endpoints,
+        }
+        update_config(self.client, CERTIFICATE_PLUGIN_KEY, config)
+
+    def post_disable(self) -> None:
+        """Handler to perform tasks after the plugin is disabled."""
+        super().post_disable()
+        data_location = self.snap.paths.user_data
+        jhelper = JujuHelper(self.client, data_location)
+        plan = [RemoveCACertsFromKeystoneStep(jhelper, self.plugin_key)]
+        run_plan(plan, console)
+
+        config = {}
+        update_config(self.client, CERTIFICATE_PLUGIN_KEY, config)
+
+
+class AddCACertsToKeystoneStep(BaseStep):
+    """Transfer CA certificates"""
+
+    def __init__(
+        self,
+        jhelper: JujuHelper,
+        name: str,
+        ca_cert: str,
+        ca_chain: str,
+    ):
+        super().__init__(
+            "Transfer CA certs to keystone", "Transferring CA certificates to keystone"
+        )
+        self.jhelper = jhelper
+        self.name = name.lower()
+        self.ca_cert = ca_cert
+        self.ca_chain = ca_chain
+        self.app = "keystone"
+        self.model = OPENSTACK_MODEL
+
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        action_cmd = "list-ca-certs"
+        try:
+            unit = run_sync(self.jhelper.get_leader_unit(self.app, self.model))
+        except LeaderNotFoundException as e:
+            LOG.debug(f"Unable to get {self.app} leader")
+            return Result(ResultType.FAILED, str(e))
+
+        try:
+            action_result = run_sync(
+                self.jhelper.run_action(unit, self.model, action_cmd)
+            )
+        except ActionFailedException as e:
+            LOG.debug(f"Running action {action_cmd} on {unit} failed")
+            return Result(ResultType.FAILED, str(e))
+
+        LOG.debug(f"Result from action {action_cmd}: {action_result}")
+        if action_result.get("return-code", 0) > 1:
+            return Result(
+                ResultType.FAILED, f"Action {action_cmd} on {unit} returned error"
+            )
+
+        action_result.pop("return-code")
+        ca_list = action_result
+        if self.name in ca_list:
+            return Result(ResultType.SKIPPED)
+
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Run keystone add-ca-certs action."""
+        action_cmd = "add-ca-certs"
+        try:
+            unit = run_sync(self.jhelper.get_leader_unit(self.app, self.model))
+        except LeaderNotFoundException as e:
+            LOG.debug(f"Unable to get {self.app} leader")
+            return Result(ResultType.FAILED, str(e))
+
+        action_params = {
+            "name": self.name,
+            "ca": self.ca_cert,
+            "chain": self.ca_chain,
+        }
+
+        try:
+            LOG.debug(f"Running action {action_cmd} with params {action_params}")
+            action_result = run_sync(
+                self.jhelper.run_action(unit, self.model, action_cmd, action_params)
+            )
+        except ActionFailedException as e:
+            LOG.debug(f"Running action {action_cmd} on {unit} failed")
+            return Result(ResultType.FAILED, str(e))
+
+        LOG.debug(f"Result from action {action_cmd}: {action_result}")
+        if action_result.get("return-code", 0) > 1:
+            return Result(
+                ResultType.FAILED, f"Action {action_cmd} on {unit} returned error"
+            )
+
+        return Result(ResultType.COMPLETED)
+
+
+class RemoveCACertsFromKeystoneStep(BaseStep):
+    """Remove CA certificates"""
+
+    def __init__(
+        self,
+        jhelper: JujuHelper,
+        name: str,
+    ):
+        super().__init__(
+            "Remove CA certs from keystone", "Removing CA certificates from keystone"
+        )
+        self.jhelper = jhelper
+        self.name = name.lower()
+        self.app = "keystone"
+        self.model = OPENSTACK_MODEL
+
+    def is_skip(self, status: Optional[Status] = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        action_cmd = "list-ca-certs"
+        try:
+            unit = run_sync(self.jhelper.get_leader_unit(self.app, self.model))
+        except LeaderNotFoundException as e:
+            LOG.debug(f"Unable to get {self.app} leader")
+            return Result(ResultType.FAILED, str(e))
+
+        try:
+            action_result = run_sync(
+                self.jhelper.run_action(unit, self.model, action_cmd)
+            )
+        except ActionFailedException as e:
+            LOG.debug(f"Running action {action_cmd} on {unit} failed")
+            return Result(ResultType.FAILED, str(e))
+
+        LOG.debug(f"Result from action {action_cmd}: {action_result}")
+        if action_result.get("return-code", 0) > 1:
+            return Result(
+                ResultType.FAILED, f"Action {action_cmd} on {unit} returned error"
+            )
+
+        action_result.pop("return-code")
+        ca_list = action_result
+        if self.name not in ca_list:
+            return Result(ResultType.SKIPPED)
+
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Run keystone add-ca-certs action."""
+        action_cmd = "remove-ca-certs"
+        try:
+            unit = run_sync(self.jhelper.get_leader_unit(self.app, self.model))
+        except LeaderNotFoundException as e:
+            LOG.debug(f"Unable to get {self.app} leader")
+            return Result(ResultType.FAILED, str(e))
+
+        action_params = {"name": self.name}
+        LOG.debug(f"Running action {action_cmd} with params {action_params}")
+        try:
+            action_result = run_sync(
+                self.jhelper.run_action(unit, self.model, action_cmd, action_params)
+            )
+        except ActionFailedException as e:
+            LOG.debug(f"Running action {action_cmd} on {unit} failed")
+            return Result(ResultType.FAILED, str(e))
+
+        LOG.debug(f"Result from action {action_cmd}: {action_result}")
+        if action_result.get("return-code", 0) > 1:
+            return Result(
+                ResultType.FAILED, f"Action {action_cmd} on {unit} returned error"
+            )
+
+        return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/plugins/ldap/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/ldap/plugin.py
@@ -428,7 +428,7 @@ class LDAPPlugin(OpenStackControlPlanePlugin):
             commands.update(
                 {
                     "init": [{"name": "ldap", "command": self.ldap_groups}],
-                    "ldap": [
+                    "init.ldap": [
                         {"name": "list-domains", "command": self.list_domains},
                         {"name": "add-domain", "command": self.add_domain},
                         {"name": "update-domain", "command": self.update_domain},

--- a/sunbeam-python/sunbeam/plugins/observability/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/observability/plugin.py
@@ -720,7 +720,7 @@ class ObservabilityPlugin(EnableDisablePlugin):
                     "init": [
                         {"name": "observability", "command": self.observability_group}
                     ],
-                    "observability": [
+                    "init.observability": [
                         {"name": "dashboard-url", "command": self.dashboard_url}
                     ],
                 }

--- a/sunbeam-python/sunbeam/plugins/plugins.yaml
+++ b/sunbeam-python/sunbeam/plugins/plugins.yaml
@@ -67,3 +67,9 @@ sunbeam-plugins:
       path: sunbeam.plugins.ldap.plugin.LDAPPlugin
       supported_architectures:
         - amd64
+    - name: "ca"
+      version: "0.0.1"
+      description: "Plugin for TLS Manual Certificates"
+      path: sunbeam.plugins.ca.plugin.CaTlsPlugin
+      supported_architectures:
+        - amd64

--- a/sunbeam-python/sunbeam/plugins/repo/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/repo/plugin.py
@@ -226,7 +226,7 @@ class RepoPlugin(BasePlugin):
     def commands(self) -> dict:
         return {
             "init": [{"name": self.name, "command": self.repo}],
-            "repo": [
+            "init.repo": [
                 {"name": "add", "command": self.add},
                 {"name": "remove", "command": self.remove},
                 {"name": "list", "command": self.list},


### PR DESCRIPTION
Add TLS CA plugin to enable manual-tls-certificate operator. The plugin takes ca certificate and chain as arguments. Endpoints can be specified to integrate operator with traefik-public or traefik internal.

Add command configure to get the certificate from
user and update certificates in the traefik application.

Transfer the CA and chain certificate to keystone so that the certs can be distributed.