### PR TITLE
Fix configuring validation schedule

### DIFF
--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -36,9 +36,9 @@ from sunbeam.commands.terraform import TerraformException, TerraformInitStep
 from sunbeam.jobs.common import BaseStep, Result, ResultType, run_plan
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import (
+    CONTROLLER,
     ActionFailedException,
     ApplicationNotFoundException,
-    CONTROLLER,
     JujuHelper,
     LeaderNotFoundException,
     UnitNotFoundException,
@@ -199,6 +199,7 @@ class ConfigureValidationStep(BaseStep):
         manifest: Manifest,
         tfplan: str,
         tfvar_map: dict,
+        tfvar_config: str,
     ):
         super().__init__(
             "Configure validation plugin",
@@ -209,6 +210,7 @@ class ConfigureValidationStep(BaseStep):
         self.manifest = manifest
         self.tfplan = tfplan
         self.tfvar_map = tfvar_map
+        self.tfvar_config = tfvar_config
 
     def run(self, status: Optional[Status] = None) -> Result:
         """Execute step using terraform."""
@@ -223,7 +225,10 @@ class ConfigureValidationStep(BaseStep):
                     tempest_k8s_config_var: {"schedule": self.config_changes.schedule}
                 }
             self.manifest.update_tfvars_and_apply_tf(
-                self.client, tfplan=self.tfplan, override_tfvars=override_tfvars
+                self.client,
+                tfplan=self.tfplan,
+                tfvar_config=self.tfvar_config,
+                override_tfvars=override_tfvars,
             )
         except TerraformException as e:
             LOG.exception("Error configuring validation pluging.")
@@ -450,6 +455,7 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
                     self.manifest,
                     self.tfplan,
                     self.manifest_attributes_tfvar_map(),
+                    self.get_tfvar_config_key(),
                 ),
             ],
             console,


### PR DESCRIPTION
Previously changing the validation schedule would result in all the openstack applications being removed from the openstack model.

This fixes it by passing in the appropriate tfvar_config key to method that generates and applies the terraform.

Example command affected:

```
sunbeam configure validation schedule="*/15 * * * *"
```