### PR TITLE
Map machine application endpoints to spaces

### DIFF
--- a/cloud/etc/deploy-k8s/main.tf
+++ b/cloud/etc/deploy-k8s/main.tf
@@ -43,4 +43,5 @@ resource "juju_application" "k8s" {
   }
 
   config = var.k8s_config
+  endpoint_bindings = var.endpoint_bindings
 }

--- a/cloud/etc/deploy-k8s/variables.tf
+++ b/cloud/etc/deploy-k8s/variables.tf
@@ -41,3 +41,9 @@ variable "machine_model" {
   description = "Model to deploy to"
   type        = string
 }
+
+variable "endpoint_bindings" {
+  description = "Endpoint bindings for k8s"
+  type        = set(map(string))
+  default     = null
+}

--- a/cloud/etc/deploy-microceph/main.tf
+++ b/cloud/etc/deploy-microceph/main.tf
@@ -40,12 +40,13 @@ resource "juju_application" "microceph" {
     name     = "microceph"
     channel  = var.charm_microceph_channel
     revision = var.charm_microceph_revision
-    base    = "ubuntu@22.04"
+    base     = "ubuntu@22.04"
   }
 
   config = merge({
     snap-channel = var.microceph_channel
   }, var.charm_microceph_config)
+  endpoint_bindings = var.endpoint_bindings
 }
 
 # juju_offer.microceph_offer will be created

--- a/cloud/etc/deploy-microceph/variables.tf
+++ b/cloud/etc/deploy-microceph/variables.tf
@@ -46,3 +46,9 @@ variable "machine_model" {
   description = "Model to deploy to"
   type        = string
 }
+
+variable "endpoint_bindings" {
+  description = "Endpoint bindings for microceph"
+  type        = set(map(string))
+  default     = null
+}

--- a/cloud/etc/deploy-microk8s/main.tf
+++ b/cloud/etc/deploy-microk8s/main.tf
@@ -50,4 +50,5 @@ resource "juju_application" "microk8s" {
     kubelet_serialize_image_pulls = false
     skip_verify                   = true
   }, var.charm_microk8s_config)
+  endpoint_bindings = var.endpoint_bindings
 }

--- a/cloud/etc/deploy-microk8s/variables.tf
+++ b/cloud/etc/deploy-microk8s/variables.tf
@@ -56,3 +56,9 @@ variable "addons" {
     metallb          = "10.20.21.1-10.20.21.10"
   }
 }
+
+variable "endpoint_bindings" {
+  description = "Endpoint bindings for microk8s"
+  type        = set(map(string))
+  default     = null
+}

--- a/cloud/etc/deploy-openstack-hypervisor/main.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/main.tf
@@ -46,8 +46,9 @@ resource "juju_application" "openstack-hypervisor" {
 
   config = merge({
     snap-channel = var.snap_channel
+    use-migration-binding = true
   }, var.charm_config)
-
+  endpoint_bindings = var.endpoint_bindings
 }
 
 resource "juju_integration" "hypervisor-amqp" {

--- a/cloud/etc/deploy-openstack-hypervisor/variables.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/variables.tf
@@ -58,6 +58,13 @@ variable "openstack-state-backend" {
   type        = string
   default     = "local"
 }
+
 variable "openstack-state-config" {
   type = map(any)
+}
+
+variable "endpoint_bindings" {
+  description = "Endpoint bindings for openstack-hypervisor"
+  type        = set(map(string))
+  default     = null
 }

--- a/cloud/etc/deploy-sunbeam-machine/main.tf
+++ b/cloud/etc/deploy-sunbeam-machine/main.tf
@@ -40,5 +40,6 @@ resource "juju_application" "sunbeam-machine" {
   }
 
   config = var.charm_config
+  endpoint_bindings = var.endpoint_bindings
 
 }

--- a/cloud/etc/deploy-sunbeam-machine/variables.tf
+++ b/cloud/etc/deploy-sunbeam-machine/variables.tf
@@ -41,3 +41,9 @@ variable "machine_model" {
   description = "Name of model to deploy sunbeam-machine into."
   type        = string
 }
+
+variable "endpoint_bindings" {
+  description = "Endpoint bindings for sunbeam-machine"
+  type        = set(map(string))
+  default     = null
+}

