### PR TITLE
Bump juju to 3.5

### DIFF
--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -15,7 +15,7 @@
 
 
 SUPPORTED_RELEASE = "jammy"
-JUJU_CHANNEL = "3.4/stable"
+JUJU_CHANNEL = "3.5/stable"
 JUJU_BASE = "ubuntu@22.04"
 OPENSTACK_CHANNEL = "2024.1/stable"
 OVN_CHANNEL = "24.03/stable"


### PR DESCRIPTION
Juju 3.5.1 just released and solved the rabbitmq issue. Bump to the newest version.