### PR TITLE
Make observability hard depend on telemetry

### DIFF
--- a/sunbeam-python/sunbeam/plugins/observability/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/observability/plugin.py
@@ -475,7 +475,7 @@ class PatchCosLoadBalancerStep(PatchLoadBalancerServicesStep):
 
 class ObservabilityPlugin(EnableDisablePlugin):
     version = Version("0.0.1")
-    requires = {PluginRequirement("telemetry", optional=True)}
+    requires = {PluginRequirement("telemetry")}
 
     def __init__(self, client: Client) -> None:
         super().__init__("observability", client)


### PR DESCRIPTION
Telemetry was an optional dependency of Observability. Make it not optional anymore.