### PR TITLE
Download controller charm only when proxy is set

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -316,7 +316,8 @@ def bootstrap(
     # Workaround for bug https://bugs.launchpad.net/juju/+bug/2044481
     # Remove the below step and dont pass controller charm as bootstrap
     # arguments once the above bug is fixed
-    plan.append(DownloadJujuControllerCharmStep(proxy_settings))
+    if proxy_settings:
+        plan.append(DownloadJujuControllerCharmStep(proxy_settings))
     plan.append(
         MaasBootstrapJujuStep(
             maas_client,

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -904,10 +904,6 @@ class MaasBootstrapJujuStep(BootstrapJujuStep):
         proxy_settings: dict | None = None,
         accept_defaults: bool = False,
     ):
-        snap = Snap()
-        controller_charm = str(
-            snap.paths.user_common / "downloads" / JUJU_CONTROLLER_CHARM
-        )
         bootstrap_args = bootstrap_args or []
         bootstrap_args.extend(
             (
@@ -915,8 +911,21 @@ class MaasBootstrapJujuStep(BootstrapJujuStep):
                 f"tags={maas_deployment.RoleTags.JUJU_CONTROLLER.value}",
                 "--bootstrap-base",
                 JUJU_BASE,
-                "--controller-charm-path",
-                controller_charm,
+            )
+        )
+        if proxy_settings:
+            snap = Snap()
+            controller_charm = str(
+                snap.paths.user_common / "downloads" / JUJU_CONTROLLER_CHARM
+            )
+            bootstrap_args.extend(
+                (
+                    "--controller-charm-path",
+                    controller_charm,
+                )
+            )
+        bootstrap_args.extend(
+            (
                 "--config",
                 f"admin-secret={password}",
             )


### PR DESCRIPTION
For maas based deployments, juju bootstrap requires additional step to download juju controller charm
and provide the same to juju bootstrap command.
Currently this step is enabled irrespective of
proxy is set. Change the logic to download
juju controller charm only when proxy is set.