### PR TITLE
Revert "Always use 3 replicas for ceph pools"

### DIFF
--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -97,6 +97,17 @@ def compute_ingress_scale(topology: str, control_nodes: int) -> int:
     return min(control_nodes, 3)
 
 
+def compute_ceph_replica_scale(osds: int) -> int:
+    return min(osds, 3)
+
+
+async def _get_number_of_osds(jhelper: JujuHelper, model: str) -> int:
+    """Fetch the number of osds from the microceph application"""
+    leader = await jhelper.get_leader_unit(microceph.APPLICATION, model)
+    osds, _ = await microceph.list_disks(jhelper, model, leader)
+    return len(osds)
+
+
 class DeployControlPlaneStep(BaseStep, JujuStepHelper):
     """Deploy OpenStack using Terraform cloud"""
 
@@ -131,10 +142,12 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         """Create terraform variables related to storage."""
         tfvars = {}
         if storage_nodes:
-            tfvars["ceph-osd-replication-count"] = 3
             tfvars["enable-ceph"] = True
             tfvars["ceph-offer-url"] = (
                 f"admin/{self.machine_model}.{microceph.APPLICATION}"
+            )
+            tfvars["ceph-osd-replication-count"] = compute_ceph_replica_scale(
+                run_sync(_get_number_of_osds(self.jhelper, self.machine_model))
             )
         else:
             tfvars["enable-ceph"] = False

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
@@ -24,6 +24,7 @@ from sunbeam.commands.openstack import (
     DeployControlPlaneStep,
     PatchLoadBalancerServicesStep,
     ReapplyOpenStackTerraformPlanStep,
+    compute_ceph_replica_scale,
     compute_ha_scale,
     compute_ingress_scale,
     compute_os_api_scale,
@@ -360,6 +361,19 @@ def test_compute_os_api_scale(topology, control_nodes, scale):
 )
 def test_compute_ingress_scale(topology, control_nodes, scale):
     assert compute_ingress_scale(topology, control_nodes) == scale
+
+
+@pytest.mark.parametrize(
+    "osds,scale",
+    [
+        (1, 1),
+        (1, 1),
+        (9, 3),
+        (2, 2),
+    ],
+)
+def test_compute_ceph_replica_scale(osds, scale):
+    assert compute_ceph_replica_scale(osds) == scale
 
 
 class TestReapplyOpenStackTerraformPlanStep(unittest.TestCase):


### PR DESCRIPTION
This reverts commit 4bacfc1cf4d8586ec7d6f0f9fc47da7a25423f17.

Not a clean revert since I needed to make use of the `machine_model` variable to get the leader/run the action. (Introduced in the maas feature work)