### PR TITLE
Bump the HYPERVISOR_UNIT_TIMEOUT

### DIFF
--- a/sunbeam-python/sunbeam/commands/hypervisor.py
+++ b/sunbeam-python/sunbeam/commands/hypervisor.py
@@ -44,7 +44,7 @@ CONFIG_KEY = "TerraformVarsHypervisor"
 APPLICATION = "openstack-hypervisor"
 HYPERVISOR_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
 HYPERVISOR_UNIT_TIMEOUT = (
-    1200  # 15 minutes, adding / removing units can take a long time
+    1800  # 30 minutes, adding / removing units can take a long time
 )
 
 


### PR DESCRIPTION
A fixed timeout is not good in general without checking the status if a charm is really in the error/blocked status and stuck without a human intervention or hooks are still going on and just taking time. However, "Timed out while waiting for units openstack-hypervisor/N to be ready" is the most frequent timeout I saw in the testing so bump it not to hit into it with normal circumstances.

Closes-Bug: [LP: #2065866](https://bugs.launchpad.net/snap-openstack/+bug/2065866)