### PR TITLE
Fix typo in proxy sub-command.

### DIFF
--- a/sunbeam-python/sunbeam/commands/proxy.py
+++ b/sunbeam-python/sunbeam/commands/proxy.py
@@ -81,7 +81,7 @@ def _preflight_checks(deployment: Deployment):
 def _update_proxy(proxy: dict, deployment: Deployment):
     from sunbeam.provider.maas.deployment import MAAS_TYPE  # to avoid circular import
 
-    _preflight_checks(depoyment)
+    _preflight_checks(deployment)
     client = deployment.get_client()
 
     # Update proxy in clusterdb

--- a/sunbeam-python/sunbeam/plugins/observability/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/observability/plugin.py
@@ -179,6 +179,8 @@ class UpdateObservabilityModelConfigStep(BaseStep, JujuStepHelper):
             LOG.exception("Error updating Observability Model config")
             return Result(ResultType.FAILED, str(e))
 
+        return Result(ResultType.COMPLETED)
+
 
 class DeployGrafanaAgentStep(BaseStep, JujuStepHelper):
     """Deploy Grafana Agent using Terraform"""


### PR DESCRIPTION
There is typo in `proxy.py` and causing error like this:

```
ubuntu@sunbeam01:~$ sunbeam proxy clear
An unexpected error has occurred. Please run 'sunbeam inspect' to generate an inspection report.
Error: name 'depoyment' is not defined
```

Furthermore, there is missing return for `Result` in `UpdateObservabilityModelConfigStep`.