### PR TITLE
[k8s] remove k8s_snap_channel

### DIFF
--- a/cloud/etc/deploy-k8s/main.tf
+++ b/cloud/etc/deploy-k8s/main.tf
@@ -42,7 +42,5 @@ resource "juju_application" "k8s" {
     base     = "ubuntu@22.04"
   }
 
-  config = merge({
-    channel = var.k8s_snap_channel
-  }, var.k8s_config)
+  config = var.k8s_config
 }

--- a/cloud/etc/deploy-k8s/variables.tf
+++ b/cloud/etc/deploy-k8s/variables.tf
@@ -31,11 +31,6 @@ variable "k8s_config" {
   default     = {}
 }
 
-variable "k8s_snap_channel" {
-  description = "K8S snap channel to deploy, not the operator channel"
-  default     = "latest/edge"
-}
-
 variable "machine_ids" {
   description = "List of machine ids to include"
   type        = list(string)


### PR DESCRIPTION
k8s config channel is removed from
k8s-operator. So remove corresponding
configs from terraform plan