### PR TITLE
maas: check for partition label only if fs is defined

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -167,8 +167,7 @@ def _convert_raw_machine(machine_raw: dict) -> dict:
                 root_disk = _to_root_disk(blockdevice)
 
         for partition in blockdevice.get("partitions", []):
-            fs = partition.get("filesystem")
-            if fs.get("label") == "root":
+            if (fs := partition.get("filesystem")) and fs.get("label") == "root":
                 root_disk = _to_root_disk(blockdevice, partition)
 
     spaces = []


### PR DESCRIPTION
This check could fail with a NoneType error when a partition did not have a FS defined.