### PR TITLE
Add validation plugin

### DIFF
--- a/sunbeam-python/requirements.txt
+++ b/sunbeam-python/requirements.txt
@@ -35,6 +35,9 @@ lightkube-models
 jsonschema
 GitPython
 
+# For plugin validation
+croniter
+
 # Regression introduced in 1.3.3
 macaroonbakery!=1.3.3
 

--- a/sunbeam-python/sunbeam/plugins/plugins.yaml
+++ b/sunbeam-python/sunbeam/plugins/plugins.yaml
@@ -73,3 +73,9 @@ sunbeam-plugins:
       path: sunbeam.plugins.ca.plugin.CaTlsPlugin
       supported_architectures:
         - amd64
+    - name: "validation"
+      version: "0.0.1"
+      description: "Plugin for integrating with tempest"
+      path: sunbeam.plugins.validation.plugin.ValidationPlugin
+      supported_architectures:
+        - amd64

--- a/sunbeam-python/sunbeam/plugins/validation/README.md
+++ b/sunbeam-python/sunbeam/plugins/validation/README.md
@@ -1,0 +1,47 @@
+# Validation
+
+This plugin provides OpenStack Integration Test Suite: tempest for Sunbeam. It
+is based on [tempest-k8s][1] and [tempest-rock][2] project.
+
+## Installation
+
+To enable cloud validation, you need an already bootstrapped Sunbeam instance.
+Then, you can install the plugin with:
+
+```bash
+sunbeam enable validation
+```
+
+This plugin is also related to the `observability` plugin.
+
+## Contents
+
+This plugin will install [tempest-k8s][1], and provide the `validation`
+subcommand to sunbeam client. For more information, please run
+
+```
+sunbeam validation --help
+```
+
+Additionally, if you enable `observability` plugin, you will also get the
+periodic cloud validation feature from this plugin. The loki alert rules for
+validation results (e.g. when some tempest tests failed) will be configured, and
+a summary of validation results will also be shown in Grafana dashboard.
+
+You can configure the periodic validation schedule using `configure` subcommand
+in sunbeam client. For more information, please run
+
+```
+sunbeam configure validation --help
+```
+
+## Removal
+
+To remove the plugin, run:
+
+```bash
+sunbeam disable validation
+```
+
+[1]: https://opendev.org/openstack/sunbeam-charms/src/branch/main/charms/tempest-k8s
+[2]: https://github.com/canonical/ubuntu-openstack-rocks/tree/main/rocks/tempest

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -259,9 +259,9 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
             # Note: this is a workaround to run command to payload container
             # since python-libjuju does not support such feature. See related
             # bug: https://github.com/juju/python-libjuju/issues/1029
