### PR TITLE
Fix resize not scaling control plane

### DIFF
--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -173,7 +173,7 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         determined_topology = determine_target_topology(self.client)
 
         if self.topology == "auto":
-            self.topology = previous_config.get("topology", determined_topology)
+            self.topology = determined_topology
         LOG.debug(f"topology {self.topology}")
 
         if self.database == "auto":


### PR DESCRIPTION
This step is only called during deployment and resize operations.


The case where behavior differs:
- bootstrap first node
- add X nodes
- re-run bootstrap instead of rejoin ? this would now also resize while it wouldn't before

Closes-Bug: LP:2058482