### PR TITLE
Update failure message on microceph add-osd action

### DIFF
--- a/sunbeam-python/sunbeam/commands/microceph.py
+++ b/sunbeam-python/sunbeam/commands/microceph.py
@@ -292,7 +292,8 @@ class ConfigureMicrocephOSDStep(BaseStep):
             )
             LOG.debug(f"Result after running action add-osd: {action_result}")
         except (UnitNotFoundException, ActionFailedException) as e:
-            LOG.debug(str(e))
-            return Result(ResultType.FAILED, str(e))
+            message = f"Microceph Adding disks {self.disks} failed: {str(e)}"
+            LOG.debug(message)
+            return Result(ResultType.FAILED, message)
 
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_microceph.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_microceph.py
@@ -76,5 +76,8 @@ class TestConfigureMicrocephOSDStep(unittest.TestCase):
         result = step.run()
 
         self.jhelper.run_action.assert_called_once()
+        expected_message = (
+            f"Microceph Adding disks {step.disks} failed: Action failed..."
+        )
         assert result.result_type == ResultType.FAILED
-        assert result.message == "Action failed..."
+        assert result.message == expected_message


### PR DESCRIPTION
In case of failure of microceph action add-osd, log a proper message in addition to the message returned by microceph.