-            if destination == ".":
-                # juju scp does not allow "." as destination
-                destination = Path("./", Path(source).name)
+            if Path(destination).is_dir():
+                # juju scp does not allow directory as destination
+                destination = str(Path(destination, Path(source).name))
             subprocess.run(
                 [
                     "juju",

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -24,9 +24,13 @@ import pydantic
 from croniter import croniter
 from packaging.version import Version
 from rich.console import Console
+from rich.status import Status
 
+from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import ClusterServiceUnavailableException
 from sunbeam.commands.openstack import OPENSTACK_MODEL
+from sunbeam.commands.terraform import TerraformException, TerraformInitStep
+from sunbeam.jobs.common import BaseStep, Result, ResultType, run_plan
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import (
     ActionFailedException,
@@ -36,6 +40,7 @@ from sunbeam.jobs.juju import (
     UnitNotFoundException,
     run_sync,
 )
+from sunbeam.jobs.manifest import Manifest
 from sunbeam.jobs.plugin import PluginManager
 from sunbeam.plugins.interface.v1.openstack import (
     OpenStackControlPlanePlugin,
@@ -144,6 +149,49 @@ def validated_config_args(args: Dict[str, str]) -> Config:
     return Config(**args)
 
 
+class ConfigureValidationStep(BaseStep):
+    """Configure validation plugin."""
+
+    def __init__(
+        self,
+        config_changes: Config,
+        client: Client,
+        manifest: Manifest,
+        tfplan: str,
+        tfvar_map: dict,
+    ):
+        super().__init__(
+            "Configure validation plugin",
+            "Changing the configuration options for tempest",
+        )
+        self.config_changes = config_changes
+        self.client = client
+        self.manifest = manifest
+        self.tfplan = tfplan
+        self.tfvar_map = tfvar_map
+
+    def run(self, status: Optional[Status] = None) -> Result:
+        """Execute step using terraform."""
+        try:
+            # See ValidationPlugin.manifest_attributes_tfvar_map
+            charms = self.tfvar_map[self.tfplan]["charms"]
+            tempest_k8s_config_var = charms["tempest-k8s"]["config"]
+            if self.config_changes.schedule is None:
+                override_tfvars = {}
+            else:
+                override_tfvars = {
+                    tempest_k8s_config_var: {"schedule": self.config_changes.schedule}
+                }
+            self.manifest.update_tfvars_and_apply_tf(
+                self.client, tfplan=self.tfplan, override_tfvars=override_tfvars
+            )
+        except TerraformException as e:
+            LOG.exception("Error configuring validation pluging.")
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)
+
+
 class ValidationPlugin(OpenStackControlPlanePlugin):
     """Deploy tempest to openstack model."""
 
@@ -157,16 +205,35 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
             tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO,
         )
 
+    def manifest_defaults(self) -> dict:
+        """Manifest plugin part in dict format."""
+        return {"charms": {"tempest-k8s": {"channel": TEMPEST_CHANNEL}}}
+
+    def manifest_attributes_tfvar_map(self) -> dict:
+        """Manifest attributes terraformvars map."""
+        return {
+            self.tfplan: {
+                "charms": {
+                    "tempest-k8s": {
+                        "config": "tempest-config",
+                        "channel": "tempest-channel",
+                        "revision": "tempest-revision",
+                    }
+                }
+            },
+        }
+
     def set_application_names(self) -> list:
         """Application names handled by the terraform plan."""
         return [TEMPEST_APP_NAME]
 
     def set_tfvars_on_enable(self) -> dict:
         """Set terraform variables to enable the application."""
-        return {
-            "enable-validation": True,
-            "tempest-channel": TEMPEST_CHANNEL,
-        }
+        return {"enable-validation": True}
+
+    def set_tfvars_on_disable(self) -> dict:
+        """Set terraform variables to disable the application."""
+        return {"enable-validation": False}
 
     def set_application_timeout_on_enable(self) -> int:
         """Set Application Timeout on enabling the plugin.
@@ -183,10 +250,6 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
         are not removed within this time.
         """
         return VALIDATION_PLUGIN_DEPLOY_TIMEOUT
-
-    def set_tfvars_on_disable(self) -> dict:
-        """Set terraform variables to disable the application."""
-        return {"enable-validation": False}
 
     def set_tfvars_on_resize(self) -> dict:
         """Set terraform variables to resize the application."""
@@ -334,17 +397,19 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
 
         config_changes = validated_config_args(parse_config_args(options))
 
-        if config_changes.schedule is not None:
-            jhelper = JujuHelper(self.deployment.get_connected_controller())
-            with console.status("Configuring validation plugin ..."):
-                run_sync(
-                    jhelper.set_application_config(
-                        OPENSTACK_MODEL,
-                        TEMPEST_APP_NAME,
-                        config={"schedule": config_changes.schedule},
-                    )
-                )
-                console.print(f"Schedule has been set to '{config_changes.schedule}'")
+        run_plan(
+            [
+                TerraformInitStep(self.manifest.get_tfhelper(self.tfplan)),
+                ConfigureValidationStep(
+                    config_changes,
+                    self.deployment.get_client(),
+                    self.manifest,
+                    self.tfplan,
+                    self.manifest_attributes_tfvar_map(),
+                ),
+            ],
+            console,
+        )
 
     @click.command()
     @click.option(

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -41,6 +41,7 @@ from sunbeam.plugins.interface.v1.openstack import (
     OpenStackControlPlanePlugin,
     TerraformPlanLocation,
 )
+from sunbeam.versions import TEMPEST_CHANNEL
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -49,7 +50,6 @@ PLUGIN_VERSION = "0.0.1"
 MINIMAL_PERIOD = 15 * 60  # 15 minutes in seconds
 TEMPEST_APP_NAME = "tempest"
 TEMPEST_CONTAINER_NAME = "tempest"
-TEMPEST_CHANNEL = "2023.2/edge"
 TEMPEST_VALIDATION_RESULT = "/var/lib/tempest/workspace/tempest-validation.log"
 VALIDATION_PLUGIN_DEPLOY_TIMEOUT = (
     60 * 60

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -1,0 +1,472 @@
+# Copyright (c) 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import click
+from croniter import croniter
+from packaging.version import Version
+from rich.console import Console
+
+from sunbeam.clusterd.client import Client
+from sunbeam.clusterd.service import ClusterServiceUnavailableException
+from sunbeam.commands.openstack import OPENSTACK_MODEL
+from sunbeam.jobs.juju import JujuHelper, run_sync
+from sunbeam.jobs.plugin import PluginManager
+from sunbeam.plugins.interface.v1.openstack import (
+    OpenStackControlPlanePlugin,
+    TerraformPlanLocation,
+)
+
+LOG = logging.getLogger(__name__)
+console = Console()
+
+PLUGIN_VERSION = "0.0.1"
+MINIMAL_PERIOD = 15 * 60  # 15 minutes in seconds
+TEMPEST_APP_NAME = "tempest"
+TEMPEST_CONTAINER_NAME = "tempest"
+TEMPEST_CHANNEL = "2023.2/edge"
+TEMPEST_VALIDATION_RESULT = "/var/lib/tempest/workspace/tempest-validation.log"
+VALIDATION_PLUGIN_DEPLOY_TIMEOUT = (
+    60 * 60
+)  # 60 minutes in seconds, tempest can take some time to initialized
+
+
+def validated_schedule(schedule: str) -> str:
+    """Validate the schedule config option.
+
+    Return the valid schedule if valid,
+    otherwise Raise a click BadParameter exception.
+    """
+    # Empty schedule is fine; it means it's disabled in this context.
+    if not schedule:
+        return ""
+
+    # croniter supports second repeats, but vixie cron does not.
+    if len(schedule.split()) == 6:
+        raise click.ClickException(
+            "This cron does not support seconds in schedule (6 fields)."
+            " Exactly 5 columns must be specified for iterator expression."
+        )
+
+    # constant base time for consistency
+    base = datetime(2004, 3, 5)
+
+    try:
+        cron = croniter(schedule, base, max_years_between_matches=1)
+    except ValueError as e:
+        msg = str(e)
+        # croniter supports second repeats, but vixie cron does not,
+        # so update the error message here to suit.
+        if "Exactly 5 or 6 columns" in msg:
+            msg = "Exactly 5 columns must be specified for iterator expression."
+        raise click.ClickException(msg)
+
+    # This is a rather naive method for enforcing this,
+    # and it may be possible to craft an expression
+    # that results in some consecutive runs within 15 minutes,
+    # however this is fine, as there is process locking for tempest,
+    # and this is more of a sanity check than a security requirement.
+    t1 = cron.get_next()
+    t2 = cron.get_next()
+    if t2 - t1 < MINIMAL_PERIOD:
+        raise click.ClickException(
+            "Cannot schedule periodic check to run faster than every 15 minutes."
+        )
+
+    return schedule
+
+
+@dataclass()
+class Config:
+    """Represents config updates provided by the user.
+
+    None values mean the user did not provide them.
+    """
+
+    schedule: Optional[str] = None
+
+
+def parse_config_args(args: List[str]) -> Dict[str, str]:
+    """Parse key=value args into a valid dictionary of key: values.
+
+    Raise a click bad argument error if errors (only checks syntax here).
+    """
+    config = {}
+    for arg in args:
+        split_arg = arg.split("=", 1)
+        if len(split_arg) == 1:
+            raise click.ClickException("syntax: key=value")
+        key, value = split_arg
+        if key in config:
+            raise click.ClickException(
+                f"{key!r} parameter seen multiple times. Only provide it once."
+            )
+        config[key] = value
+    return config
+
+
+def validated_config_args(args: Dict[str, str]) -> Config:
+    """Validate config and return validated config if no errors.
+
+    Raise a click bad argument error if errors.
+    """
+
+    config = Config()
+
+    for key, value in args.items():
+        if key == "schedule":
+            config.schedule = validated_schedule(value)
+        else:
+            raise click.ClickException(f"{key!r} is not a supported config option")
+
+    return config
+
+
+class ValidationPlugin(OpenStackControlPlanePlugin):
+    """Deploy tempest to openstack model."""
+
+    version = Version(PLUGIN_VERSION)
+
+    def __init__(self, client: Client) -> None:
+        """Initialize the plugin class."""
+        super().__init__(
+            "validation",
+            client,
+            tf_plan_location=TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO,
+        )
+
+    def set_application_names(self) -> list:
+        """Application names handled by the terraform plan."""
+        return [TEMPEST_APP_NAME]
+
+    def set_tfvars_on_enable(self) -> dict:
+        """Set terraform variables to enable the application."""
+        return {
+            "enable-validation": True,
+            "tempest-channel": TEMPEST_CHANNEL,
+        }
+
+    def set_application_timeout_on_enable(self) -> int:
+        """Set Application Timeout on enabling the plugin.
+
+        The plugin plan will timeout if the applications
+        are not in active status within in this time.
+        """
+        return VALIDATION_PLUGIN_DEPLOY_TIMEOUT
+
+    def set_application_timeout_on_disable(self) -> int:
+        """Set Application Timeout on disabling the plugin.
+
+        The plugin plan will timeout if the applications
+        are not removed within this time.
+        """
+        return VALIDATION_PLUGIN_DEPLOY_TIMEOUT
+
+    def set_tfvars_on_disable(self) -> dict:
+        """Set terraform variables to disable the application."""
+        return {"enable-validation": False}
+
+    def set_tfvars_on_resize(self) -> dict:
+        """Set terraform variables to resize the application."""
+        return {}
+
+    def _get_tempest_leader_unit(self) -> str:
+        """Return the leader unit of tempest application."""
+        jhelper = JujuHelper(self.client, self.snap.paths.user_data)
+        with console.status(f"Retrieving {TEMPEST_APP_NAME}'s unit name."):
+            app = TEMPEST_APP_NAME
+            model = OPENSTACK_MODEL
+            unit = run_sync(jhelper.get_leader_unit(app, model))
+            if not unit:
+                message = f"Unable to get {app} leader"
+                raise click.ClickException(message)
+            return unit
+
+    def _run_action_on_tempest_unit(
+        self,
+        action_name: str,
+        action_params: Optional[dict] = None,
+        progress_message: str = "",
+    ) -> Dict[str, Any]:
+        """Run the charm's action."""
+        unit = self._get_tempest_leader_unit()
+        jhelper = JujuHelper(self.client, self.snap.paths.user_data)
+        with console.status(progress_message):
+            action_result = run_sync(
+                jhelper.run_action(
+                    unit,
+                    OPENSTACK_MODEL,
+                    action_name,
+                    action_params or {},
+                )
+            )
+
+            if action_result.get("return-code", 0) > 1:
+                message = f"Unable to run action: {action_name}"
+                raise click.ClickException(message)
+
+            return action_result
+
+    def _check_file_exist_in_tempest_container(self, filename: str) -> bool:
+        """Check if file exist in tempest container."""
+        unit = self._get_tempest_leader_unit()
+        # Note: this is a workaround to run command to payload container
+        # since python-libjuju does not support such feature. See related
+        # bug: https://github.com/juju/python-libjuju/issues/1029
+        result = subprocess.run(
+            [
+                "juju",
+                "ssh",
+                "--container",
+                TEMPEST_CONTAINER_NAME,
+                unit,
+                "ls",
+                TEMPEST_VALIDATION_RESULT,
+            ],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            return False
+        return True
+
+    def _copy_file_from_tempest_container(self, source: str, destination: str) -> None:
+        """Copy file from tempest container."""
+        unit = self._get_tempest_leader_unit()
+        progress_message = (
+            f"Copying {source} from "
+            f"{TEMPEST_APP_NAME} ({TEMPEST_CONTAINER_NAME}) "
+            f"to {destination} ..."
+        )
+        with console.status(progress_message):
+            # Note: this is a workaround to run command to payload container
+            # since python-libjuju does not support such feature. See related
+            # bug: https://github.com/juju/python-libjuju/issues/1029
+            if destination == ".":
+                # juju scp does not allow "." as destination
+                destination = Path("./", Path(source).name)
+            subprocess.run(
+                [
+                    "juju",
+                    "scp",
+                    "--container",
+                    TEMPEST_CONTAINER_NAME,
+                    f"{unit}:{source}",
+                    destination,
+                ],
+            )
+
+    def _configure_preflight_check(self) -> False:
+        """Preflight check for configure command."""
+        enabled_plugins = PluginManager.enabled_plugins(self.client)
+        if "observability" not in enabled_plugins:
+            return False
+        return True
+
+    @click.command()
+    def enable_plugin(self) -> None:
+        """Enable OpenStack Integration Test Suite (tempest)."""
+        super().enable_plugin()
+
+    @click.command()
+    def disable_plugin(self) -> None:
+        """Disable OpenStack Integration Test Suite (tempest)."""
+        super().disable_plugin()
+
+    @click.command()
+    @click.argument("options", nargs=-1)
+    def configure_validation(self, options: Optional[List[str]] = None) -> None:
+        """Configure validation plugin.
+
+        Run without arguments to view available configuration options.
+
+        Run with key=value args to set configuration values.
+        For example: sunbeam configure validation schedule="*/30 * * * *"
+        """
+        if not self._configure_preflight_check():
+            raise click.ClickException(
+                "'observability' plugin is required for configuring validation plugin."
+            )
+
+        if not options:
+            console.print(
+                "Config options available: \n\n"
+                "schedule: set a cron schedule for running periodic tests.  "
+                "Empty disables.\n\n"
+                "Run with key=value args to set configuration values.\n"
+                'For example: sunbeam configure validation schedule="*/30 * * * *"'
+            )
+            return
+
+        config_changes = validated_config_args(parse_config_args(options))
+
+        if config_changes.schedule is not None:
+            jhelper = JujuHelper(self.client, self.snap.paths.user_data)
+            with console.status("Configuring validation plugin ..."):
+                run_sync(
+                    jhelper.set_application_config(
+                        OPENSTACK_MODEL,
+                        TEMPEST_APP_NAME,
+                        config={"schedule": config_changes.schedule},
+                    )
+                )
+                console.print(f"Schedule has been set to '{config_changes.schedule}'")
+
+    @click.command()
+    @click.option(
+        "-r",
+        "--regex",
+        default="",
+        help=(
+            "A list of regexes, whitespace separated, used to select tests from"
+            " the list."
+        ),
+    )
+    @click.option(
+        "-e",
+        "--exclude-regex",
+        default="",
+        help="A single regex to exclude tests.",
+    )
+    @click.option(
+        "-t",
+        "--serial",
+        is_flag=True,
+        default=False,
+        help="Run tests serially. By default, tests run in parallel.",
+    )
+    @click.option(
+        "-l",
+        "--test-list",
+        default="",
+        help=(
+            "Use a predefined test list. See `sunbeam validation test-lists`"
+            " for available test lists."
+        ),
+    )
+    @click.option(
+        "-o",
+        "--output",
+        type=click.Path(),
+        default=None,
+        help=(
+            "Download the full log to output file. "
+            "If not provided, the output can be retrieved later "
+            "by running `sunbeam validation get-last-result`."
+        ),
+    )
+    def run_validate_action(
+        self,
+        regex: str = "",
+        exclude_regex: str = "",
+        serial: bool = False,
+        test_list: str = "",
+        output: Optional[str] = None,
+    ) -> None:
+        """Run a set of tests on the sunbeam installation."""
+        action_name = "validate"
+        action_params = {
+            "regex": regex,
+            "exclude-regex": exclude_regex,
+            "serial": serial,
+            "test-list": test_list,
+        }
+        progress_message = "Running tempest to validate the sunbeam deployment ..."
+        action_result = self._run_action_on_tempest_unit(
+            action_name,
+            action_params=action_params,
+            progress_message=progress_message,
+        )
+
+        console.print(action_result.get("summary").strip())
+
+        if output:
+            self._copy_file_from_tempest_container(TEMPEST_VALIDATION_RESULT, output)
+
+    @click.command()
+    def run_get_lists_action(self) -> None:
+        """Get supported test lists for validation."""
+        action_name = "get-lists"
+        progress_message = "Retrieving existing test lists from tempest charm ..."
+        action_result = self._run_action_on_tempest_unit(
+            action_name,
+            action_params={},
+            progress_message=progress_message,
+        )
+        console.print(action_result.get("stdout").strip())
+
+    @click.command()
+    @click.option(
+        "-o",
+        "--output",
+        type=click.Path(),
+        required=True,
+        help="Download the last validation check result to output file.",
+    )
+    def run_get_last_result(self, output: str) -> None:
+        """Get last validation result."""
+        if not self._check_file_exist_in_tempest_container(TEMPEST_VALIDATION_RESULT):
+            raise click.ClickException(
+                (
+                    f"Cannot find '{TEMPEST_VALIDATION_RESULT}'. "
+                    "Have you run `sunbeam validation run` at least once?"
+                )
+            )
+        self._copy_file_from_tempest_container(TEMPEST_VALIDATION_RESULT, output)
+
+    @click.group()
+    def validation_group(self):
+        """Manage cloud validation functionality."""
+
+    def commands(self) -> dict:
+        """Dict of clickgroup along with commands."""
+        commands = super().commands()
+        try:
+            enabled = self.enabled
+        except ClusterServiceUnavailableException:
+            LOG.debug(
+                "Failed to query for plugin status, is cloud bootstrapped ?",
+                exc_info=True,
+            )
+            enabled = False
+
+        if enabled:
+            commands.update(
+                {
+                    # sunbeam configure validation ...
+                    "configure": [
+                        {"name": "validation", "command": self.configure_validation}
+                    ],
+                    # add the validation subcommand group to the root group:
+                    # sunbeam validation ...
+                    "init": [{"name": "validation", "command": self.validation_group}],
+                    # add the subcommands:
+                    # sunbeam validation run ... etc.
+                    "init.validation": [
+                        {"name": "run", "command": self.run_validate_action},
+                        {"name": "test-lists", "command": self.run_get_lists_action},
+                        {
+                            "name": "get-last-result",
+                            "command": self.run_get_last_result,
+                        },
+                    ],
+                }
+            )
+        return commands

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Canonical Ltd.
+# Copyright (c) 2024 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Canonical Ltd.
+#       e Copyright (c) 2024 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -353,7 +353,7 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 raise click.ClickException(str(e))
 
-    def _configure_preflight_check(self) -> False:
+    def _configure_preflight_check(self) -> bool:
         """Preflight check for configure command."""
         enabled_plugins = PluginManager.enabled_plugins(self.deployment)
         if "observability" not in enabled_plugins:

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -28,6 +28,7 @@ MYSQL_CHANNEL = "8.0/candidate"
 CERT_AUTH_CHANNEL = "latest/beta"
 BIND_CHANNEL = "9/edge"
 VAULT_CHANNEL = "latest/edge"
+TEMPEST_CHANNEL = "2023.2/edge"
 
 # List of charms with default channels
 OPENSTACK_CHARMS_K8S = {

--- a/sunbeam-python/test-requirements.txt
+++ b/sunbeam-python/test-requirements.txt
@@ -17,3 +17,6 @@ openstacksdk # Apache-2.0
 pytest
 pytest-mock
 pytest-asyncio
+
+# For validation plugin
+croniter

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import click
+import pytest
+
+from sunbeam.plugins.validation import plugin as validation_plugin
+
+
+class TestValidatorFunction:
+    """Test validator functions."""
+
+    @pytest.mark.parametrize(
+        "input_schedule",
+        [
+            "",
+            "5 4 * * *",
+            "5 4 * * mon",
+            "*/30 * * * *",
+        ],
+    )
+    def test_valid_cron_expressions(self, input_schedule):
+        """Verify valid cron expressions."""
+        assert validation_plugin.validated_schedule(input_schedule) == input_schedule
+
+    @pytest.mark.parametrize(
+        "test_input,expected_msg",
+        [
+            ("*/5 * * * *", "Cannot schedule periodic check"),
+            ("*/30 * * * * 6", "This cron does not support"),
+            ("*/30 * *", "Exactly 5 columns must"),
+            ("*/5 * * * xyz", "not acceptable"),
+        ],
+    )
+    def test_invalid_cron_expressions(self, test_input, expected_msg):
+        """Verify invalid cron expressions."""
+        with pytest.raises(click.ClickException) as e:
+            validation_plugin.validated_schedule(test_input)
+        assert expected_msg in str(e)

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
@@ -32,7 +32,8 @@ class TestValidatorFunction:
     )
     def test_valid_cron_expressions(self, input_schedule):
         """Verify valid cron expressions."""
-        assert validation_plugin.validated_schedule(input_schedule) == input_schedule
+        config = validation_plugin.Config(schedule=input_schedule)
+        assert config.schedule == input_schedule
 
     @pytest.mark.parametrize(
         "test_input,expected_msg",
@@ -46,8 +47,8 @@ class TestValidatorFunction:
     def test_invalid_cron_expressions(self, test_input, expected_msg):
         """Verify invalid cron expressions."""
         with pytest.raises(click.ClickException) as e:
-            validation_plugin.validated_schedule(test_input)
-        assert expected_msg in str(e)
+            validation_plugin.Config(schedule=test_input)
+            assert expected_msg in str(e)
 
     @pytest.mark.parametrize(
         "test_args",


### PR DESCRIPTION
This PR adds validation plugin to sunbeam.

User can enable `validation` plugin to deploy tempest-k8s operator and patch necessary relations. This plugin provides and configures cloud validation suite (tempest) to the existing sunbeam deployment. Cloud operator can make use of this plugin to validate the status of the cloud.

This plugin also works with `observability` plugin to provide periodic cloud validation. Validation results can be seen from the Grafana dashboard provided by the `observability` plugin.

Review together:
- https://github.com/canonical/sunbeam-terraform/pull/55