### PR TITLE
Add region option

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -88,6 +88,7 @@ from sunbeam.commands.openstack import (
     OPENSTACK_MODEL,
     DeployControlPlaneStep,
     PatchLoadBalancerServicesStep,
+    PromptRegionStep,
 )
 from sunbeam.commands.proxy import PromptForProxyStep
 from sunbeam.commands.sunbeam_machine import (
@@ -322,6 +323,8 @@ def bootstrap(
     deployment.reload_juju_credentials()
     jhelper = JujuHelper(deployment.get_connected_controller())
     plan4 = []
+
+    plan4.append(PromptRegionStep(client, preseed, accept_defaults))
     # Deploy sunbeam machine charm
     sunbeam_machine_tfhelper = deployment.get_tfhelper("sunbeam-machine-plan")
     plan4.append(TerraformInitStep(sunbeam_machine_tfhelper))

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -34,6 +34,7 @@ from sunbeam.commands.configure import (
 )
 from sunbeam.commands.juju import BOOTSTRAP_CONFIG_KEY, bootstrap_questions
 from sunbeam.commands.k8s import K8S_ADDONS_CONFIG_KEY, k8s_addons_questions
+from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.microceph import CONFIG_DISKS_KEY, microceph_questions
 from sunbeam.commands.microk8s import (
     MICROK8S_ADDONS_CONFIG_KEY,
@@ -126,6 +127,22 @@ class LocalDeployment(Deployment):
             previous_answers=variables.get("proxy", {}),
         )
         preseed_content.extend(show_questions(proxy_bank, section="proxy"))
+
+        variables = {}
+        try:
+            if client is not None:
+                variables = load_answers(client, REGION_CONFIG_KEY)
+        except ClusterServiceUnavailableException:
+            pass
+
+        region_bank = QuestionBank(
+            questions=region_questions(),
+            console=console,
+            previous_answers=variables,
+        )
+        preseed_content.extend(show_questions(region_bank))
+
+        variables = {}
         try:
             variables = load_answers(client, BOOTSTRAP_CONFIG_KEY)
         except ClusterServiceUnavailableException:

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -69,6 +69,7 @@ from sunbeam.commands.openstack import (
     OPENSTACK_MODEL,
     DeployControlPlaneStep,
     PatchLoadBalancerServicesStep,
+    PromptRegionStep,
 )
 from sunbeam.commands.proxy import PromptForProxyStep
 from sunbeam.commands.sunbeam_machine import (
@@ -497,6 +498,8 @@ def deploy(
         sys.exit(1)
 
     plan2 = []
+
+    plan2.append(PromptRegionStep(client, preseed, accept_defaults))
     plan2.append(TerraformInitStep(tfhelper_sunbeam_machine))
     plan2.append(
         DeploySunbeamMachineApplicationStep(

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -25,6 +25,7 @@ from sunbeam.commands.configure import (
     ext_net_questions,
     user_questions,
 )
+from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.proxy import proxy_questions
 from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment
 from sunbeam.jobs.plugin import PluginManager
@@ -201,6 +202,20 @@ class MaasDeployment(Deployment):
             previous_answers=variables.get("proxy", {}),
         )
         preseed_content.extend(show_questions(proxy_bank, section="proxy"))
+
+        variables = {}
+        try:
+            if client is not None:
+                variables = load_answers(client, REGION_CONFIG_KEY)
+        except ClusterServiceUnavailableException:
+            pass
+
+        region_bank = QuestionBank(
+            questions=region_questions(),
+            console=console,
+            previous_answers=variables,
+        )
+        preseed_content.extend(show_questions(region_bank))
 
         variables = {}
         try:

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
@@ -95,7 +95,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         )
         with patch(
             "sunbeam.commands.openstack.read_config",
-            Mock(return_value={}),
+            Mock(return_value={"region": "TestOne"}),
         ):
             result = step.run()
 
@@ -119,7 +119,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         )
         with patch(
             "sunbeam.commands.openstack.read_config",
-            Mock(return_value={}),
+            Mock(return_value={"region": "TestOne"}),
         ):
             result = step.run()
 
@@ -142,7 +142,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         )
         with patch(
             "sunbeam.commands.openstack.read_config",
-            Mock(return_value={}),
+            Mock(return_value={"region": "TestOne"}),
         ):
             result = step.run()
 
@@ -167,7 +167,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         )
         with patch(
             "sunbeam.commands.openstack.read_config",
-            Mock(return_value={}),
+            Mock(return_value={"region": "TestOne"}),
         ):
             result = step.run()
 


### PR DESCRIPTION
Add a step to prompt user for the region name. This region name cannot be changed later.
Add dedicated entry in the deployment manifest.

Requires:
- [x] https://github.com/canonical/sunbeam-terraform/pull/72