--- a/sunbeam-python/sunbeam/commands/hypervisor.py
+++ b/sunbeam-python/sunbeam/commands/hypervisor.py
@@ -30,6 +30,7 @@ from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.commands.openstack_api import guests_on_hypervisor, remove_hypervisor
 from sunbeam.commands.terraform import TerraformException, TerraformHelper
 from sunbeam.jobs.common import BaseStep, Result, ResultType, read_config, update_config
+from sunbeam.jobs.deployment import Deployment, Networks
 from sunbeam.jobs.juju import (
     ApplicationNotFoundException,
     JujuHelper,
@@ -55,6 +56,7 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
 
     def __init__(
         self,
+        deployment: Deployment,
         client: Client,
         tfhelper: TerraformHelper,
         openstack_tfhelper: TerraformHelper,
@@ -63,6 +65,7 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
         model: str,
     ):
         super().__init__(
+            deployment,
             client,
             tfhelper,
             jhelper,
@@ -82,6 +85,49 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
             "openstack_model": self.openstack_model,
             "openstack-state-backend": self.openstack_tfhelper.backend,
             "openstack-state-config": openstack_backend_config,
+            "endpoint_bindings": [
+                {"space": self.deployment.get_space(Networks.MANAGEMENT)},
+                {
+                    "endpoint": "ceph-access",
+                    "space": self.deployment.get_space(Networks.STORAGE),
+                },
+                {
+                    "endpoint": "migration",
+                    "space": self.deployment.get_space(Networks.DATA),
+                },
+                {
+                    "endpoint": "amqp",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "ceilometer-service",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "certificates",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "cos-agent",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "identity-credentials",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "nova-service",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "ovsdb-cms",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "receive-ca-cert",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+            ],
         }
 
     def get_application_timeout(self) -> int:

--- a/sunbeam-python/sunbeam/commands/k8s.py
+++ b/sunbeam-python/sunbeam/commands/k8s.py
@@ -40,6 +40,7 @@ from sunbeam.jobs.common import (
     read_config,
     update_config,
 )
+from sunbeam.jobs.deployment import Deployment, Networks
 from sunbeam.jobs.juju import (
     ActionFailedException,
     ApplicationNotFoundException,
@@ -100,6 +101,7 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
 
     def __init__(
         self,
+        deployment: Deployment,
         client: Client,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
@@ -110,6 +112,7 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
         refresh: bool = False,
     ):
         super().__init__(
+            deployment,
             client,
             tfhelper,
             jhelper,
@@ -164,6 +167,13 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
 
     def get_application_timeout(self) -> int:
         return K8S_APP_TIMEOUT
+
+    def extra_tfvars(self) -> dict:
+        return {
+            "endpoint_bindings": [
+                {"space": self.deployment.get_space(Networks.MANAGEMENT)},
+            ]
+        }
 
 
 class AddK8SUnitsStep(AddMachineUnitsStep):

--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -27,6 +27,7 @@ from sunbeam.commands.juju import JujuStepHelper
 from sunbeam.commands.terraform import TerraformHelper
 from sunbeam.jobs import questions
 from sunbeam.jobs.common import BaseStep, Result, ResultType, read_config, update_config
+from sunbeam.jobs.deployment import Deployment, Networks
 from sunbeam.jobs.juju import (
     ActionFailedException,
     ApplicationNotFoundException,
@@ -91,6 +92,7 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
 
     def __init__(
         self,
+        deployment: Deployment,
         client: Client,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
@@ -101,6 +103,7 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
         refresh: bool = False,
     ):
         super().__init__(
+            deployment,
             client,
             tfhelper,
             jhelper,
@@ -160,6 +163,13 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
             return False
 
         return True
+
+    def extra_tfvars(self) -> dict:
+        return {
+            "endpoint_bindings": [
+                {"space": self.deployment.get_space(Networks.MANAGEMENT)},
+            ]
+        }
 
 
 class AddMicrok8sUnitsStep(AddMachineUnitsStep):

--- a/sunbeam-python/sunbeam/commands/proxy.py
+++ b/sunbeam-python/sunbeam/commands/proxy.py
@@ -93,6 +93,7 @@ def _update_proxy(proxy: dict, deployment: Deployment):
     plan = []
     plan.append(
         DeploySunbeamMachineApplicationStep(
+            deployment,
             client,
             deployment.get_tfhelper("sunbeam-machine-plan"),
             jhelper,

--- a/sunbeam-python/sunbeam/commands/sunbeam_machine.py
+++ b/sunbeam-python/sunbeam/commands/sunbeam_machine.py
@@ -17,6 +17,7 @@ import logging
 
 from sunbeam.clusterd.client import Client
 from sunbeam.commands.terraform import TerraformHelper
+from sunbeam.jobs.deployment import Deployment, Networks
 from sunbeam.jobs.juju import JujuHelper
 from sunbeam.jobs.manifest import Manifest
 from sunbeam.jobs.steps import (
@@ -39,6 +40,7 @@ class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
 
     def __init__(
         self,
+        deployment: Deployment,
         client: Client,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
@@ -48,6 +50,7 @@ class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
         proxy_settings: dict = {},
     ):
         super().__init__(
+            deployment,
             client,
             tfhelper,
             jhelper,
@@ -66,11 +69,14 @@ class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
 
     def extra_tfvars(self) -> dict:
         return {
+            "endpoint_bindings": [
+                {"space": self.deployment.get_space(Networks.MANAGEMENT)},
+            ],
             "charm_config": {
                 "http_proxy": self.proxy_settings.get("HTTP_PROXY", ""),
                 "https_proxy": self.proxy_settings.get("HTTPS_PROXY", ""),
                 "no_proxy": self.proxy_settings.get("NO_PROXY", ""),
-            }
+            },
         }
 
 

--- a/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
@@ -133,6 +133,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
             ),
             TerraformInitStep(self.deployment.get_tfhelper("sunbeam-machine-plan")),
             DeploySunbeamMachineApplicationStep(
+                self.deployment,
                 self.client,
                 self.deployment.get_tfhelper("sunbeam-machine-plan"),
                 self.jhelper,
@@ -147,6 +148,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                 [
                     TerraformInitStep(self.deployment.get_tfhelper("k8s-plan")),
                     DeployK8SApplicationStep(
+                        self.deployment,
                         self.client,
                         self.deployment.get_tfhelper("k8s-plan"),
                         self.jhelper,
@@ -161,6 +163,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                 [
                     TerraformInitStep(self.deployment.get_tfhelper("microk8s-plan")),
                     DeployMicrok8sApplicationStep(
+                        self.deployment,
                         self.client,
                         self.deployment.get_tfhelper("microk8s-plan"),
                         self.jhelper,
@@ -175,6 +178,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
             [
                 TerraformInitStep(self.deployment.get_tfhelper("microceph-plan")),
                 DeployMicrocephApplicationStep(
+                    self.deployment,
                     self.client,
                     self.deployment.get_tfhelper("microceph-plan"),
                     self.jhelper,

--- a/sunbeam-python/sunbeam/jobs/deployment.py
+++ b/sunbeam-python/sunbeam/jobs/deployment.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import copy
+import enum
 import logging
 import pathlib
 import shutil
@@ -61,6 +62,20 @@ class MissingTerraformInfoException(Exception):
     """An Exception raised when terraform information is missing in manifest"""
 
     pass
+
+
+class Networks(enum.Enum):
+    PUBLIC = "public"
+    STORAGE = "storage"
+    STORAGE_CLUSTER = "storage-cluster"
+    INTERNAL = "internal"
+    DATA = "data"
+    MANAGEMENT = "management"
+
+    @classmethod
+    def values(cls) -> list[str]:
+        """Return list of tag values."""
+        return [tag.value for tag in cls]
 
 
 class Deployment(pydantic.BaseModel):
@@ -263,3 +278,7 @@ class Deployment(pydantic.BaseModel):
             return tfhelper
 
         raise ValueError(f"{tfplan} not found in tfhelpers")
+
+    def get_space(self, network: Networks) -> str:
+        """Get space associated to network."""
+        return NotImplemented

--- a/sunbeam-python/sunbeam/jobs/steps.py
+++ b/sunbeam-python/sunbeam/jobs/steps.py
@@ -25,6 +25,7 @@ from sunbeam.clusterd.service import (
 )
 from sunbeam.commands.terraform import TerraformException, TerraformHelper
 from sunbeam.jobs.common import BaseStep, Result, ResultType, read_config, update_config
+from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import (
     ApplicationNotFoundException,
     JujuHelper,
@@ -41,6 +42,7 @@ class DeployMachineApplicationStep(BaseStep):
 
     def __init__(
         self,
+        deployment: Deployment,
         client: Client,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
@@ -53,6 +55,7 @@ class DeployMachineApplicationStep(BaseStep):
         refresh: bool = False,
     ):
         super().__init__(banner, description)
+        self.deployment = deployment
         self.client = client
         self.tfhelper = tfhelper
         self.jhelper = jhelper

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -128,7 +128,7 @@ from sunbeam.jobs.common import (
     run_preflight_checks,
     validate_roles,
 )
-from sunbeam.jobs.deployment import Deployment
+from sunbeam.jobs.deployment import Deployment, Networks
 from sunbeam.jobs.juju import CONTROLLER, JujuHelper, ModelNotFoundException, run_sync
 from sunbeam.jobs.manifest import AddManifestStep
 from sunbeam.provider.base import ProviderBase
@@ -336,7 +336,7 @@ def bootstrap(
         AddJujuSpaceStep(
             jhelper,
             deployment.infrastructure_model,
-            "management",
+            deployment.get_space(Networks.MANAGEMENT),
             [management_cidr],
         )
     )
@@ -345,7 +345,7 @@ def bootstrap(
             jhelper,
             deployment.infrastructure_model,
             {
-                "default-space": "management",
+                "default-space": deployment.get_space(Networks.MANAGEMENT),
             },
         )
     )
@@ -358,7 +358,7 @@ def bootstrap(
             jhelper,
             deployment.infrastructure_model,
             "controller",
-            "management",
+            deployment.get_space(Networks.MANAGEMENT),
         )
     )
     plan4.append(PromptRegionStep(client, preseed, accept_defaults))
@@ -367,6 +367,7 @@ def bootstrap(
     plan4.append(TerraformInitStep(sunbeam_machine_tfhelper))
     plan4.append(
         DeploySunbeamMachineApplicationStep(
+            deployment,
             client,
             sunbeam_machine_tfhelper,
             jhelper,
@@ -387,6 +388,7 @@ def bootstrap(
         plan4.append(TerraformInitStep(k8s_tfhelper))
         plan4.append(
             DeployK8SApplicationStep(
+                deployment,
                 client,
                 k8s_tfhelper,
                 jhelper,
@@ -411,6 +413,7 @@ def bootstrap(
         plan4.append(TerraformInitStep(k8s_tfhelper))
         plan4.append(
             DeployMicrok8sApplicationStep(
+                deployment,
                 client,
                 k8s_tfhelper,
                 jhelper,
@@ -433,6 +436,7 @@ def bootstrap(
     plan4.append(TerraformInitStep(microceph_tfhelper))
     plan4.append(
         DeployMicrocephApplicationStep(
+            deployment,
             client,
             microceph_tfhelper,
             jhelper,
@@ -489,6 +493,7 @@ def bootstrap(
     plan5.append(TerraformInitStep(hypervisor_tfhelper))
     plan5.append(
         DeployHypervisorApplicationStep(
+            deployment,
             client,
             hypervisor_tfhelper,
             openstack_tfhelper,

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -37,14 +37,14 @@ from sunbeam.commands.configure import (
     user_questions,
 )
 from sunbeam.commands.k8s import K8S_ADDONS_CONFIG_KEY, k8s_addons_questions
-from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.microceph import CONFIG_DISKS_KEY, microceph_questions
 from sunbeam.commands.microk8s import (
     MICROK8S_ADDONS_CONFIG_KEY,
     microk8s_addons_questions,
 )
+from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.proxy import proxy_questions
-from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment
+from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment, Networks
 from sunbeam.jobs.juju import JujuAccount, JujuAccountNotFound, JujuController
 from sunbeam.jobs.plugin import PluginManager
 from sunbeam.jobs.questions import QuestionBank, load_answers, show_questions
@@ -256,3 +256,10 @@ class LocalDeployment(Deployment):
         proxy_configs = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"]
         proxy = {p: v.strip("\"'") for p in proxy_configs if (v := current_env.get(p))}
         return proxy
+
+    def get_space(self, network: Networks) -> str:
+        """Get space associated to network.
+
+        Local deployment only supports management space as of now.
+        """
+        return "management"

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -22,11 +22,10 @@ from typing import overload
 from maas.client import bones, connect
 from rich.console import Console
 
-from sunbeam.jobs.deployment import Deployment
+from sunbeam.jobs.deployment import Deployment, Networks
 from sunbeam.jobs.deployments import DeploymentsConfig
 from sunbeam.provider.maas.deployment import (
     MaasDeployment,
-    Networks,
     RoleTags,
     StorageTags,
     is_maas_deployment,

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -97,7 +97,7 @@ from sunbeam.jobs.common import (
     run_preflight_checks,
     str_presenter,
 )
-from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment
+from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment, Networks
 from sunbeam.jobs.deployments import DeploymentsConfig, deployment_path
 from sunbeam.jobs.juju import (
     CONTROLLER_MODEL,
@@ -111,7 +111,6 @@ from sunbeam.provider.base import ProviderBase
 from sunbeam.provider.maas.client import (
     MaasClient,
     MaasDeployment,
-    Networks,
     RoleTags,
     get_machine,
     get_network_mapping,
@@ -324,8 +323,6 @@ def bootstrap(
             deployment.controller,
             deployment.juju_account.password,
             manifest.software.juju.bootstrap_args,
-            deployment_preseed=preseed,
-            accept_defaults=accept_defaults,
             proxy_settings=proxy_settings,
         )
     )
@@ -503,6 +500,7 @@ def deploy(
     plan2.append(TerraformInitStep(tfhelper_sunbeam_machine))
     plan2.append(
         DeploySunbeamMachineApplicationStep(
+            deployment,
             client,
             tfhelper_sunbeam_machine,
             jhelper,
@@ -521,15 +519,12 @@ def deploy(
     if k8s_provider == "k8s":
         plan2.append(
             MaasDeployK8SApplicationStep(
+                deployment,
                 client,
                 maas_client,
                 tfhelper_k8s,
                 jhelper,
                 manifest,
-                str(deployment.network_mapping[Networks.PUBLIC.value]),
-                deployment.public_api_label,
-                str(deployment.network_mapping[Networks.INTERNAL.value]),
-                deployment.internal_api_label,
                 deployment.infrastructure_model,
                 preseed,
                 accept_defaults,
@@ -555,15 +550,12 @@ def deploy(
     else:
         plan2.append(
             MaasDeployMicrok8sApplicationStep(
+                deployment,
                 client,
                 maas_client,
                 tfhelper_k8s,
                 jhelper,
                 manifest,
-                str(deployment.network_mapping[Networks.PUBLIC.value]),
-                deployment.public_api_label,
-                str(deployment.network_mapping[Networks.INTERNAL.value]),
-                deployment.internal_api_label,
                 deployment.infrastructure_model,
                 preseed,
                 accept_defaults,
@@ -582,6 +574,7 @@ def deploy(
     plan2.append(TerraformInitStep(tfhelper_microceph))
     plan2.append(
         DeployMicrocephApplicationStep(
+            deployment,
             client,
             tfhelper_microceph,
             jhelper,
@@ -620,6 +613,7 @@ def deploy(
     plan2.append(TerraformInitStep(tfhelper_hypervisor_deploy))
     plan2.append(
         DeployHypervisorApplicationStep(
+            deployment,
             client,
             tfhelper_hypervisor_deploy,
             tfhelper_openstack_deploy,

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -27,25 +27,11 @@ from sunbeam.commands.configure import (
 )
 from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.proxy import proxy_questions
-from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment
+from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment, Networks
 from sunbeam.jobs.plugin import PluginManager
 from sunbeam.jobs.questions import Question, QuestionBank, load_answers, show_questions
 
 MAAS_TYPE = "maas"
-
-
-class Networks(enum.Enum):
-    PUBLIC = "public"
-    STORAGE = "storage"
-    STORAGE_CLUSTER = "storage-cluster"
-    INTERNAL = "internal"
-    DATA = "data"
-    MANAGEMENT = "management"
-
-    @classmethod
-    def values(cls) -> list[str]:
-        """Return list of tag values."""
-        return [tag.value for tag in cls]
 
 
 class RoleTags(enum.Enum):
@@ -262,6 +248,13 @@ class MaasDeployment(Deployment):
         subnets_cidr = (subnet.get("cidr") for subnet in subnets if subnet.get("cidr"))
         no_proxy = ",".join(subnets_cidr)
         return {"HTTP_PROXY": proxy, "HTTPS_PROXY": proxy, "NO_PROXY": no_proxy}
+
+    def get_space(self, network: Networks) -> str:
+        """Return space by name."""
+        space = self.network_mapping.get(network.value)
+        if space is None:
+            raise ValueError(f"Space for network {network.value} not set.")
+        return space
 
 
 def is_maas_deployment(deployment: Deployment) -> TypeGuard[MaasDeployment]:


### PR DESCRIPTION
Map each application to the corresponding space. Sunbeam networks are semantics that will always map out to a space.
In local mode, the only supported space is `management`.