### PR TITLE
Create management space as default space (local mode)

### DIFF
--- a/sunbeam-python/requirements.txt
+++ b/sunbeam-python/requirements.txt
@@ -46,3 +46,6 @@ pydantic
 
 # maas
 python-libmaas
+
+# Faillible management
+tenacity

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -25,14 +25,17 @@ from sunbeam.clusterd.service import (
     ClusterServiceUnavailableException,
     ConfigItemNotFoundException,
 )
-from sunbeam.commands.clusterd import CLUSTERD_PORT
+from sunbeam.commands.clusterd import (
+    BOOTSTRAP_CONFIG_KEY,
+    CLUSTERD_PORT,
+    bootstrap_questions,
+)
 from sunbeam.commands.configure import (
     CLOUD_CONFIG_SECTION,
     ext_net_questions,
     ext_net_questions_local_only,
     user_questions,
 )
-from sunbeam.commands.juju import BOOTSTRAP_CONFIG_KEY, bootstrap_questions
 from sunbeam.commands.k8s import K8S_ADDONS_CONFIG_KEY, k8s_addons_questions
 from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.microceph import CONFIG_DISKS_KEY, microceph_questions

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -903,9 +903,7 @@ class MaasBootstrapJujuStep(BootstrapJujuStep):
         controller: str,
         password: str,
         bootstrap_args: list[str] | None = None,
-        deployment_preseed: dict | None = None,
         proxy_settings: dict | None = None,
-        accept_defaults: bool = False,
     ):
         bootstrap_args = bootstrap_args or []
         bootstrap_args.extend(
@@ -941,9 +939,7 @@ class MaasBootstrapJujuStep(BootstrapJujuStep):
             cloud_type,
             controller,
             bootstrap_args=bootstrap_args,
-            deployment_preseed=deployment_preseed,
             proxy_settings=proxy_settings,
-            accept_defaults=accept_defaults,
         )
         self.maas_client = maas_client
 

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -176,7 +176,18 @@ def get_local_ip_by_default_route() -> str:
     return get_ifaddresses_by_default_route()["addr"]
 
 
-def get_local_cidr_by_default_routes() -> str:
+def get_local_ip_by_cidr(cidr: str) -> str:
+    """Get first IP address of host associated with CIDR."""
+    network = ipaddress.ip_network(cidr, strict=True)
+    with NDB() as ndb:
+        for parsed_address in ndb.addresses.values():
+            address = ipaddress.ip_address(parsed_address["address"])
+            if address in network:
+                return str(address)
+    raise ValueError(f"No local IP address found for CIDR {cidr}")
+
+
+def get_local_cidr_by_default_route() -> str:
     """Get CIDR of host associated with default gateway"""
     conf = get_ifaddresses_by_default_route()
     ip = conf["addr"]


### PR DESCRIPTION
Create a management space after the controller is bootstrapped:
- move question about management cidr earlier
- bootstrap clusterd with local address found in management_cidr answer
- save management cidr to clusterd
- create a space management with management cidr
- update controller model to set management as default space
- bind controller's app endpoints to management space (until LP#2067617 is fixed)

All application deployed to controller model will be bound to the management space and should make use of this feature (except for microk8s).

Related-Bug: LP#2065700
Related-Bug: LP#2048678