### PR TITLE
Remove images-sync from test manifest

### DIFF
--- a/.github/assets/testing/manifest.yml
+++ b/.github/assets/testing/manifest.yml
@@ -39,8 +39,9 @@ software:
       channel: OS_CHARM
     openstack-hypervisor:
       channel: OS_CHARM
-    openstack-images-sync-k8s:
-      channel: OS_CHARM
+    # removed as not present in 2023.2
+    # openstack-images-sync-k8s:
+    #   channel: OS_CHARM
     ovn-central-k8s:
       channel: OVN_CHARM
     ovn-relay-k8s:


### PR DESCRIPTION
Image-sync is not present in 2023.2, remove it from the test.