### PR TITLE
Hint users to use the risk manifest when not deploying from stable

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -82,6 +82,27 @@ sudo snap install --channel {JUJU_CHANNEL} juju
 # Workaround a bug between snapd and juju
 mkdir -p $HOME/.local/share
 mkdir -p $HOME/.config/openstack
+
+# Check the snap channel and deduce risk level from it
+snap_output=$(snap list openstack --unicode=never --color=never | grep openstack)
+track=$(awk -v col=4 '{{print $col}}' <<<"$snap_output")
+risk=stable
+
+# if never installed from the store, the channel is "-"
+if [[ $track =~ "edge" ]] || [[ $track == "-" ]]; then
+    risk="edge"
+fi
+
+if [[ $track =~ "candidate" ]]; then
+    risk="candidate"
+fi
+
+if [[ $risk != "stable" ]]; then
+    echo "You're deploying from $risk channel," \
+        " to test $risk charms, you must provide the $risk manifest."
+    echo "Example: sunbeam cluster bootstrap " \
+        "--manifest /snap/openstack/current/etc/manifests/$risk.yml"
+fi
 """
 
 


### PR DESCRIPTION
Recent change about always deploying stable charms by default causes some friction for users installing from edge / candidate. Add a hint at the end of prepare-node script to use the right manifest when right risk detected.