### PR TITLE
Add CA Cert to cloud config and openrc

### DIFF
--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -48,7 +48,9 @@ from sunbeam.jobs.common import (
 )
 from sunbeam.jobs.juju import (
     CONTROLLER_MODEL,
+    ActionFailedException,
     JujuHelper,
+    LeaderNotFoundException,
     ModelNotFoundException,
     run_sync,
 )
@@ -264,17 +266,21 @@ def retrieve_admin_credentials(jhelper: JujuHelper, model: str) -> dict:
     app = "keystone"
     action_cmd = "get-admin-account"
 
-    unit = run_sync(jhelper.get_leader_unit(app, model))
-    if not unit:
-        _message = f"Unable to get {app} leader"
-        raise click.ClickException(_message)
+    try:
+        unit = run_sync(jhelper.get_leader_unit(app, model))
+    except LeaderNotFoundException:
+        raise click.ClickException(f"Unable to get {app} leader")
 
-    action_result = run_sync(jhelper.run_action(unit, model, action_cmd))
+    try:
+        action_result = run_sync(jhelper.run_action(unit, model, action_cmd))
+    except ActionFailedException as e:
+        LOG.debug(f"Running action {action_cmd} on {unit} failed: {str(e)}")
+        raise click.ClickException("Unable to retrieve openrc from Keystone service")
+
     if action_result.get("return-code", 0) > 1:
-        _message = "Unable to retrieve openrc from Keystone service"
-        raise click.ClickException(_message)
+        raise click.ClickException("Unable to retrieve openrc from Keystone service")
 
