### PR TITLE
Revert "Add manifest support for validation plugin."

### DIFF
--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -30,6 +30,7 @@ from rich.table import Column, Table
 from sunbeam.clusterd.service import ClusterServiceUnavailableException
 from sunbeam.commands.juju import JujuLoginStep
 from sunbeam.commands.openstack import OPENSTACK_MODEL
+from sunbeam.jobs.common import run_plan
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import (
     ActionFailedException,


### PR DESCRIPTION
This reverts commit 1214b4a52c8bfe3d55638740ee83b55349d4c468.

That commit caused all the applications to be removed from the openstack model when running `sunbeam configure validation schedule=<valid schedule>`. So here we revert that commit, returning to the previous method for setting the configuration, which was known to be working.

We can implement complete support for manifests in a future patch.