### PR TITLE
Remove sysctl config from prepare-node-script

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -53,10 +53,6 @@ dpkg -s openssh-server &> /dev/null || {{
     sudo apt install -y openssh-server
 }}
 
-# Increase the number of inotify watchers per user
-echo "fs.inotify.max_user_instances = 1024" | sudo tee /etc/sysctl.d/80-sunbeam.conf
-sudo sysctl -q -p /etc/sysctl.d/80-sunbeam.conf
-
 # Connect snap to the ssh-keys interface to allow
 # read access to private keys - this supports bootstrap
 # of the Juju controller to the local machine via SSH.


### PR DESCRIPTION
Sysctl configuration is now performed via sunbeam-machine. This allows the limits to be set indepently from the machine provider.