### PR TITLE
Tailor manifest generation to deployment type

### DIFF
--- a/sunbeam-python/sunbeam/jobs/deployment.py
+++ b/sunbeam-python/sunbeam/jobs/deployment.py
@@ -84,3 +84,7 @@ class Deployment(pydantic.BaseModel):
                 f"No juju controller configured for deployment {self.name}."
             )
         return self.juju_controller.to_controller(self.juju_account)
+
+    def generate_preseed(self, console) -> str:
+        """Generate preseed for deployment."""
+        return NotImplemented

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -110,6 +110,10 @@ class MaasClient:
                 ip_ranges.append(ip_range._data)
         return ip_ranges
 
+    def get_dns_servers(self) -> list[str]:
+        """Get configured upstream dns"""
+        return self._client.maas.get_upstream_dns()  # type: ignore
+
     @classmethod
     def from_deployment(cls, deployment: Deployment) -> "MaasClient":
         """Return client connected to active deployment."""

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -36,7 +36,6 @@ from sunbeam.commands.configure import (
     SetHypervisorCharmConfigStep,
     TerraformDemoInitStep,
     UserOpenRCStep,
-    UserQuestions,
     retrieve_admin_credentials,
 )
 from sunbeam.commands.hypervisor import (
@@ -128,6 +127,7 @@ from sunbeam.provider.maas.steps import (
     MaasSaveControllerStep,
     MaasScaleJujuStep,
     MaasSetHypervisorUnitsOptionsStep,
+    MaasUserQuestions,
     MachineComputeNicCheck,
     MachineNetworkCheck,
     MachineRequirementsCheck,
@@ -621,9 +621,9 @@ def configure_cmd(
     )
     plan = [
         JujuLoginStep(deployment.juju_account),
-        UserQuestions(
+        MaasUserQuestions(
             client,
-            answer_file=answer_file,
+            maas_client,
             deployment_preseed=preseed,
             accept_defaults=accept_defaults,
         ),


### PR DESCRIPTION
This change specializes the generated manifest to the deployment type. Maas deployments don't need most of the options a local deployment needs.