### PR TITLE
Fix wrong controller name in validation plugin

### DIFF
--- a/sunbeam-python/sunbeam/jobs/deployment.py
+++ b/sunbeam-python/sunbeam/jobs/deployment.py
@@ -92,6 +92,11 @@ class Deployment(pydantic.BaseModel):
         """Return the infrastructure model name."""
         return NotImplemented
 
+    @property
+    def controller(self) -> str:
+        """Return controller name."""
+        return NotImplemented
+
     @classmethod
     def load(cls, deployment: dict) -> "Deployment":
         """Load deployment from dict."""

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -45,7 +45,12 @@ from sunbeam.commands.microk8s import (
 from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.proxy import proxy_questions
 from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment, Networks
-from sunbeam.jobs.juju import JujuAccount, JujuAccountNotFound, JujuController
+from sunbeam.jobs.juju import (
+    CONTROLLER,
+    JujuAccount,
+    JujuAccountNotFound,
+    JujuController,
+)
 from sunbeam.jobs.plugin import PluginManager
 from sunbeam.jobs.questions import QuestionBank, load_answers, show_questions
 
@@ -95,6 +100,11 @@ class LocalDeployment(Deployment):
     def infrastructure_model(self) -> str:
         """Return the infrastructure model name."""
         return "controller"
+
+    @property
+    def controller(self) -> str:
+        """Return the controller name."""
+        return CONTROLLER
 
     def get_client(self) -> Client:
         """Return a client for the deployment."""


### PR DESCRIPTION
Since the controller name can be different for local deployment and maas deployment, we cannot hardcode the controller name in validation plugin. Also since there is only one controller in sunbeam, we don't need to explicitly specify the controller name when running `juju` command. 

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2066412