### PR TITLE
Fix microceph and hypervisor issues

### DIFF
--- a/sunbeam-python/sunbeam/commands/resize.py
+++ b/sunbeam-python/sunbeam/commands/resize.py
@@ -57,6 +57,7 @@ def resize(ctx: click.Context, topology: str, force: bool = False) -> None:
             [
                 TerraformInitStep(microceph_tfhelper),
                 DeployMicrocephApplicationStep(
+                    deployment,
                     client,
                     microceph_tfhelper,
                     jhelper,

--- a/sunbeam-python/sunbeam/jobs/steps.py
+++ b/sunbeam-python/sunbeam/jobs/steps.py
@@ -226,6 +226,10 @@ class AddMachineUnitsStep(BaseStep):
         tfvars.update({"machine_ids": sorted(machine_ids)})
         update_config(self.client, self.config, tfvars)
 
+    def get_accepted_unit_status(self) -> dict[str, list[str]]:
+        """Accepted status to pass wait_units_ready function."""
+        return {"agent": ["idle"], "workload": ["active"]}
+
     def run(self, status: Optional[Status] = None) -> Result:
         """Add unit to machine application on Juju model."""
         try:
@@ -239,6 +243,7 @@ class AddMachineUnitsStep(BaseStep):
                 self.jhelper.wait_units_ready(
                     units,
                     self.model,
+                    accepted_status=self.get_accepted_unit_status(),
                     timeout=self.get_unit_timeout(),
                 )
             )

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_hypervisor.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_hypervisor.py
@@ -202,6 +202,7 @@ class TestReapplyHypervisorTerraformPlanStep(unittest.TestCase):
 
     def setUp(self):
         self.client = Mock()
+        self.client.cluster.list_nodes_by_role.return_value = []
         self.read_config.start()
         self.tfhelper = Mock()
         self.jhelper = AsyncMock()
@@ -211,6 +212,7 @@ class TestReapplyHypervisorTerraformPlanStep(unittest.TestCase):
         self.read_config.stop()
 
     def test_is_skip(self):
+        self.client.cluster.list_nodes_by_role.return_value = ["node-1"]
         step = ReapplyHypervisorTerraformPlanStep(
             self.client, self.tfhelper, self.jhelper, self.manifest, "test-model"
         )


### PR DESCRIPTION
microceph: fix wrongly initialized micrceph deploy in resize
hypervisor: AddHypervisorUnitsStep relied on a wrong behaviour of the
hypervisor getting to active status which does not happen when there's
no ceph relation. In case of no ceph relation, the hypervisor stays in
waiting. It only went to active because of the way status were treated
in sunbeam charms. This has been fixed.