### PR TITLE
Set default osd_devices to None

### DIFF
--- a/sunbeam-python/sunbeam/commands/microceph.py
+++ b/sunbeam-python/sunbeam/commands/microceph.py
@@ -216,7 +216,7 @@ class ConfigureMicrocephOSDStep(BaseStep):
         """
         self.variables = questions.load_answers(self.client, self._CONFIG)
         self.variables.setdefault("microceph_config", {})
-        self.variables["microceph_config"].setdefault(self.name, {"osd_devices": ""})
+        self.variables["microceph_config"].setdefault(self.name, {"osd_devices": None})
 
         # Set defaults
         self.preseed.setdefault("microceph_config", {})


### PR DESCRIPTION
Default value calculation was changed to check for None instead of truthy.

Default value of `''` used to return False, but is now considered as True (since it's not None).