### PR TITLE
Add manifest for beta channel

### DIFF
--- a/manifests/beta.yml
+++ b/manifests/beta.yml
@@ -1,0 +1,62 @@
+software:
+  charms:
+    aodh-k8s:
+      channel: 2024.1/beta
+    barbican-k8s:
+      channel: 2024.1/beta
+    ceilometer-k8s:
+      channel: 2024.1/beta
+    cinder-ceph-k8s:
+      channel: 2024.1/beta
+    cinder-k8s:
+      channel: 2024.1/beta
+    designate-bind-k8s:
+      channel: 9/beta
+    designate-k8s:
+      channel: 2024.1/beta
+    glance-k8s:
+      channel: 2024.1/beta
+    gnocchi-k8s:
+      channel: 2024.1/beta
+    heat-k8s:
+      channel: 2024.1/beta
+    horizon-k8s:
+      channel: 2024.1/beta
+    keystone-k8s:
+      channel: 2024.1/beta
+    keystone-ldap-k8s:
+      channel: 2024.1/beta
+    magnum-k8s:
+      channel: 2024.1/beta
+    neutron-k8s:
+      channel: 2024.1/beta
+    nova-k8s:
+      channel: 2024.1/beta
+    octavia-k8s:
+      channel: 2024.1/beta
+    openstack-exporter-k8s:
+      channel: 2024.1/beta
+    openstack-hypervisor:
+      channel: 2024.1/beta
+      config:
+        snap-channel: 2024.1/beta
+    openstack-images-sync-k8s:
+      channel: 2024.1/beta
+    ovn-central-k8s:
+      channel: 24.03/beta
+    ovn-relay-k8s:
+      channel: 24.03/beta
+    placement-k8s:
+      channel: 2024.1/beta
+    sunbeam-clusterd:
+      channel: 2024.1/beta
+      config:
+        snap-channel: 2024.1/beta
+    sunbeam-machine:
+      channel: 2024.1/beta
+    tempest-k8s:
+      channel: 2024.1/beta
+    microceph:
+      channel: reef/beta
+      config:
+        snap-channel: reef/beta

--- a/manifests/candidate.yml
+++ b/manifests/candidate.yml
@@ -58,3 +58,5 @@ software:
       channel: 2024.1/candidate
     microceph:
       channel: reef/candidate
+      config:
+        snap-channel: reef/candidate

--- a/manifests/edge.yml
+++ b/manifests/edge.yml
@@ -58,3 +58,5 @@ software:
       channel: 2024.1/edge
     microceph:
       channel: reef/edge
+      config:
+        snap-channel: reef/edge

--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -444,8 +444,7 @@ def infer_risk(snap: Snap) -> RiskLevel:
             return RiskLevel.CANDIDATE
         # Beta and edge are considered the same for now
         case "beta":
-            LOG.debug("Beta channel detected, using edge instead.")
-            return RiskLevel.EDGE
+            return RiskLevel.BETA
         case "edge":
             return RiskLevel.EDGE
         case _:


### PR DESCRIPTION
Add manifest for use with beta channels of artefacts.

Update existing manifests to select microceph version aligned to risk levels.