### PR TITLE
Fix ubuntu-advantage channel

### DIFF
--- a/sunbeam-python/sunbeam/plugins/pro/etc/deploy-pro/variables.tf
+++ b/sunbeam-python/sunbeam/plugins/pro/etc/deploy-pro/variables.tf
@@ -15,7 +15,8 @@
 
 variable "ubuntu-advantage-channel" {
   description = "Channel to use for deployment of ubuntu-advantage charm"
-  default     = "stable"
+  type        = string
+  default     = "latest/stable"
 }
 
 variable "token" {


### PR DESCRIPTION
Ubuntu advantage channel did not specify a track, only a risk. This behavior has been removed in the terraform provider a while ago when switching to the new provider framework.

Related-bug: [2067395](https://bugs.launchpad.net/snap-openstack/+bug/2067395)