### PR TITLE
Wait until active for applications

### DIFF
--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_ldap.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_ldap.py
@@ -97,9 +97,6 @@ class TestAddLDAPDomainStep:
             }
         )
         step.tfhelper.apply.assert_called_once_with()
-        self.jhelper.wait_until_active.assert_called_once_with(
-            "openstack", ["keystone", "keystone-ldap-dom1"], timeout=900
-        )
         assert result.result_type == ResultType.COMPLETED
 
     def test_enable_second_domain(self, read_config, update_config, snap):
@@ -117,9 +114,6 @@ class TestAddLDAPDomainStep:
             }
         )
         step.tfhelper.apply.assert_called_once_with()
-        self.jhelper.wait_until_active.assert_called_once_with(
-            "openstack", ["keystone", "keystone-ldap-dom2"], timeout=900
-        )
         assert result.result_type == ResultType.COMPLETED
 
     def test_enable_tf_apply_failed(self, read_config, update_config, snap):
@@ -142,9 +136,6 @@ class TestAddLDAPDomainStep:
             }
         )
         step.tfhelper.apply.assert_called_once_with()
-        self.jhelper.wait_until_active.assert_called_once_with(
-            "openstack", ["keystone", "keystone-ldap-dom1"], timeout=900
-        )
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
 
@@ -231,9 +222,6 @@ class TestUpdateLDAPDomainStep:
             }
         )
         step.tfhelper.apply.assert_called_once_with()
-        self.jhelper.wait_until_active.assert_called_once_with(
-            "openstack", ["keystone", "keystone-ldap-dom1"], timeout=900
-        )
         assert result.result_type == ResultType.COMPLETED
 
     def test_update_wrong_domain(self, read_config, update_config, snap):


### PR DESCRIPTION
This change the way we wait for active (mostly used on the openstack model). Only wait for each individual app to be active once, then stop checking. When an application is active, the waiting co-routine will notify its caller that the application is ready.

While waiting for applications, display number of app ready / app total, instead of unit ready / units total.
