### PR TITLE
Enable tmate session on failure when debug mode is on

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -59,3 +59,6 @@ jobs:
           juju status
           juju status -m openstack
           juju debug-log -m openstack --replay
+      - name: Setup tmate session
+        if: ${{ failure() && runner.debug }}
+        uses: canonical/action-tmate@main


### PR DESCRIPTION
This will setup a tmate session to allow remote access to the runner when the action failed + has been launched with debug mode.