### PR TITLE
Add validation on proxy answers

### DIFF
--- a/sunbeam-python/sunbeam/commands/proxy.py
+++ b/sunbeam-python/sunbeam/commands/proxy.py
@@ -198,6 +198,12 @@ def clear(ctx: click.Context) -> None:
         return
 
 
+def does_not_contain_quotes(answer: str):
+    """Check if the answer does not contain quotes."""
+    if '"' in answer or "'" in answer:
+        raise ValueError("Answer cannot contain quotes (\" or ').")
+
+
 def proxy_questions():
     return {
         "proxy_required": ConfirmQuestion(
@@ -206,12 +212,15 @@ def proxy_questions():
         ),
         "http_proxy": PromptQuestion(
             "Enter value for http_proxy:",
+            validation_function=does_not_contain_quotes,
         ),
         "https_proxy": PromptQuestion(
             "Enter value for https_proxy:",
+            validation_function=does_not_contain_quotes,
         ),
         "no_proxy": PromptQuestion(
             "Enter value for no_proxy:",
+            validation_function=does_not_contain_quotes,
         ),
     }
 

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -234,5 +234,5 @@ class LocalDeployment(Deployment):
             )
 
         proxy_configs = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"]
-        proxy = {p: v for p in proxy_configs if (v := current_env.get(p))}
+        proxy = {p: v.strip("\"'") for p in proxy_configs if (v := current_env.get(p))}
         return proxy


### PR DESCRIPTION
http-proxy, https-proxy and no-proxy should not contain quotes, fail if submitted interactive answer contains quotes.