### PR TITLE
Find local ip address from management cidr as much as possible

### DIFF
--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -78,7 +78,6 @@ class ClusterInitStep(BaseStep):
         self.machineid = machineid
         self.client = client
         self.management_cidr = management_cidr
-        self.fqdn = utils.get_fqdn()
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -86,6 +85,7 @@ class ClusterInitStep(BaseStep):
         :return: ResultType.SKIPPED if the Step should be skipped,
                  ResultType.COMPLETED or ResultType.FAILED otherwise
         """
+        self.fqdn = utils.get_fqdn(self.management_cidr)
         try:
             members = self.client.cluster.get_cluster_members()
             LOG.info(members)
@@ -277,15 +277,22 @@ class ClusterAddNodeStep(BaseStep):
 class ClusterJoinNodeStep(BaseStep):
     """Join node to the sunbeam cluster."""
 
-    def __init__(self, client: Client, token: str, role: List[str]):
+    def __init__(
+        self,
+        client: Client,
+        token: str,
+        host_address: str,
+        fqdn: str,
+        role: list[str],
+    ):
         super().__init__("Join node to Cluster", "Adding node to Sunbeam cluster")
 
         self.port = CLUSTERD_PORT
         self.client = client
         self.token = token
         self.role = role
-        self.fqdn = utils.get_fqdn()
-        self.ip = utils.get_local_ip_by_default_route()
+        self.ip = host_address
+        self.fqdn = fqdn
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -37,12 +37,12 @@ from sunbeam.commands.configure import (
     user_questions,
 )
 from sunbeam.commands.k8s import K8S_ADDONS_CONFIG_KEY, k8s_addons_questions
-from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.microceph import CONFIG_DISKS_KEY, microceph_questions
 from sunbeam.commands.microk8s import (
     MICROK8S_ADDONS_CONFIG_KEY,
     microk8s_addons_questions,
 )
+from sunbeam.commands.openstack import REGION_CONFIG_KEY, region_questions
 from sunbeam.commands.proxy import proxy_questions
 from sunbeam.jobs.deployment import PROXY_CONFIG_KEY, Deployment
 from sunbeam.jobs.juju import JujuAccount, JujuAccountNotFound, JujuController
@@ -58,6 +58,7 @@ class LocalDeployment(Deployment):
     url: str = "local"
     type: str = LOCAL_TYPE
     _client: Client | None = pydantic.PrivateAttr(default=None)
+    _management_cidr: str | None = pydantic.PrivateAttr(default=None)
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -100,15 +101,30 @@ class LocalDeployment(Deployment):
             self._client = Client.from_socket()
         return self._client
 
+    def get_management_cidr(self) -> str:
+        """Return the management CIDR."""
+        if self._management_cidr is not None:
+            return self._management_cidr
+        bootstrap_config = load_answers(self.get_client(), BOOTSTRAP_CONFIG_KEY)
+        management_cidr = bootstrap_config.get("bootstrap", {}).get("management_cidr")
+        if management_cidr is None:
+            raise ValueError("Management CIDR not found in bootstrap config")
+        self._management_cidr = management_cidr
+        return management_cidr
+
     def get_clusterd_http_address(self) -> str:
         """Return the address of the clusterd server."""
-        local_ip = utils.get_local_ip_by_default_route()
+        local_ip = utils.get_local_ip_by_cidr(self.get_management_cidr())
         address = f"https://{local_ip}:{CLUSTERD_PORT}"
         return address
 
     def generate_preseed(self, console: Console) -> str:
         """Generate preseed for deployment."""
-        fqdn = utils.get_fqdn()
+        try:
+            management_cidr = self.get_management_cidr()
+        except ValueError:
+            management_cidr = None
+        fqdn = utils.get_fqdn(management_cidr)
         client = self.get_client()
         preseed_content = ["deployment:"]
         try:

--- a/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
@@ -53,6 +53,7 @@ class TestClusterdSteps:
         role = "control"
         init_step = ClusterInitStep(cclient, [role], 0, "10.0.0.0/16")
         init_step.client = MagicMock()
+        init_step.fqdn = "node1"
         with mocker.patch(
             "sunbeam.utils.get_local_ip_by_cidr", return_value="10.0.0.2"
         ):
@@ -69,7 +70,11 @@ class TestClusterdSteps:
 
     def test_join_node_step(self, cclient):
         join_node_step = ClusterJoinNodeStep(
-            cclient, token="TESTTOKEN", role=["control"]
+            cclient,
+            token="TESTTOKEN",
+            host_address="10.0.0.3",
+            fqdn="node1",
+            role=["control"],
         )
         join_node_step.client = MagicMock()
         result = join_node_step.run()


### PR DESCRIPTION
Terraform talks to microcluster via ip, and the IP could still be wrong if the default route is not right. Derive local IP address from management cidr.
During join, try to find local ip address matching network of the join addresses, fallback to previous behavior of trying to find via default route.