-    return {
+    params = {
         "OS_USERNAME": action_result.get("username"),
         "OS_PASSWORD": action_result.get("password"),
         "OS_AUTH_URL": action_result.get("public-endpoint"),
@@ -284,6 +290,46 @@ def retrieve_admin_credentials(jhelper: JujuHelper, model: str) -> dict:
         "OS_AUTH_VERSION": action_result.get("api-version"),
         "OS_IDENTITY_API_VERSION": action_result.get("api-version"),
     }
+
+    action_cmd = "list-ca-certs"
+    try:
+        action_result = run_sync(jhelper.run_action(unit, model, action_cmd))
+    except ActionFailedException as e:
+        LOG.debug(f"Running action {action_cmd} on {unit} failed: {str(e)}")
+        raise click.ClickException("Unable to retrieve CA certs from Keystone service")
+
+    if action_result.get("return-code", 0) > 1:
+        raise click.ClickException("Unable to retrieve CA certs from Keystone service")
+
+    action_result.pop("return-code")
+    ca_bundle = []
+    for name, certs in action_result.items():
+        # certs = json.loads(certs)
+        ca = certs.get("ca")
+        chain = certs.get("chain")
+        if ca and ca not in ca_bundle:
+            ca_bundle.append(ca)
+        if chain and chain not in ca_bundle:
+            ca_bundle.append(chain)
+
+    bundle = "\n".join(ca_bundle)
+
+    if bundle:
+        home = os.environ.get("SNAP_REAL_HOME")
+        cafile = Path(home) / ".config" / "openstack" / "ca_bundle.pem"
+        LOG.debug("Writing CA bundle to {str(cafile)}")
+
+        cafile.parent.mkdir(mode=0o775, parents=True, exist_ok=True)
+        if not cafile.exists():
+            cafile.touch()
+        cafile.chmod(0o660)
+
+        with cafile.open("w") as file:
+            file.write(bundle)
+
+        params["OS_CACERT"] = str(cafile)
+
+    return params
 
 
 class SetHypervisorCharmConfigStep(BaseStep):
@@ -358,12 +404,20 @@ class SetHypervisorCharmConfigStep(BaseStep):
 class UserOpenRCStep(BaseStep):
     """Generate openrc for created cloud user."""
 
-    def __init__(self, client: Client, auth_url: str, auth_version: str, openrc: Path):
+    def __init__(
+        self,
+        client: Client,
+        auth_url: str,
+        auth_version: str,
+        cacert: str | None,
+        openrc: Path,
+    ):
         super().__init__(
             "Generate admin openrc", "Generating openrc for cloud admin usage"
         )
         self.auth_url = auth_url
         self.auth_version = auth_version
+        self.cacert = cacert
         self.openrc = openrc
         self.client = client
 
@@ -416,6 +470,8 @@ export OS_PROJECT_DOMAIN_NAME={tf_output["OS_PROJECT_DOMAIN_NAME"]["value"]}
 export OS_PROJECT_NAME={tf_output["OS_PROJECT_NAME"]["value"]}
 export OS_AUTH_VERSION={self.auth_version}
 export OS_IDENTITY_API_VERSION={self.auth_version}"""
+        if self.cacert:
+            _openrc = f"{_openrc}\nexport OS_CACERT={self.cacert}"
         if self.openrc:
             message = f"Writing openrc to {self.openrc} ... "
             console.status(message)
@@ -768,6 +824,8 @@ def _configure(
         LOG.error(f"Expected model {OPENSTACK_MODEL} missing")
         raise click.ClickException("Please run `sunbeam cluster bootstrap` first")
     admin_credentials = retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)
+    # Add OS_INSECURE as https not working with terraform openstack provider.
+    admin_credentials["OS_INSECURE"] = "true"
     tfhelper = TerraformHelper(
         path=snap.paths.user_common / "etc" / tfplan_dir,
         env=admin_credentials,
@@ -794,6 +852,7 @@ def _configure(
             client=client,
             auth_url=admin_credentials["OS_AUTH_URL"],
             auth_version=admin_credentials["OS_AUTH_VERSION"],
+            cacert=admin_credentials.get("OS_CACERT"),
             openrc=openrc,
         ),
         SetHypervisorCharmConfigStep(client, jhelper, ext_network=answer_file),

--- a/sunbeam-python/sunbeam/commands/generate_cloud_config.py
+++ b/sunbeam-python/sunbeam/commands/generate_cloud_config.py
@@ -155,6 +155,9 @@ class GenerateCloudConfigStep(BaseStep):
                 },
             }
 
+        if self.admin_credentials.get("OS_CACERT"):
+            cloud_data[self.cloud]["cacert"] = self.admin_credentials["OS_CACERT"]
+
         return cloud_data
 
     def _get_cloud_config_from_file(self, clouds_yaml: Path) -> dict:

--- a/sunbeam-python/sunbeam/commands/launch.py
+++ b/sunbeam-python/sunbeam/commands/launch.py
@@ -101,6 +101,7 @@ def launch(
             project_name=tf_output["OS_PROJECT_NAME"]["value"],
             user_domain_name=tf_output["OS_USER_DOMAIN_NAME"]["value"],
             project_domain_name=tf_output["OS_PROJECT_DOMAIN_NAME"]["value"],
+            cacert=admin_auth_info.get("OS_CACERT"),
         )
     except openstack.exceptions.SDKException:
         LOG.error("Could not authenticate to Keystone.")

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_configure.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_configure.py
@@ -254,14 +254,18 @@ class TestUserOpenRCStep:
     def test_is_skip_with_demo(self, tmpdir, cclient, load_answers):
         outfile = tmpdir + "/" + "openrc"
         load_answers.return_value = {"user": {"run_demo_setup": True}}
-        step = configure.UserOpenRCStep(cclient, "http://keystone:5000", "3", outfile)
+        step = configure.UserOpenRCStep(
+            cclient, "http://keystone:5000", "3", None, outfile
+        )
         result = step.is_skip()
         assert result.result_type == ResultType.COMPLETED
 
     def test_is_skip(self, tmpdir, cclient, load_answers):
         outfile = tmpdir + "/" + "openrc"
         load_answers.return_value = {"user": {"run_demo_setup": False}}
-        step = configure.UserOpenRCStep(cclient, "http://keystone:5000", "3", outfile)
+        step = configure.UserOpenRCStep(
+            cclient, "http://keystone:5000", "3", None, outfile
+        )
         result = step.is_skip()
         assert result.result_type == ResultType.SKIPPED
 
@@ -282,7 +286,7 @@ class TestUserOpenRCStep:
         run.return_value = runout_mock
         auth_url = "http://keystone:5000"
         auth_version = 3
-        step = configure.UserOpenRCStep(cclient, auth_url, "3", outfile)
+        step = configure.UserOpenRCStep(cclient, auth_url, "3", None, outfile)
         step.run()
         with open(outfile, "r") as f:
             contents = f.read()


### PR DESCRIPTION
* Add CA Cert config option in generate cloud config
* Add CA cert option in configure command which generates openrc
* Use inseceure=true for configure command to apply terraform plan. This is due to terraform provider
openstack failure even though cacert is provided.
* Add CA cert config option to launch