### PR TITLE
prepare-node: drop message about using manifest

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -99,8 +99,6 @@ else
 fi
 
 if [[ $risk != "stable" ]]; then
-    echo "You're deploying from $risk channel," \
-        " to test $risk charms, you must provide the $risk manifest."
     sudo snap set openstack deployment.risk=$risk
     echo "Snap has been automatically configured to deploy from" \
         "$risk channel."


### PR DESCRIPTION
Drop surplus message about having to use a manifest to deploy from channels other than stable as this is now set based on the risk level of the install of the openstack snap.