### PR TITLE
Support for proxy in maas deployments

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -16,11 +16,10 @@
 import click
 from rich.console import Console
 
+from sunbeam.versions import JUJU_CHANNEL, SUPPORTED_RELEASE
+
 console = Console()
 
-
-JUJU_CHANNEL = "3.4/stable"
-SUPPORTED_RELEASE = "jammy"
 
 PREPARE_NODE_TEMPLATE = f"""[ $(lsb_release -sc) != '{SUPPORTED_RELEASE}' ] && \
 {{ echo 'ERROR: Sunbeam deploy only supported on {SUPPORTED_RELEASE}'; exit 1; }}

--- a/sunbeam-python/sunbeam/jobs/juju.py
+++ b/sunbeam-python/sunbeam/jobs/juju.py
@@ -42,6 +42,7 @@ from juju.model import Model
 from juju.unit import Unit
 
 from sunbeam.clusterd.client import Client
+from sunbeam.versions import JUJU_BASE
 
 LOG = logging.getLogger(__name__)
 CONTROLLER_MODEL = "admin/controller"
@@ -236,16 +237,17 @@ class JujuHelper:
                 raise ModelNotFoundException(f"Model {model!r} not found")
             raise e
 
-    async def add_model(self, model: str) -> Model:
+    async def add_model(self, model: str, config: dict | None = None) -> Model:
         """Add a model.
 
         :model: Name of the model
+        :config: model configuration
         """
         # TODO(gboutry): workaround until we manage public ssh keys properly
         old_home = os.environ["HOME"]
         os.environ["HOME"] = os.environ["SNAP_REAL_HOME"]
         try:
-            return await self.controller.add_model(model)
+            return await self.controller.add_model(model, config=config)
         finally:
             os.environ["HOME"] = old_home
 
@@ -320,7 +322,7 @@ class JujuHelper:
             charm,
             application_name=name,
             num_units=num_units,
-            base="ubuntu@22.04",
+            base=JUJU_BASE,
             **options,
         )
 

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -114,6 +114,10 @@ class MaasClient:
         """Get configured upstream dns"""
         return self._client.maas.get_upstream_dns()  # type: ignore
 
+    def get_http_proxy(self) -> str | None:
+        """Get configured http proxy"""
+        return self._client.maas.get_http_proxy()  # type: ignore
+
     @classmethod
     def from_deployment(cls, deployment: Deployment) -> "MaasClient":
         """Return client connected to active deployment."""

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 
+SUPPORTED_RELEASE = "jammy"
+JUJU_CHANNEL = "3.4/stable"
+JUJU_BASE = "ubuntu@22.04"
 OPENSTACK_CHANNEL = "2023.2/edge"
 OVN_CHANNEL = "23.09/edge"
 RABBITMQ_CHANNEL = "3.12/edge"

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 from maas.client.bones import CallError
 
+import sunbeam.provider.maas.steps as maas_steps
 from sunbeam.jobs.deployments import DeploymentsConfig
 from sunbeam.jobs.juju import ControllerNotFoundException
 from sunbeam.provider.maas.deployment import (
@@ -599,12 +600,13 @@ class TestIpRangesCheck:
 
 
 class TestMaasBootstrapJujuStep:
-    def test_is_skip_with_no_machines(self, mocker):
+    def test_is_skip_with_no_machines(self, snap, mocker):
         maas_client = Mock()
         mocker.patch(
             "sunbeam.provider.maas.client.list_machines",
             return_value=[],
         )
+        mocker.patch.object(maas_steps, "Snap", return_value=snap)
         step = MaasBootstrapJujuStep(
             maas_client=maas_client,
             cloud="test_cloud",
@@ -616,7 +618,7 @@ class TestMaasBootstrapJujuStep:
         assert result.result_type == ResultType.FAILED
         assert result.message and "No machines with tag" in result.message
 
-    def test_is_skip_with_multiple_machines(self, mocker):
+    def test_is_skip_with_multiple_machines(self, snap, mocker):
         maas_client = Mock()
         mocker.patch(
             "sunbeam.provider.maas.client.list_machines",
@@ -629,6 +631,7 @@ class TestMaasBootstrapJujuStep:
             "sunbeam.commands.juju.BootstrapJujuStep.is_skip",
             return_value=Result(ResultType.COMPLETED),
         )
+        mocker.patch.object(maas_steps, "Snap", return_value=snap)
         step = MaasBootstrapJujuStep(
             maas_client=maas_client,
             cloud="test_cloud",
@@ -641,7 +644,7 @@ class TestMaasBootstrapJujuStep:
         assert "--to" in step.bootstrap_args
         assert step.bootstrap_args[-1].endswith("1st")
 
-    def test_is_skip_with_single_machine(self, mocker):
+    def test_is_skip_with_single_machine(self, snap, mocker):
         maas_client = Mock()
         mocker.patch(
             "sunbeam.provider.maas.client.list_machines",
@@ -653,6 +656,7 @@ class TestMaasBootstrapJujuStep:
             "sunbeam.commands.juju.BootstrapJujuStep.is_skip",
             return_value=Result(ResultType.COMPLETED),
         )
+        mocker.patch.object(maas_steps, "Snap", return_value=snap)
         step = MaasBootstrapJujuStep(
             maas_client=maas_client,
             cloud="test_cloud",


### PR DESCRIPTION
* Get proxy from maas using maas client api
* Use proxy during bootstrap and set proxy related model configs on controller charm
* Pass model configs related to proxy while creating infrastructure model
* Pass proxy arguments to sunbeam machine cluster
* Update proxy management commands for maas deployments.

* Donwload juju controller charm and pass it as an argument to juju bootstrap command. This is a workaround for juju bug https://bugs.launchpad.net/juju/+bug/2044481