### PR TITLE
Use manifest from detected risk

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -86,22 +86,25 @@ mkdir -p $HOME/.config/openstack
 # Check the snap channel and deduce risk level from it
 snap_output=$(snap list openstack --unicode=never --color=never | grep openstack)
 track=$(awk -v col=4 '{{print $col}}' <<<"$snap_output")
-risk=stable
 
 # if never installed from the store, the channel is "-"
 if [[ $track =~ "edge" ]] || [[ $track == "-" ]]; then
     risk="edge"
-fi
-
-if [[ $track =~ "candidate" ]]; then
+elif [[ $track =~ "beta" ]]; then
+    risk="beta"
+elif [[ $track =~ "candidate" ]]; then
     risk="candidate"
+else
+    risk="stable"
 fi
 
 if [[ $risk != "stable" ]]; then
     echo "You're deploying from $risk channel," \
         " to test $risk charms, you must provide the $risk manifest."
-    echo "Example: sunbeam cluster bootstrap " \
-        "--manifest /snap/openstack/current/etc/manifests/$risk.yml"
+    sudo snap set openstack deployment.risk=$risk
+    echo "Snap has been automatically configured to deploy from" \
+        "$risk channel."
+    echo "Override by passing a custom manifest with -m/--manifest."
 fi
 """
 

--- a/sunbeam-python/sunbeam/commands/refresh.py
+++ b/sunbeam-python/sunbeam/commands/refresh.py
@@ -75,7 +75,7 @@ def refresh(
     # Validate manifest file
     manifest = None
     if clear_manifest:
-        run_plan([AddManifestStep(client)], console)
+        run_plan([AddManifestStep(client, clear=True)], console)
     elif manifest_path:
         manifest = deployment.get_manifest(manifest_path)
         run_plan([AddManifestStep(client, manifest_path)], console)

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -27,6 +27,7 @@ DEFAULT_CONFIG = {
     "daemon.group": "snap_daemon",
     "daemon.debug": False,
     "k8s.provider": "microk8s",
+    "deployment.risk": "stable",
 }
 
 OPTION_KEYS = set(k.split(".")[0] for k in DEFAULT_CONFIG.keys())

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -276,8 +276,7 @@ def bootstrap(
     plan.append(JujuLoginStep(deployment.juju_account))
     # bootstrapped node is always machine 0 in controller model
     plan.append(ClusterInitStep(client, roles_to_str_list(roles), 0))
-    if manifest_path:
-        plan.append(AddManifestStep(client, manifest_path))
+    plan.append(AddManifestStep(client, manifest_path))
     plan.append(
         PromptForProxyStep(
             deployment, accept_defaults=accept_defaults, deployment_preseed=preseed

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -367,10 +367,9 @@ def bootstrap(
         sys.exit(1)
 
     client = deployment.get_client()
-    if manifest_path:
-        plan3 = []
-        plan3.append(AddManifestStep(client))
-        run_plan(plan3, console)
+    plan3 = []
+    plan3.append(AddManifestStep(client, manifest_path))
+    run_plan(plan3, console)
 
     if proxy_from_user and isinstance(proxy_from_user, dict):
         LOG.debug(f"Writing proxy information to clusterdb: {proxy_from_user}")

--- a/sunbeam-python/tests/unit/sunbeam/conftest.py
+++ b/sunbeam-python/tests/unit/sunbeam/conftest.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -19,23 +20,32 @@ from snaphelpers import Snap, SnapConfig, SnapServices
 
 
 @pytest.fixture
-def snap_env():
+def snap_env(tmp_path: Path, mocker):
     """Environment variables defined in the snap.
 
     This is primarily used to setup the snaphelpers bit.
     """
-    yield {
-        "SNAP": "/snap/mysnap/2",
-        "SNAP_COMMON": "/var/snap/mysnap/common",
-        "SNAP_DATA": "/var/snap/mysnap/2",
+    snap_name = "sunbeam-test"
+    real_home = tmp_path / "home/ubuntu"
+    snap_user_common = real_home / f"snap/{snap_name}/common"
+    snap_user_data = real_home / f"snap/{snap_name}/2"
+    snap_path = tmp_path / f"snap/2/{snap_name}"
+    snap_common = tmp_path / f"var/snap/{snap_name}/common"
+    snap_data = tmp_path / f"var/snap/{snap_name}/2"
+    env = {
+        "SNAP": str(snap_path),
+        "SNAP_COMMON": str(snap_common),
+        "SNAP_DATA": str(snap_data),
+        "SNAP_USER_COMMON": str(snap_user_common),
+        "SNAP_USER_DATA": str(snap_user_data),
+        "SNAP_REAL_HOME": str(real_home),
         "SNAP_INSTANCE_NAME": "",
-        "SNAP_NAME": "mysnap",
+        "SNAP_NAME": snap_name,
         "SNAP_REVISION": "2",
-        "SNAP_USER_COMMON": "/var/snap/mysnap/usercommon",
-        "SNAP_USER_DATA": "",
         "SNAP_VERSION": "1.2.3",
-        "SNAP_REAL_HOME": "/home/ubuntu",
     }
+    mocker.patch("os.environ", env)
+    yield env
 
 
 @pytest.fixture

--- a/sunbeam-python/tests/unit/sunbeam/jobs/test_checks.py
+++ b/sunbeam-python/tests/unit/sunbeam/jobs/test_checks.py
@@ -16,7 +16,6 @@
 import base64
 import json
 import os
-from pathlib import PosixPath
 from unittest.mock import Mock
 
 from sunbeam.jobs import checks
@@ -44,7 +43,7 @@ class TestSshKeysConnectedCheck:
         result = check.run()
 
         assert result is False
-        assert "sudo snap connect mysnap:ssh-keys" in check.message
+        assert f"sudo snap connect {snap.name}:ssh-keys" in check.message
 
 
 class TestDaemonGroupCheck:
@@ -80,7 +79,7 @@ class TestLocalShareCheck:
         result = check.run()
 
         assert result is True
-        os.path.exists.assert_called_with(PosixPath("/home/ubuntu/.local/share"))
+        os.path.exists.assert_called_with(snap.paths.real_home / ".local/share")
 
     def test_run_missing(self, mocker, snap):
         mocker.patch.object(checks, "Snap", return_value=snap)
@@ -92,7 +91,7 @@ class TestLocalShareCheck:
 
         assert result is False
         assert "directory not detected" in check.message
-        os.path.exists.assert_called_with(PosixPath("/home/ubuntu/.local/share"))
+        os.path.exists.assert_called_with(snap.paths.real_home / ".local/share")
 
 
 class TestVerifyFQDNCheck:


### PR DESCRIPTION
Use detected risk to choose a manifest when an user does not provide a manifest.

Risk manifests will be loaded only when clusterd does not have a manifest yet. This manifest will be stored in database.