### PR TITLE
Target openstack model for running juju command on tempest charm

### DIFF
--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -345,6 +345,8 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
                 [
                     "juju",
                     "ssh",
+                    "--model",
+                    OPENSTACK_MODEL,
                     "--container",
                     TEMPEST_CONTAINER_NAME,
                     unit,
@@ -381,6 +383,8 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
                     [
                         "juju",
                         "scp",
+                        "--model",
+                        OPENSTACK_MODEL,
                         "--container",
                         TEMPEST_CONTAINER_NAME,
                         f"{unit}:{source}",


### PR DESCRIPTION
Juju command would fail to execute without passing in the model where tempest charm is deployed under if that model is not set as current on CLI. This PR fixes this issue. 