### PR TITLE
Migrate lint

### DIFF
--- a/sunbeam-python/pyproject.toml
+++ b/sunbeam-python/pyproject.toml
@@ -1,0 +1,100 @@
+# Copyright (c) 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+log_cli_level = "INFO"
+
+[tool.ruff]
+exclude = [
+    '*egg',
+    '*lib/python*',
+    'releasenotes',
+    'tools',
+    'build',
+    '*.egg_info',
+    'dist',
+    '__pycache__',
+    'venv',
+    '.venv',
+    '.tox',
+    'doc',
+    '.git',
+]
+output-format = "full"
+line-length = 88
+target-version = "py310"
+
+[tool.ruff.lint]
+preview = true # to enable CPY
+select = [
+    "E", # pycodestyle
+    "W", # pycodestyle
+    "F", # pyflakes
+    "C", # convention
+    "N", # pep8-naming
+    "D", # pydocstyle
+    "S", # bandit
+    "I", # isort
+    "CPY", # flake8-copyright
+]
+ignore = [
+    "F821",
+    "S105", # hardcoded password checks - likely to generate false positives
+    "S107", # same as above
+    "S401", # import subprocess - not necessarily a security issue; this plugin is mainly used for penetration testing workflow
+    "S404", # import subprocess - same as above
+    "S603", # process without shell - not necessarily a security issue; this plugin is mainly used for penetration testing workflow
+    "S606", # same as above
+    "S605", # process with a shell - possible security issue; this should be investigated by the project for possible exploitation
+    "S607", #start process with a partial path - this should be a project level decision
+]
+extend-ignore = ["E203"]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/*" = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D107",
+    "D415",
+    "E501",
+    "N802",
+    "N803",
+    "N806",
+    "S",    # Disable bandit rules in tests
+]
+"setup.py" = ["D100"]
+"**/__init__.py" = ["D104"]
+
+"sunbeam/*" = [
+    "D107", # missing docstring in __init__ method
+    "D101", # Missing docstring in public class
+    "D103", # Missing docstring in public function
+    "D100", # Missing docstring in public module
+    "N818", # Exception should be named with an Error suffix
+]
+
+[tool.ruff.lint.pycodestyle]
+max-line-length = 88
+max-doc-length = 88
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-copyright]
+author = "Canonical Ltd."
+# don't enforce on empty files
+min-file-size = 1
+
+[tool.ruff.lint.mccabe]
+max-complexity = 15

--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -126,7 +126,7 @@ class ExtendedAPIService(service.BaseService):
         return nodes.get("metadata")
 
     def get_node_info(self, name: str) -> dict:
-        """Fetch Node Information from a name"""
+        """Fetch Node Information from a name."""
         return self._get(f"1.0/nodes/{name}").get("metadata")
 
     def remove_node_info(self, name: str) -> None:
@@ -242,17 +242,24 @@ class ClusterService(MicroClusterService, ExtendedAPIService):
     def bootstrap(
         self, name: str, address: str, role: List[str], machineid: int = -1
     ) -> None:
+        """Bootstrap cluster and register node information."""
         self.bootstrap_cluster(name, address)
         self.add_node_info(name, role, machineid)
 
     def add_node(self, name: str) -> str:
+        """Request token for additional node."""
         return self.generate_token(name)
 
     def join_node(self, name: str, address: str, token: str, role: List[str]) -> None:
+        """Join node to cluster and register node information."""
         self.join(name, address, token)
         self.add_node_info(name, role)
 
     def remove_node(self, name) -> None:
+        """Remove node from cluster and database.
+
+        If node is not part of cluster, remove its potential token.
+        """
         members = self.get_cluster_members()
         member_names = [member.get("name") for member in members]
 
@@ -274,7 +281,7 @@ class ClusterService(MicroClusterService, ExtendedAPIService):
         self.update_config(self.SUNBEAM_BOOTSTRAP_KEY, json.dumps("True"))
 
     def check_sunbeam_bootstrapped(self) -> bool:
-        """Check if the sunbeam deployment has been bootstrapped"""
+        """Check if the sunbeam deployment has been bootstrapped."""
         try:
             state = json.loads(self.get_config(self.SUNBEAM_BOOTSTRAP_KEY))
         except service.ConfigItemNotFoundException:

--- a/sunbeam-python/sunbeam/clusterd/service.py
+++ b/sunbeam-python/sunbeam/clusterd/service.py
@@ -23,73 +23,73 @@ LOG = logging.getLogger(__name__)
 
 
 class RemoteException(Exception):
-    """An Exception raised when interacting with the remote microclusterd service"""
+    """An Exception raised when interacting with the remote microclusterd service."""
 
     pass
 
 
 class ClusterAlreadyBootstrappedException(RemoteException):
-    """Raised when cluster service is already bootstrapped"""
+    """Raised when cluster service is already bootstrapped."""
 
     pass
 
 
 class ClusterServiceUnavailableException(RemoteException):
-    """Raised when cluster service is not yet bootstrapped"""
+    """Raised when cluster service is not yet bootstrapped."""
 
     pass
 
 
 class ConfigItemNotFoundException(RemoteException):
-    """Raise when ConfigItem cannot be found on the remote"""
+    """Raise when ConfigItem cannot be found on the remote."""
 
     pass
 
 
 class ManifestItemNotFoundException(RemoteException):
-    """Raise when ManifestItem cannot be found on the remote"""
+    """Raise when ManifestItem cannot be found on the remote."""
 
     pass
 
 
 class NodeAlreadyExistsException(RemoteException):
-    """Raised when the node already exists"""
+    """Raised when the node already exists."""
 
     pass
 
 
 class NodeNotExistInClusterException(RemoteException):
-    """Raised when the node does not exist in cluster"""
+    """Raised when the node does not exist in cluster."""
 
     pass
 
 
 class NodeJoinException(RemoteException):
-    """Raised when the node not able to join cluster"""
+    """Raised when the node not able to join cluster."""
 
     pass
 
 
 class LastNodeRemovalFromClusterException(RemoteException):
-    """Raised when token is already generated for the node"""
+    """Raised when token is already generated for the node."""
 
     pass
 
 
 class TokenAlreadyGeneratedException(RemoteException):
-    """Raised when token is already generated for the node"""
+    """Raised when token is already generated for the node."""
 
     pass
 
 
 class TokenNotFoundException(RemoteException):
-    """Raised when token is not found for the node"""
+    """Raised when token is not found for the node."""
 
     pass
 
 
 class JujuUserNotFoundException(RemoteException):
-    """Raise when jujuuser is not found"""
+    """Raise when jujuuser is not found."""
 
     pass
 
@@ -98,7 +98,7 @@ class BaseService(ABC):
     """BaseService is the base service class for sunbeam clusterd services."""
 
     def __init__(self, session: Session, endpoint: str):
-        """Creates a new BaseService for the sunbeam clusterd API
+        """Creates a new BaseService for the sunbeam clusterd API.
 
         The service class is used to provide convenient APIs for clients to
         use when interacting with the sunbeam clusterd api.
@@ -110,7 +110,7 @@ class BaseService(ABC):
         self.__session = session
         self._endpoint = endpoint
 
-    def _request(self, method, path, **kwargs):
+    def _request(self, method, path, **kwargs):  # noqa: C901 too complex
         if path.startswith("/"):
             path = path[1:]
         netloc = self._endpoint

--- a/sunbeam-python/sunbeam/commands/bootstrap_state.py
+++ b/sunbeam-python/sunbeam/commands/bootstrap_state.py
@@ -31,6 +31,7 @@ class SetBootstrapped(BaseStep):
         self.client = client
 
     def run(self, status: Optional[Status] = None) -> Result:
+        """Set deployment as bootstrapped in clusterd."""
         LOG.debug("Setting deployment as bootstrapped")
         self.client.cluster.set_sunbeam_bootstrapped()
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -101,7 +101,7 @@ class ClusterInitStep(BaseStep):
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Bootstrap sunbeam cluster"""
+        """Bootstrap sunbeam cluster."""
         try:
             ip = utils.get_local_ip_by_cidr(self.management_cidr)
         except ValueError as e:
@@ -167,9 +167,9 @@ class AskManagementCidrStep(BaseStep):
             accept_defaults=self.accept_defaults,
         )
 
-        self.variables["bootstrap"][
-            "management_cidr"
-        ] = bootstrap_bank.management_cidr.ask()
+        self.variables["bootstrap"]["management_cidr"] = (
+            bootstrap_bank.management_cidr.ask()
+        )
 
     def has_prompts(self) -> bool:
         """Returns true if the step has prompts that it can ask the user.
@@ -264,7 +264,7 @@ class ClusterAddNodeStep(BaseStep):
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Add node to sunbeam cluster"""
+        """Add node to sunbeam cluster."""
         try:
             token = self.client.cluster.add_node(name=self.node_name)
             LOG.info(token)
@@ -315,7 +315,7 @@ class ClusterJoinNodeStep(BaseStep):
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Join node to sunbeam cluster"""
+        """Join node to sunbeam cluster."""
         try:
             self.client.cluster.join_node(
                 name=self.fqdn,
@@ -338,7 +338,7 @@ class ClusterListNodeStep(BaseStep):
         self.client = client
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """List nodes in the sunbeam cluster"""
+        """List nodes in the sunbeam cluster."""
         try:
             members = self.client.cluster.get_cluster_members()
             LOG.debug(f"Members: {members}")
@@ -375,7 +375,7 @@ class ClusterUpdateNodeStep(BaseStep):
         self.machine_id = machine_id
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Update Node info"""
+        """Update Node info."""
         try:
             self.client.cluster.update_node_info(self.name, self.role, self.machine_id)
             return Result(result_type=ResultType.COMPLETED)
@@ -395,7 +395,7 @@ class ClusterRemoveNodeStep(BaseStep):
         self.client = client
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Remove node from sunbeam cluster"""
+        """Remove node from sunbeam cluster."""
         try:
             self.client.cluster.remove_node(self.node_name)
             return Result(result_type=ResultType.COMPLETED)
@@ -442,7 +442,7 @@ class ClusterAddJujuUserStep(BaseStep):
         return Result(ResultType.SKIPPED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Add node to sunbeam cluster"""
+        """Add node to sunbeam cluster."""
         try:
             self.client.cluster.add_juju_user(self.username, self.token)
             return Result(result_type=ResultType.COMPLETED)
@@ -464,7 +464,7 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
         self.controller = controller
 
     def _extract_ip(self, ip) -> Union[ipaddress.IPv4Address, ipaddress.IPv6Address]:
-        """Extract ip from ipv4 or ipv6 ip:port"""
+        """Extract ip from ipv4 or ipv6 ip:port."""
         # Check for ipv6 addr
         ipv6_addr = re.match(r"\[(.*?)\]", ip)
         if ipv6_addr:
@@ -474,7 +474,7 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
         return ipaddress.ip_address(ip_str)
 
     def filter_ips(self, ips: List[str], network_str: Optional[str]) -> List[str]:
-        """Filter ips missing from specified networks
+        """Filter ips missing from specified networks.
 
         :param ips: list of ips to filter
         :param network_str: network to filter ips from, separated by comma

--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -236,7 +236,7 @@ def retrieve_admin_credentials(jhelper: JujuHelper, model: str) -> dict:
 
 
 class SetHypervisorCharmConfigStep(BaseStep):
-    """Update openstack-hypervisor charm config"""
+    """Update openstack-hypervisor charm config."""
 
     IPVANYNETWORK_UNSET = "0.0.0.0/0"
 
@@ -257,6 +257,7 @@ class SetHypervisorCharmConfigStep(BaseStep):
         self.charm_config = {}
 
     def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user."""
         return False
 
     def run(self, status: Optional["Status"] = None) -> Result:
@@ -343,6 +344,7 @@ class UserOpenRCStep(BaseStep):
             return Result(ResultType.SKIPPED)
 
     def run(self, status: Optional["Status"] = None) -> Result:
+        """Fetch openrc from terraform state."""
         try:
             tf_output = self.tfhelper.output(hide_output=True)
             # Mask any passwords before printing process.stdout
@@ -353,7 +355,7 @@ class UserOpenRCStep(BaseStep):
             return Result(ResultType.FAILED, str(e))
 
     def _print_openrc(self, tf_output: dict) -> None:
-        """Print openrc to console and save to disk using provided information"""
+        """Print openrc to console and save to disk using provided information."""
         _openrc = f"""# openrc for {tf_output["OS_USERNAME"]}
 export OS_AUTH_URL={self.auth_url}
 export OS_USERNAME={tf_output["OS_USERNAME"]}
@@ -395,6 +397,7 @@ class UserQuestions(BaseStep):
         self.answer_file = answer_file
 
     def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user."""
         return True
 
     def prompt(self, console: Optional[Console] = None) -> None:
@@ -419,9 +422,9 @@ class UserQuestions(BaseStep):
             previous_answers=self.variables.get("user"),
             accept_defaults=self.accept_defaults,
         )
-        self.variables["user"][
-            "remote_access_location"
-        ] = user_bank.remote_access_location.ask()
+        self.variables["user"]["remote_access_location"] = (
+            user_bank.remote_access_location.ask()
+        )
         # External Network Configuration
         if self.variables["user"]["remote_access_location"] == utils.LOCAL_ACCESS:
             ext_net_bank = sunbeam.jobs.questions.QuestionBank(
@@ -471,13 +474,13 @@ class UserQuestions(BaseStep):
             "external_network"
         ]["physical_network"]
 
-        self.variables["external_network"][
-            "network_type"
-        ] = ext_net_bank.network_type.ask()
+        self.variables["external_network"]["network_type"] = (
+            ext_net_bank.network_type.ask()
+        )
         if self.variables["external_network"]["network_type"] == "vlan":
-            self.variables["external_network"][
-                "segmentation_id"
-            ] = ext_net_bank.segmentation_id.ask()
+            self.variables["external_network"]["segmentation_id"] = (
+                ext_net_bank.segmentation_id.ask()
+            )
         else:
             self.variables["external_network"]["segmentation_id"] = 0
 
@@ -487,18 +490,19 @@ class UserQuestions(BaseStep):
             self.variables["user"]["username"] = user_bank.username.ask()
             self.variables["user"]["password"] = user_bank.password.ask()
             self.variables["user"]["cidr"] = user_bank.cidr.ask()
-            self.variables["user"][
-                "dns_nameservers"
-            ] = user_bank.nameservers.ask().split()
-            self.variables["user"][
-                "security_group_rules"
-            ] = user_bank.security_group_rules.ask()
+            self.variables["user"]["dns_nameservers"] = (
+                user_bank.nameservers.ask().split()
+            )
+            self.variables["user"]["security_group_rules"] = (
+                user_bank.security_group_rules.ask()
+            )
 
         sunbeam.jobs.questions.write_answers(
             self.client, CLOUD_CONFIG_SECTION, self.variables
         )
 
     def run(self, status: Optional[Status] = None) -> Result:
+        """Run the step to completion."""
         return Result(ResultType.COMPLETED)
 
 
@@ -594,6 +598,7 @@ class SetHypervisorUnitsOptionsStep(BaseStep):
         self.nics: dict[str, str | None] = {}
 
     def run(self, status: Optional[Status] = None) -> Result:
+        """Apply individual hypervisor settings."""
         app = "openstack-hypervisor"
         action_cmd = "set-hypervisor-local-settings"
         for name in self.names:

--- a/sunbeam-python/sunbeam/commands/generate_cloud_config.py
+++ b/sunbeam-python/sunbeam/commands/generate_cloud_config.py
@@ -98,6 +98,7 @@ class GenerateCloudConfigStep(BaseStep):
             return Result(ResultType.SKIPPED)
 
     def run(self, status: Optional["Status"] = None) -> Result:
+        """Generate cloud-config yaml for cloud access."""
         try:
             if self.is_admin:
                 # pass emptydictionary for tf_output

--- a/sunbeam-python/sunbeam/commands/hypervisor.py
+++ b/sunbeam-python/sunbeam/commands/hypervisor.py
@@ -50,7 +50,7 @@ HYPERVISOR_UNIT_TIMEOUT = (
 
 
 class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
-    """Deploy openstack-hyervisor application using Terraform cloud"""
+    """Deploy openstack-hyervisor application using Terraform cloud."""
 
     _CONFIG = CONFIG_KEY
 
@@ -80,6 +80,7 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
         self.openstack_model = OPENSTACK_MODEL
 
     def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
         openstack_backend_config = self.openstack_tfhelper.backend_config()
         return {
             "openstack_model": self.openstack_model,
@@ -131,6 +132,7 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
         }
 
     def get_application_timeout(self) -> int:
+        """Return application timeout in seconds."""
         return HYPERVISOR_APP_TIMEOUT
 
 
@@ -162,6 +164,7 @@ class AddHypervisorUnitsStep(AddMachineUnitsStep):
         return {"agent": ["idle"], "workload": workload_statuses}
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return HYPERVISOR_UNIT_TIMEOUT
 
 
@@ -278,7 +281,7 @@ class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
 
 
 class ReapplyHypervisorTerraformPlanStep(BaseStep):
-    """Reapply openstack-hyervisor terraform plan"""
+    """Reapply openstack-hyervisor terraform plan."""
 
     _CONFIG = CONFIG_KEY
 
@@ -314,7 +317,7 @@ class ReapplyHypervisorTerraformPlanStep(BaseStep):
         return Result(ResultType.SKIPPED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to deploy hypervisor"""
+        """Apply terraform configuration to deploy hypervisor."""
         statuses = ["active", "unknown"]
         if len(self.client.cluster.list_nodes_by_role("storage")) < 1:
             LOG.debug("No storage nodes found, allowing hypervisor waiting status")

--- a/sunbeam-python/sunbeam/commands/inspect.py
+++ b/sunbeam-python/sunbeam/commands/inspect.py
@@ -85,9 +85,10 @@ def inspect(ctx: click.Context) -> None:
             if log_dir.exists():
                 shutil.copytree(log_dir, Path(tmpdirname) / "logs")
 
-        with console.status("[bold green]Creating tarball..."), tarfile.open(
-            dump_file, "w:gz"
-        ) as tar:
+        with (
+            console.status("[bold green]Creating tarball..."),
+            tarfile.open(dump_file, "w:gz") as tar,
+        ):
             tar.add(tmpdirname, arcname="./")
 
     console.print(f"[green]Output file written to {dump_file}[/green]")

--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -67,7 +67,7 @@ class JujuStepHelper:
         return str(juju_binary)
 
     def _juju_cmd(self, *args):
-        """Runs the specified juju command line command
+        """Runs the specified juju command line command.
 
         The command will be run using the json formatter. Invoking functions
         do not need to worry about the format or the juju command that should
@@ -107,7 +107,7 @@ class JujuStepHelper:
             return False
 
     def get_clouds(self, cloud_type: str, local: bool = False) -> list:
-        """Get clouds based on cloud type"""
+        """Get clouds based on cloud type."""
         clouds = []
         cmd = ["clouds"]
         if local:
@@ -135,7 +135,7 @@ class JujuStepHelper:
         return self._juju_cmd(*cmd)
 
     def get_controllers(self, clouds: list) -> list:
-        """Get controllers hosted on given clouds"""
+        """Get controllers hosted on given clouds."""
         existing_controllers = []
 
         controllers = self._juju_cmd("controllers")
@@ -535,7 +535,6 @@ class ScaleJujuStep(BaseStep, JujuStepHelper):
 
     def is_skip(self, status: Status | None = None) -> Result:
         """Determines if the step should be skipped or not."""
-
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Status | None = None) -> Result:
@@ -1055,7 +1054,7 @@ class RemoveJujuMachineStep(BaseStep, JujuStepHelper):
 
 
 class BackupBootstrapUserStep(BaseStep, JujuStepHelper):
-    """Backup bootstrap user credentials"""
+    """Backup bootstrap user credentials."""
 
     def __init__(self, name: str, data_location: Path):
         super().__init__("Backup Bootstrap User", "Saving bootstrap user credentials")
@@ -1132,7 +1131,6 @@ class SaveJujuUserLocallyStep(BaseStep):
 
         :return:
         """
-
         password = pwgen.pwgen(12)
 
         juju_account = JujuAccount(
@@ -1262,7 +1260,7 @@ class WriteCharmLogStep(BaseStep, JujuStepHelper):
 
 
 class JujuLoginStep(BaseStep, JujuStepHelper):
-    """Login to Juju Controller"""
+    """Login to Juju Controller."""
 
     def __init__(self, juju_account: JujuAccount | None):
         super().__init__(
@@ -1369,7 +1367,7 @@ class AddInfrastructureModelStep(BaseStep):
 
 
 class UpdateJujuModelConfigStep(BaseStep):
-    """Update Model Config for the given models"""
+    """Update Model Config for the given models."""
 
     def __init__(self, jhelper: JujuHelper, model: str, model_configs: dict):
         super().__init__("Update Model Config", f"Updating model config for {model}")
@@ -1394,7 +1392,7 @@ class UpdateJujuModelConfigStep(BaseStep):
 
 
 class DownloadJujuControllerCharmStep(BaseStep, JujuStepHelper):
-    """Download Juju Controller Charm"""
+    """Download Juju Controller Charm."""
 
     def __init__(self, proxy_settings: dict | None = None):
         super().__init__(

--- a/sunbeam-python/sunbeam/commands/k8s.py
+++ b/sunbeam-python/sunbeam/commands/k8s.py
@@ -95,7 +95,7 @@ def k8s_addons_questions():
 
 
 class DeployK8SApplicationStep(DeployMachineApplicationStep):
-    """Deploy K8S application using Terraform"""
+    """Deploy K8S application using Terraform."""
 
     _ADDONS_CONFIG = K8S_ADDONS_CONFIG_KEY
 
@@ -146,9 +146,9 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
             previous_answers=self.variables.get("k8s-addons", {}),
             accept_defaults=self.accept_defaults,
         )
-        self.variables["k8s-addons"][
-            "loadbalancer"
-        ] = k8s_addons_bank.loadbalancer.ask()
+        self.variables["k8s-addons"]["loadbalancer"] = (
+            k8s_addons_bank.loadbalancer.ask()
+        )
 
         LOG.debug(self.variables)
         write_answers(self.client, self._ADDONS_CONFIG, self.variables)
@@ -166,9 +166,11 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
         return True
 
     def get_application_timeout(self) -> int:
+        """Return application timeout."""
         return K8S_APP_TIMEOUT
 
     def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
         return {
             "endpoint_bindings": [
                 {"space": self.deployment.get_space(Networks.MANAGEMENT)},
@@ -198,6 +200,7 @@ class AddK8SUnitsStep(AddMachineUnitsStep):
         )
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return K8S_UNIT_TIMEOUT
 
 
@@ -223,11 +226,12 @@ class RemoveK8SUnitStep(RemoveMachineUnitStep):
         )
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return K8S_UNIT_TIMEOUT
 
 
 class EnableK8SFeatures(BaseStep):
-    """Enable K8S Features"""
+    """Enable K8S Features."""
 
     _ADDONS_CONFIG = K8S_ADDONS_CONFIG_KEY
 
@@ -355,7 +359,6 @@ class EnableK8SFeatures(BaseStep):
 
 
 class AddK8SCloudStep(BaseStep, JujuStepHelper):
-
     _KUBECONFIG = K8S_KUBECONFIG_KEY
 
     def __init__(self, client: Client, jhelper: JujuHelper):
@@ -450,6 +453,7 @@ class K8SHelper:
 
     @classmethod
     def get_provider(cls) -> str:
+        """Return k8s provider from snap settings."""
         provider = Snap().config.get("k8s.provider")
         if provider not in SUPPORTED_K8S_PROVIDERS:
             raise click.ClickException(
@@ -460,6 +464,7 @@ class K8SHelper:
 
     @classmethod
     def get_cloud(cls) -> str:
+        """Return cloud name matching provider."""
         match cls.get_provider():
             case "k8s":
                 return K8S_CLOUD
@@ -468,6 +473,7 @@ class K8SHelper:
 
     @classmethod
     def get_default_storageclass(cls) -> str:
+        """Return storageclass matching provider."""
         match cls.get_provider():
             case "k8s":
                 return K8S_DEFAULT_STORAGECLASS
@@ -476,6 +482,7 @@ class K8SHelper:
 
     @classmethod
     def get_kubeconfig_key(cls) -> str:
+        """Return kubeconfig key matching provider."""
         match cls.get_provider():
             case "k8s":
                 return K8S_KUBECONFIG_KEY
@@ -484,6 +491,7 @@ class K8SHelper:
 
     @classmethod
     def get_loadbalancer_annotation(cls) -> str:
+        """Return loadbalancer annotation matching provider."""
         match cls.get_provider():
             case "k8s":
                 return SERVICE_LB_ANNOTATION

--- a/sunbeam-python/sunbeam/commands/launch.py
+++ b/sunbeam-python/sunbeam/commands/launch.py
@@ -56,7 +56,7 @@ def launch(
     key: str,
     name: Optional[str] = None,
 ) -> None:
-    """Launch an OpenStack instance on demo setup"""
+    """Launch an OpenStack instance on demo setup."""
     snap = Snap()
     data_location = snap.paths.user_data
     deployment: Deployment = ctx.obj

--- a/sunbeam-python/sunbeam/commands/manifest.py
+++ b/sunbeam-python/sunbeam/commands/manifest.py
@@ -80,7 +80,7 @@ def generate_software_manifest(manifest: Manifest) -> str:
 )
 @click.pass_context
 def list(ctx: click.Context, format: str) -> None:
-    """List manifests"""
+    """List manifests."""
     deployment: Deployment = ctx.obj
     client = deployment.get_client()
     manifests = []

--- a/sunbeam-python/sunbeam/commands/microceph.py
+++ b/sunbeam-python/sunbeam/commands/microceph.py
@@ -80,7 +80,7 @@ def ceph_replica_scale(storage_nodes: int) -> int:
 
 
 class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
-    """Deploy Microceph application using Terraform"""
+    """Deploy Microceph application using Terraform."""
 
     def __init__(
         self,
@@ -107,9 +107,11 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
         )
 
     def get_application_timeout(self) -> int:
+        """Return application timeout in seconds."""
         return MICROCEPH_APP_TIMEOUT
 
     def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
         storage_nodes = self.client.cluster.list_nodes_by_role("storage")
         tfvars: dict[str, Any] = {
             "endpoint_bindings": [
@@ -183,6 +185,7 @@ class AddMicrocephUnitsStep(AddMachineUnitsStep):
         )
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return MICROCEPH_UNIT_TIMEOUT
 
 
@@ -202,11 +205,12 @@ class RemoveMicrocephUnitStep(RemoveMachineUnitStep):
         )
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return MICROCEPH_UNIT_TIMEOUT
 
 
 class ConfigureMicrocephOSDStep(BaseStep):
-    """Configure Microceph OSD disks"""
+    """Configure Microceph OSD disks."""
 
     _CONFIG = CONFIG_DISKS_KEY
 
@@ -233,6 +237,7 @@ class ConfigureMicrocephOSDStep(BaseStep):
         self.osd_disks = []
 
     def microceph_config_questions(self):
+        """Return questions for configuring microceph."""
         disks_str = None
         if len(self.unpartitioned_disks) > 0:
             disks_str = ",".join(self.unpartitioned_disks)
@@ -243,6 +248,7 @@ class ConfigureMicrocephOSDStep(BaseStep):
         return questions
 
     def get_all_disks(self) -> None:
+        """Get all disks from microceph unit."""
         try:
             node = self.client.cluster.get_node_info(self.node_name)
             self.machine_id = str(node.get("machineid"))
@@ -293,9 +299,9 @@ class ConfigureMicrocephOSDStep(BaseStep):
         )
         if isinstance(osd_devices, list):
             osd_devices_str = ",".join(osd_devices)
-            self.preseed["microceph_config"][self.node_name][
-                "osd_devices"
-            ] = osd_devices_str
+            self.preseed["microceph_config"][self.node_name]["osd_devices"] = (
+                osd_devices_str
+            )
 
         microceph_config_bank = questions.QuestionBank(
             questions=self.microceph_config_questions(),
@@ -393,7 +399,7 @@ class ConfigureMicrocephOSDStep(BaseStep):
 
 
 class SetCephMgrPoolSizeStep(BaseStep):
-    """Configure Microceph pool size for mgr"""
+    """Configure Microceph pool size for mgr."""
 
     def __init__(self, client: Client, jhelper: JujuHelper, model: str):
         super().__init__(

--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -86,7 +86,7 @@ def microk8s_addons_questions():
 
 
 class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
-    """Deploy Microk8s application using Terraform"""
+    """Deploy Microk8s application using Terraform."""
 
     _ADDONS_CONFIG = MICROK8S_ADDONS_CONFIG_KEY
 
@@ -121,6 +121,7 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
         self.variables = {}
 
     def get_application_timeout(self) -> int:
+        """Return application timeout in seconds."""
         return MICROK8S_APP_TIMEOUT
 
     def prompt(self, console: Optional[Console] = None) -> None:
@@ -165,6 +166,7 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
         return True
 
     def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
         return {
             "endpoint_bindings": [
                 {"space": self.deployment.get_space(Networks.MANAGEMENT)},
@@ -194,6 +196,7 @@ class AddMicrok8sUnitsStep(AddMachineUnitsStep):
         )
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return MICROK8S_UNIT_TIMEOUT
 
 
@@ -213,6 +216,7 @@ class RemoveMicrok8sUnitStep(RemoveMachineUnitStep):
         )
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return MICROK8S_UNIT_TIMEOUT
 
 

--- a/sunbeam-python/sunbeam/commands/mysql.py
+++ b/sunbeam-python/sunbeam/commands/mysql.py
@@ -58,7 +58,6 @@ class ConfigureMySQLStep(BaseStep):
         :return: ResultType.SKIPPED if the Step should be skipped,
                 ResultType.COMPLETED or ResultType.FAILED otherwise
         """
-
         try:
             run_sync(self.jhelper.get_model(OPENSTACK_MODEL))
         except ModelNotFoundException:
@@ -76,7 +75,6 @@ class ConfigureMySQLStep(BaseStep):
 
         :return: ResultType.COMPLETED or ResultType.FAILED
         """
-
         try:
             mysqls = get_mysqls(self.jhelper)
         except JujuException as e:

--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -67,7 +67,7 @@ def determine_target_topology(client: Client) -> str:
     """
     control_nodes = client.cluster.list_nodes_by_role("control")
     compute_nodes = client.cluster.list_nodes_by_role("compute")
-    combined = set(node["name"] for node in control_nodes + compute_nodes)
+    combined = {node["name"] for node in control_nodes + compute_nodes}
     host_total_ram = get_host_total_ram()
     if len(combined) == 1 and host_total_ram < RAM_32_GB_IN_KB:
         topology = "single"
@@ -102,7 +102,7 @@ def compute_ingress_scale(topology: str, control_nodes: int) -> int:
 
 
 class DeployControlPlaneStep(BaseStep, JujuStepHelper):
-    """Deploy OpenStack using Terraform cloud"""
+    """Deploy OpenStack using Terraform cloud."""
 
     _CONFIG = CONFIG_KEY
 
@@ -324,7 +324,7 @@ class PatchLoadBalancerServicesStep(BaseStep):
 
 
 class ReapplyOpenStackTerraformPlanStep(BaseStep, JujuStepHelper):
-    """Reapply OpenStack Terraform plan"""
+    """Reapply OpenStack Terraform plan."""
 
     _CONFIG = CONFIG_KEY
 
@@ -384,7 +384,7 @@ class ReapplyOpenStackTerraformPlanStep(BaseStep, JujuStepHelper):
 
 
 class UpdateOpenStackModelConfigStep(BaseStep):
-    """Update OpenStack ModelConfig via Terraform plan"""
+    """Update OpenStack ModelConfig via Terraform plan."""
 
     _CONFIG = CONFIG_KEY
 

--- a/sunbeam-python/sunbeam/commands/proxy.py
+++ b/sunbeam-python/sunbeam/commands/proxy.py
@@ -137,7 +137,7 @@ def _update_proxy(proxy: dict, deployment: Deployment):
 )
 @click.pass_context
 def show(ctx: click.Context, format: str) -> None:
-    """Show proxy configuration"""
+    """Show proxy configuration."""
     deployment: Deployment = ctx.obj
     _preflight_checks(deployment)
 
@@ -161,7 +161,7 @@ def show(ctx: click.Context, format: str) -> None:
 @click.option("--http-proxy", type=str, prompt=True, help="HTTP_PROXY configuration")
 @click.pass_context
 def set(ctx: click.Context, http_proxy: str, https_proxy: str, no_proxy: str) -> None:
-    """Update proxy configuration"""
+    """Update proxy configuration."""
     deployment: Deployment = ctx.obj
 
     if not (http_proxy and https_proxy and no_proxy):
@@ -185,7 +185,7 @@ def set(ctx: click.Context, http_proxy: str, https_proxy: str, no_proxy: str) ->
 @click.command()
 @click.pass_context
 def clear(ctx: click.Context) -> None:
-    """Clear proxy configuration"""
+    """Clear proxy configuration."""
     deployment: Deployment = ctx.obj
 
     variables = {"proxy": {}}

--- a/sunbeam-python/sunbeam/commands/sunbeam_machine.py
+++ b/sunbeam-python/sunbeam/commands/sunbeam_machine.py
@@ -36,7 +36,7 @@ SUNBEAM_MACHINE_UNIT_TIMEOUT = (
 
 
 class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
-    """Deploy openstack-hyervisor application using Terraform cloud"""
+    """Deploy openstack-hyervisor application using Terraform cloud."""
 
     def __init__(
         self,
@@ -65,9 +65,11 @@ class DeploySunbeamMachineApplicationStep(DeployMachineApplicationStep):
         self.proxy_settings = proxy_settings
 
     def get_application_timeout(self) -> int:
+        """Return application timeout."""
         return SUNBEAM_MACHINE_APP_TIMEOUT
 
     def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
         return {
             "endpoint_bindings": [
                 {"space": self.deployment.get_space(Networks.MANAGEMENT)},
@@ -102,6 +104,7 @@ class AddSunbeamMachineUnitsStep(AddMachineUnitsStep):
         )
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return SUNBEAM_MACHINE_UNIT_TIMEOUT
 
 
@@ -121,4 +124,5 @@ class RemoveSunbeamMachineStep(RemoveMachineUnitStep):
         )
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return SUNBEAM_MACHINE_UNIT_TIMEOUT

--- a/sunbeam-python/sunbeam/commands/terraform.py
+++ b/sunbeam-python/sunbeam/commands/terraform.py
@@ -57,18 +57,19 @@ provider_installation {
 
 
 class TerraformException(Exception):
-    """Terraform related exceptions"""
+    """Terraform related exceptions."""
 
     def __init__(self, message):
         super().__init__()
         self.message = message
 
     def __str__(self) -> str:
+        """Stringify the exception."""
         return self.message
 
 
 class TerraformHelper:
-    """Helper for interaction with Terraform"""
+    """Helper for interaction with Terraform."""
 
     def __init__(
         self,
@@ -91,6 +92,7 @@ class TerraformHelper:
         self.clusterd_address = clusterd_address
 
     def backend_config(self) -> dict:
+        """Get backend configuration for terraform."""
         if self.backend == "http" and self.clusterd_address is not None:
             address = self.clusterd_address
             return {
@@ -105,6 +107,10 @@ class TerraformHelper:
         return {}
 
     def write_backend_tf(self) -> bool:
+        """Write backend configuration to backend.tf file.
+
+        This is injecting clusterd as http backend for the terraform state.
+        """
         backend = self.backend_config()
         if self.backend == "http":
             backend_obj = Template(http_backend_template)
@@ -122,13 +128,13 @@ class TerraformHelper:
         return False
 
     def write_tfvars(self, vars: dict, location: Optional[Path] = None) -> None:
-        """Write terraform variables file"""
+        """Write terraform variables file."""
         filepath = location or (self.path / "terraform.tfvars.json")
         with filepath.open("w") as tfvars:
             tfvars.write(json.dumps(vars))
 
     def write_terraformrc(self) -> None:
-        """Write .terraformrc file"""
+        """Write .terraformrc file."""
         terraform_rc = self.snap.paths.user_data / ".terraformrc"
         with terraform_rc.open(mode="w") as file:
             file.write(
@@ -138,7 +144,7 @@ class TerraformHelper:
             )
 
     def init(self) -> None:
-        """terraform init"""
+        """Terraform init."""
         os_env = os.environ.copy()
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         tf_log = str(self.path / f"terraform-init-{timestamp}.log")
@@ -174,7 +180,7 @@ class TerraformHelper:
             raise TerraformException(str(e))
 
     def apply(self, extra_args: list | None = None):
-        """terraform apply"""
+        """Terraform apply."""
         os_env = os.environ.copy()
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         tf_log = str(self.path / f"terraform-apply-{timestamp}.log")
@@ -208,7 +214,7 @@ class TerraformHelper:
             raise TerraformException(str(e))
 
     def destroy(self):
-        """terraform destroy"""
+        """Terraform destroy."""
         os_env = os.environ.copy()
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         tf_log = str(self.path / f"terraform-destroy-{timestamp}.log")
@@ -239,7 +245,7 @@ class TerraformHelper:
             raise TerraformException(str(e))
 
     def output(self, hide_output: bool = False) -> dict:
-        """terraform output"""
+        """Terraform output."""
         os_env = os.environ.copy()
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         tf_log = str(self.path / f"terraform-output-{timestamp}.log")
@@ -450,7 +456,7 @@ class TerraformInitStep(BaseStep):
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Initialise Terraform configuration from provider mirror,"""
+        """Initialise Terraform configuration from provider mirror,."""
         try:
             self.tfhelper.init()
             return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/commands/upgrades/base.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/base.py
@@ -47,6 +47,7 @@ class UpgradePlugins(BaseStep):
         self.upgrade_release = upgrade_release
 
     def run(self, status: Optional[Status] = None) -> Result:
+        """Upgrade plugins."""
         PluginManager.update_plugins(
             self.deployment, repos=["core"], upgrade_release=self.upgrade_release
         )

--- a/sunbeam-python/sunbeam/commands/upgrades/inter_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/inter_channel.py
@@ -178,6 +178,7 @@ class UpgradeControlPlane(BaseUpgrade):
         self.config = OPENSTACK_CONFIG_KEY
 
     def upgrade_tasks(self, status: Optional[Status] = None) -> Result:
+        """Perform the upgrade tasks."""
         # Step 1: Upgrade mysql charms
         LOG.debug("Upgrading Mysql charms")
         charms = list(MYSQL_CHARMS_K8S.keys())
@@ -263,6 +264,7 @@ class UpgradeMachineCharm(BaseUpgrade):
         self.timeout = timeout
 
     def upgrade_tasks(self, status: Optional[Status] = None) -> Result:
+        """Perform the upgrade tasks."""
         apps = self.get_apps_filter_by_charms(self.model, self.charms)
         result = self.upgrade_applications(
             apps,

--- a/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
@@ -122,6 +122,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
     """Coordinator for refreshing charms in their current channel."""
 
     def get_plan(self) -> list[BaseStep]:
+        """Return the upgrade plan."""
         plan = [
             LatestInChannel(self.jhelper, self.manifest),
             TerraformInitStep(self.deployment.get_tfhelper("openstack-plan")),

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ DEFAULT_CONFIG = {
     "deployment.risk": "stable",
 }
 
-OPTION_KEYS = set(k.split(".")[0] for k in DEFAULT_CONFIG.keys())
+OPTION_KEYS = {k.split(".")[0] for k in DEFAULT_CONFIG.keys()}
 
 
 def _update_default_config(snap: Snap) -> None:

--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -43,7 +43,7 @@ FORMAT_YAML = "yaml"
 FORMAT_DEFAULT = "default"
 FORMAT_VALUE = "value"
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 SHARE_PATH = Path(".local/share/openstack/")
 
 CLICK_OK = "[green]OK[/green]"
@@ -55,7 +55,7 @@ K8S_CLUSTER_POD_CIDR = "10.1.0.0/16"
 
 
 class Role(enum.Enum):
-    """The role that the current node will play
+    """The role that the current node will play.
 
     This determines if the role will be a control plane node, a Compute node,
     or a storage node. The role will help determine which particular services
@@ -114,10 +114,10 @@ class ResultType(enum.Enum):
 
 
 class Result:
-    """The result of running a step"""
+    """The result of running a step."""
 
     def __init__(self, result_type: ResultType, message: Any = ""):
-        """Creates a new result
+        """Creates a new result.
 
         :param result_type:
         :param message:
@@ -170,7 +170,7 @@ class BaseStep:
     """
 
     def __init__(self, name: str, description: str = ""):
-        """Initialise the BaseStep
+        """Initialise the BaseStep.
 
         :param name: the name of the step
         """
@@ -389,15 +389,15 @@ async def update_status_background(
 def str_presenter(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
     """Return multiline string as '|' literal block.
 
-    Ref: https://stackoverflow.com/questions/8640959/how-can-i-control-what-scalar-form-pyyaml-uses-for-my-data # noqa E501
-    """
+    Ref: https://stackoverflow.com/questions/8640959/how-can-i-control-what-scalar-form-pyyaml-uses-for-my-data
+    """  # noqa W505
     if data.count("\n") > 0:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
 def _get_default_no_proxy_settings() -> set:
-    """Return default no proxy settings"""
+    """Return default no proxy settings."""
     return {
         "127.0.0.1",
         "localhost",

--- a/sunbeam-python/sunbeam/jobs/deployment.py
+++ b/sunbeam-python/sunbeam/jobs/deployment.py
@@ -59,7 +59,7 @@ def get_deployment_class(type_: str) -> Type["Deployment"]:
 
 
 class MissingTerraformInfoException(Exception):
-    """An Exception raised when terraform information is missing in manifest"""
+    """An Exception raised when terraform information is missing in manifest."""
 
     pass
 
@@ -110,7 +110,7 @@ class Deployment(pydantic.BaseModel):
         return NotImplemented  # type: ignore
 
     def get_client(self) -> Client:
-        """Return a client instance
+        """Return a client instance.
 
         Raises ValueError when fails to instantiate a client.
         """
@@ -146,6 +146,7 @@ class Deployment(pydantic.BaseModel):
         return plugin_manager
 
     def get_proxy_settings(self) -> dict:
+        """Fetch proxy settings from clusterd, if not available use defaults."""
         proxy = {}
         try:
             # If client does not exist, use detaults
@@ -243,14 +244,14 @@ class Deployment(pydantic.BaseModel):
         env = {}
         if self.juju_controller and self.juju_account:
             env.update(
-                dict(
-                    JUJU_USERNAME=self.juju_account.user,
-                    JUJU_PASSWORD=self.juju_account.password,
-                    JUJU_CONTROLLER_ADDRESSES=",".join(
+                {
+                    "JUJU_USERNAME": self.juju_account.user,
+                    "JUJU_PASSWORD": self.juju_account.password,
+                    "JUJU_CONTROLLER_ADDRESSES": ",".join(
                         self.juju_controller.api_endpoints
                     ),
-                    JUJU_CA_CERT=self.juju_controller.ca_cert,
-                )
+                    "JUJU_CA_CERT": self.juju_controller.ca_cert,
+                }
             )
         env.update(self.get_proxy_settings())
 
@@ -271,6 +272,10 @@ class Deployment(pydantic.BaseModel):
             )
 
     def get_tfhelper(self, tfplan: str) -> TerraformHelper:
+        """Get an instance of TerraformHelper for the given tfplan.
+
+        This method will load every tfhelper on first use.
+        """
         if len(self._tfhelpers) == 0:
             self._load_tfhelpers()
 

--- a/sunbeam-python/sunbeam/jobs/deployments.py
+++ b/sunbeam-python/sunbeam/jobs/deployments.py
@@ -35,7 +35,7 @@ class DeploymentsConfig(pydantic.BaseModel):
     _path: Path | None = pydantic.PrivateAttr(default=None)
 
     @pydantic.validator("deployments", pre=True, each_item=True)
-    def _validate_deployments(cls, deployment: dict | Deployment) -> Deployment:
+    def _validate_deployments(cls, deployment: dict | Deployment) -> Deployment:  # noqa N805
         if isinstance(deployment, Deployment):
             return deployment
         if isinstance(deployment, dict):

--- a/sunbeam-python/sunbeam/jobs/manifest.py
+++ b/sunbeam-python/sunbeam/jobs/manifest.py
@@ -95,6 +95,7 @@ class SoftwareConfig(pydantic.BaseModel):
     def get_default(
         cls, plugin_softwares: dict[str, "SoftwareConfig"] | None = None
     ) -> "SoftwareConfig":
+        """Load default software config."""
         # TODO(gboutry): Remove Snap instanciation
         snap = Snap()
         charms = {
@@ -127,6 +128,7 @@ class SoftwareConfig(pydantic.BaseModel):
         return SoftwareConfig(charms=charms, terraform=terraform, **extra)
 
     def validate_terraform_keys(self, default_software_config: "SoftwareConfig"):
+        """Validate the terraform keys provided are expected."""
         if self.terraform:
             tf_keys = set(self.terraform.keys())
             all_tfplans = default_software_config.terraform.keys()
@@ -136,6 +138,7 @@ class SoftwareConfig(pydantic.BaseModel):
                 )
 
     def validate_charm_keys(self, default_software_config: "SoftwareConfig"):
+        """Validate the charm keys provided are expected."""
         if self.charms:
             charms_keys = set(self.charms.keys())
             all_charms = default_software_config.charms.keys()
@@ -147,7 +150,7 @@ class SoftwareConfig(pydantic.BaseModel):
     def validate_against_default(
         self, default_software_config: "SoftwareConfig"
     ) -> None:
-        """Validate the software config against the default software config"""
+        """Validate the software config against the default software config."""
         self.validate_terraform_keys(default_software_config)
         self.validate_charm_keys(default_software_config)
 
@@ -167,6 +170,7 @@ class SoftwareConfig(pydantic.BaseModel):
 
     @property
     def extra(self) -> dict:
+        """Allow storing extra data."""
         if self.__pydantic_extra__ is None:
             self.__pydantic_extra__ = {}
         return self.__pydantic_extra__
@@ -181,18 +185,18 @@ class Manifest(pydantic.BaseModel):
         cls,
         plugin_softwares: dict[str, SoftwareConfig] | None = None,
     ) -> "Manifest":
-        """Load manifest and override the default manifest"""
+        """Load manifest and override the default manifest."""
         software_config = SoftwareConfig.get_default(plugin_softwares)
         return Manifest(software=software_config)
 
     @classmethod
     def from_file(cls, file: Path) -> "Manifest":
-        """Load manifest from file"""
+        """Load manifest from file."""
         with file.open() as f:
             return Manifest.model_validate(yaml.safe_load(f))
 
     def merge(self, other: "Manifest") -> "Manifest":
-        """Merge the manifest with the provided manifest"""
+        """Merge the manifest with the provided manifest."""
         deployment = utils.merge_dict(
             copy.deepcopy(self.deployment), copy.deepcopy(other.deployment)
         )
@@ -201,7 +205,7 @@ class Manifest(pydantic.BaseModel):
         return Manifest(deployment=deployment, software=software)
 
     def validate_against_default(self, default_manifest: "Manifest") -> None:
-        """Validate the manifest against the default manifest"""
+        """Validate the manifest against the default manifest."""
         self.software.validate_against_default(default_manifest.software)
 
 
@@ -262,7 +266,7 @@ class AddManifestStep(BaseStep):
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Write manifest to cluster db"""
+        """Write manifest to cluster db."""
         try:
             id = self.client.cluster.add_manifest(
                 data=yaml.safe_dump(self.manifest_content)

--- a/sunbeam-python/sunbeam/jobs/plugin.py
+++ b/sunbeam-python/sunbeam/jobs/plugin.py
@@ -264,6 +264,7 @@ class PluginManager:
     def get_all_plugin_manifests(
         cls, deployment: Deployment
     ) -> dict[str, SoftwareConfig]:
+        """Return a dict of all plugin manifest defaults."""
         manifests = {}
         plugins = cls.get_all_plugin_classes()
         for klass in plugins:
@@ -274,6 +275,7 @@ class PluginManager:
 
     @classmethod
     def get_all_plugin_manifest_tfvar_map(cls, deployment: Deployment) -> dict:
+        """Return a dict of all plugin manifest attributes terraformvars map."""
         tfvar_map = {}
         plugins = cls.get_all_plugin_classes()
         for klass in plugins:
@@ -287,6 +289,7 @@ class PluginManager:
     def add_manifest_section(
         cls, deployment: Deployment, software_config: SoftwareConfig
     ) -> None:
+        """Allow every plugin to augment the manifest."""
         plugins = cls.get_all_plugin_classes()
         for klass in plugins:
             plugin = klass(deployment)
@@ -294,6 +297,7 @@ class PluginManager:
 
     @classmethod
     def get_preseed_questions_content(cls, deployment: Deployment) -> list:
+        """Allow every plugin to add preseed questions to the preseed file."""
         content = []
         plugins = cls.get_all_plugin_classes()
         for klass in plugins:
@@ -304,6 +308,7 @@ class PluginManager:
 
     @classmethod
     def get_all_charms_in_openstack_plan(cls, deployment: Deployment) -> list:
+        """Return all charms in openstack-plan from all plugins."""
         charms = []
         plugins = cls.get_all_plugin_classes()
         for klass in plugins:
@@ -318,6 +323,7 @@ class PluginManager:
 
     @classmethod
     def update_proxy_model_configs(cls, deployment: Deployment) -> None:
+        """Make all plugins update proxy model configs."""
         plugins = cls.get_all_plugin_classes()
         for klass in plugins:
             plugin = klass(deployment)

--- a/sunbeam-python/sunbeam/jobs/questions.py
+++ b/sunbeam-python/sunbeam/jobs/questions.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Optional
 
 import yaml
 from rich.console import Console
-from rich.prompt import Confirm, DefaultType, Prompt
+from rich.prompt import Confirm, Prompt
 from rich.text import Text
 
 from sunbeam.clusterd.client import Client
@@ -34,7 +34,7 @@ PASSWORD_MASK = "*" * 8
 class PasswordPrompt(Prompt):
     """Prompt that asks for a password."""
 
-    def render_default(self, default: DefaultType) -> Text:
+    def render_default(self, default: str) -> Text:
         """Turn the supplied default in to a Text instance.
 
         Args:
@@ -53,15 +53,18 @@ class StreamWrapper:
         self.write_stream = write_stream
 
     def readline(self):
+        """Wrap readline, return empty string instead of None."""
         value = self.read_stream.readline()
         if value == "\n":
             return ""
         return value
 
     def flush(self):
+        """Wrap flush, do nothing."""
         self.read_stream.flush()
 
     def write(self, s: str):
+        """Write to the stream."""
         self.write_stream.write(s)
 
 
@@ -106,6 +109,7 @@ class Question:
 
     @property
     def question_function(self):
+        """Allow subclasses to define the question function."""
         raise NotImplementedError
 
     def calculate_default(self, new_default: Any = None) -> Any:
@@ -177,6 +181,7 @@ class PromptQuestion(Question):
 
     @property
     def question_function(self):
+        """Use default prompt function."""
         return Prompt.ask
 
 
@@ -185,6 +190,7 @@ class PasswordPromptQuestion(Question):
 
     @property
     def question_function(self):
+        """Use password prompt function."""
         return PasswordPrompt.ask
 
 
@@ -193,12 +199,12 @@ class ConfirmQuestion(Question):
 
     @property
     def question_function(self):
+        """Use confirm prompt function."""
         return Confirm.ask
 
 
 class QuestionBank:
     """A bank of questions.
-
 
     For example:
 
@@ -263,6 +269,7 @@ class QuestionBank:
                     self.questions[key].previous_answer = value
 
     def __getattr__(self, attr):
+        """Return a question from the bank."""
         return self.questions[attr]
 
 

--- a/sunbeam-python/sunbeam/jobs/steps.py
+++ b/sunbeam-python/sunbeam/jobs/steps.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger(__name__)
 
 
 class DeployMachineApplicationStep(BaseStep):
-    """Base class to deploy machine application using Terraform cloud"""
+    """Base class to deploy machine application using Terraform cloud."""
 
     def __init__(
         self,
@@ -67,9 +67,11 @@ class DeployMachineApplicationStep(BaseStep):
         self.refresh = refresh
 
     def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
         return {}
 
     def get_application_timeout(self) -> int:
+        """Application timeout in seconds."""
         return 600
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
@@ -89,7 +91,7 @@ class DeployMachineApplicationStep(BaseStep):
         return Result(ResultType.SKIPPED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to deploy sunbeam machine"""
+        """Apply terraform configuration to deploy sunbeam machine."""
         machine_ids = []
         try:
             app = run_sync(self.jhelper.get_application(self.application, self.model))
@@ -133,7 +135,7 @@ class DeployMachineApplicationStep(BaseStep):
 
 
 class AddMachineUnitsStep(BaseStep):
-    """Base class to add units of machine application"""
+    """Base class to add units of machine application."""
 
     def __init__(
         self,
@@ -158,6 +160,7 @@ class AddMachineUnitsStep(BaseStep):
         self.to_deploy = set()
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return 600  # 10 minutes
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
@@ -202,7 +205,7 @@ class AddMachineUnitsStep(BaseStep):
                 f"Application {self.application} has not been deployed",
             )
 
-        deployed_units_machine_ids = set(unit.machine.id for unit in app.units)
+        deployed_units_machine_ids = {unit.machine.id for unit in app.units}
         self.to_deploy -= deployed_units_machine_ids
         if len(self.to_deploy) == 0:
             return Result(ResultType.SKIPPED, "No new units to deploy")
@@ -255,7 +258,7 @@ class AddMachineUnitsStep(BaseStep):
 
 
 class RemoveMachineUnitStep(BaseStep):
-    """Base class to remove unit of machine application"""
+    """Base class to remove unit of machine application."""
 
     def __init__(
         self,
@@ -279,6 +282,7 @@ class RemoveMachineUnitStep(BaseStep):
         self.unit = None
 
     def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
         return 600  # 10 minutes
 
     def is_skip(self, status: Optional[Status] = None) -> Result:

--- a/sunbeam-python/sunbeam/main.py
+++ b/sunbeam-python/sunbeam/main.py
@@ -40,7 +40,7 @@ LOG = logging.getLogger()
 
 # Update the help options to allow -h in addition to --help for
 # triggering the help for various commands
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 # Core plugins yaml
 CORE_PLUGINS_YAML = "plugins/plugins.yaml"
@@ -62,13 +62,13 @@ def cli(ctx, quiet, verbose):
 @click.group("manifest", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
 @click.pass_context
 def manifest(ctx):
-    """Manage manifests (read-only commands)"""
+    """Manage manifests (read-only commands)."""
 
 
 @click.group("proxy", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
 @click.pass_context
 def proxy(ctx):
-    """Manage proxy configuration"""
+    """Manage proxy configuration."""
 
 
 @click.group("enable", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
@@ -80,13 +80,13 @@ def proxy(ctx):
 )
 @click.pass_context
 def enable(ctx, manifest: Path | None = None):
-    """Enable plugins"""
+    """Enable plugins."""
 
 
 @click.group("disable", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
 @click.pass_context
 def disable(ctx):
-    """Disable plugins"""
+    """Disable plugins."""
 
 
 @click.group("utils", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)

--- a/sunbeam-python/sunbeam/plugins/ca/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/ca/plugin.py
@@ -88,7 +88,7 @@ def get_outstanding_certificate_requests(
 
 
 class ConfigureCAStep(BaseStep):
-    """Configure CA certificates"""
+    """Configure CA certificates."""
 
     _CONFIG = "PluginCACertificatesConfig"
 
@@ -111,6 +111,7 @@ class ConfigureCAStep(BaseStep):
         self.process_certs = {}
 
     def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user."""
         return True
 
     def prompt(self, console: Optional[Console] = None) -> None:
@@ -245,7 +246,7 @@ class CaTlsPlugin(TlsPluginGroup):
         self.endpoints = []
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={"manual-tls-certificates": CharmManifest(channel="latest/stable")}
         )
@@ -304,6 +305,7 @@ class CaTlsPlugin(TlsPluginGroup):
         help="Base64 encoded CA certificate",
     )
     def enable_plugin(self, ca: str, ca_chain: str, endpoints: List[str]):
+        """Enable CA plugin."""
         self.ca = ca
         self.ca_chain = ca_chain
         self.endpoints = endpoints
@@ -311,6 +313,7 @@ class CaTlsPlugin(TlsPluginGroup):
 
     @click.command()
     def disable_plugin(self):
+        """Disable CA plugin."""
         super().disable_plugin()
         console.print("CA plugin disabled")
 
@@ -358,7 +361,7 @@ class CaTlsPlugin(TlsPluginGroup):
         help="Output format",
     )
     def list_outstanding_csrs(self, format: str) -> None:
-        """List outstanding CSRs"""
+        """List outstanding CSRs."""
         app = CA_APP_NAME
         model = OPENSTACK_MODEL
         action_cmd = "get-outstanding-certificate-requests"
@@ -420,6 +423,7 @@ class CaTlsPlugin(TlsPluginGroup):
         click.echo("CA certs configured")
 
     def commands(self) -> dict:
+        """Return the commands for the plugin."""
         try:
             enabled = self.enabled
         except ClusterServiceUnavailableException:

--- a/sunbeam-python/sunbeam/plugins/caas/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/caas/plugin.py
@@ -134,7 +134,7 @@ class CaasPlugin(OpenStackControlPlanePlugin):
         self.configure_plan = "caas-setup"
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={"magnum-k8s": CharmManifest(channel=OPENSTACK_CHANNEL)},
             terraform={
@@ -168,7 +168,7 @@ class CaasPlugin(OpenStackControlPlanePlugin):
         }
 
     def add_manifest_section(self, software_config: SoftwareConfig) -> None:
-        """Adds manifest section"""
+        """Adds manifest section."""
         caas_config = software_config.extra.get("caas_config")
         if caas_config is None:
             software_config.extra["caas_config"] = CaasConfig()

--- a/sunbeam-python/sunbeam/plugins/dns/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/dns/plugin.py
@@ -56,7 +56,7 @@ class DnsPlugin(OpenStackControlPlanePlugin):
         self.nameservers = None
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={
                 "designate-k8s": CharmManifest(channel=OPENSTACK_CHANNEL),
@@ -174,7 +174,6 @@ class DnsPlugin(OpenStackControlPlanePlugin):
     @click.command()
     def dns_address(self) -> None:
         """Retrieve DNS service address."""
-
         with console.status("Retrieving IP address from DNS service ... "):
             bind_address = run_sync(self.bind_address())
 
@@ -207,6 +206,7 @@ class DnsPlugin(OpenStackControlPlanePlugin):
 
     @property
     def k8s_application_data(self):
+        """K8s application data."""
         return {
             "designate": ApplicationChannelData(
                 channel=OPENSTACK_CHANNEL,
@@ -220,4 +220,5 @@ class DnsPlugin(OpenStackControlPlanePlugin):
 
     @property
     def tfvars_channel_var(self):
+        """Terrform variable channel var."""
         return "designate-channel"

--- a/sunbeam-python/sunbeam/plugins/images_sync/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/images_sync/plugin.py
@@ -43,7 +43,7 @@ class ImagesSyncPlugin(OpenStackControlPlanePlugin):
         )
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={
                 "openstack-images-sync-k8s": CharmManifest(channel=OPENSTACK_CHANNEL),
@@ -94,6 +94,7 @@ class ImagesSyncPlugin(OpenStackControlPlanePlugin):
 
     @property
     def k8s_application_data(self):
+        """K8s application data."""
         return {
             "images-sync": ApplicationChannelData(
                 channel=OPENSTACK_CHANNEL,
@@ -103,4 +104,5 @@ class ImagesSyncPlugin(OpenStackControlPlanePlugin):
 
     @property
     def tfvars_channel_var(self):
+        """Terraform vars channel variable."""
         return "images-sync-channel"

--- a/sunbeam-python/sunbeam/plugins/interface/v1/base.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/base.py
@@ -36,7 +36,7 @@ LOG = logging.getLogger(__name__)
 
 
 class PluginError(SunbeamException):
-    """Common plugin exception base class"""
+    """Common plugin exception base class."""
 
 
 class MissingPluginError(PluginError):
@@ -72,6 +72,7 @@ class ClickInstantiator:
         self.client = client
 
     def __call__(self, *args, **kwargs):
+        """Invoke the click command on the instance method."""
         return self.command(self.klass(self.client), *args, **kwargs)
 
 
@@ -275,7 +276,7 @@ class BasePlugin(ABC):
         return Snap().paths.user_common
 
     def validate_commands(self) -> bool:
-        """validate the commands dictionary.
+        """Validate the commands dictionary.
 
         Validate if the dictionary follows the format
         {<group>: [{"name": <command name>, "command": <command function>}]}
@@ -476,6 +477,7 @@ class PluginRequirement(Requirement):
 
     @property
     def klass(self) -> Type["EnableDisablePlugin"]:
+        """Return the plugin class for the requirement."""
         klass = PluginManager().resolve_plugin(self.repo, self.name)
         if klass is None:
             raise InvalidRequirementError(f"Plugin {self.name} not found")
@@ -543,7 +545,6 @@ class EnableDisablePlugin(BasePlugin):
         self, plugin: "EnableDisablePlugin", requirement: PluginRequirement
     ):
         """Check if actual plugin class is compatible with requirements."""
-
         if len(requirement.specifier) == 0:
             # No version requirement, so no need to check version
             return

--- a/sunbeam-python/sunbeam/plugins/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/openstack.py
@@ -70,7 +70,7 @@ class ApplicationChannelData(TypedDict):
 
 
 class TerraformPlanLocation(Enum):
-    """Enum to define Terraform plan location
+    """Enum to define Terraform plan location.
 
     There are 2 choices - either in sunbeam-terraform repo or
     part of plugin in etc/deploy-<plugin name> directory.
@@ -118,6 +118,7 @@ class OpenStackControlPlanePlugin(EnableDisablePlugin):
 
     @property
     def manifest(self) -> Manifest:
+        """Return the manifest."""
         if self._manifest:
             return self._manifest
 
@@ -396,7 +397,7 @@ class UpgradeOpenStackApplicationStep(BaseStep, JujuStepHelper):
 
 
 class EnableOpenStackApplicationStep(BaseStep, JujuStepHelper):
-    """Generic step to enable OpenStack application using Terraform"""
+    """Generic step to enable OpenStack application using Terraform."""
 
     def __init__(
         self,
@@ -420,7 +421,7 @@ class EnableOpenStackApplicationStep(BaseStep, JujuStepHelper):
         self.model = OPENSTACK_MODEL
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to deploy openstack application"""
+        """Apply terraform configuration to deploy openstack application."""
         config_key = self.plugin.get_tfvar_config_key()
         extra_tfvars = self.plugin.set_tfvars_on_enable()
 
@@ -452,7 +453,7 @@ class EnableOpenStackApplicationStep(BaseStep, JujuStepHelper):
 
 
 class DisableOpenStackApplicationStep(BaseStep, JujuStepHelper):
-    """Generic step to disable OpenStack application using Terraform"""
+    """Generic step to disable OpenStack application using Terraform."""
 
     def __init__(
         self,
@@ -476,7 +477,7 @@ class DisableOpenStackApplicationStep(BaseStep, JujuStepHelper):
         self.model = OPENSTACK_MODEL
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to remove openstack application"""
+        """Apply terraform configuration to remove openstack application."""
         config_key = self.plugin.get_tfvar_config_key()
 
         try:

--- a/sunbeam-python/sunbeam/plugins/interface/v1/tls.py
+++ b/sunbeam-python/sunbeam/plugins/interface/v1/tls.py
@@ -68,6 +68,7 @@ class TlsPluginGroup(OpenStackControlPlanePlugin):
         """Disable TLS group."""
 
     def commands(self) -> dict:
+        """Return a dictionary of commands for the plugin."""
         return {
             "enable": [{"name": self.group, "command": self.enable_tls}],
             "disable": [{"name": self.group, "command": self.disable_tls}],
@@ -114,7 +115,7 @@ class TlsPluginGroup(OpenStackControlPlanePlugin):
 
 
 class AddCACertsToKeystoneStep(BaseStep):
-    """Transfer CA certificates"""
+    """Transfer CA certificates."""
 
     def __init__(
         self,
@@ -201,7 +202,7 @@ class AddCACertsToKeystoneStep(BaseStep):
 
 
 class RemoveCACertsFromKeystoneStep(BaseStep):
-    """Remove CA certificates"""
+    """Remove CA certificates."""
 
     def __init__(
         self,

--- a/sunbeam-python/sunbeam/plugins/ldap/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/ldap/plugin.py
@@ -56,7 +56,7 @@ APPLICATION_REMOVE_TIMEOUT = 300  # 5 minutes
 
 
 class DisableLDAPDomainStep(BaseStep, JujuStepHelper):
-    """Generic step to enable OpenStack application using Terraform"""
+    """Generic step to enable OpenStack application using Terraform."""
 
     def __init__(
         self,
@@ -82,7 +82,7 @@ class DisableLDAPDomainStep(BaseStep, JujuStepHelper):
         self.tfhelper = self.plugin.deployment.get_tfhelper(self.plugin.tfplan)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to deploy openstack application"""
+        """Apply terraform configuration to deploy openstack application."""
         config_key = self.plugin.get_tfvar_config_key()
 
         try:
@@ -149,7 +149,7 @@ class UpdateLDAPDomainStep(BaseStep, JujuStepHelper):
         self.tfhelper = self.plugin.deployment.get_tfhelper(self.plugin.tfplan)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to deploy openstack application"""
+        """Apply terraform configuration to deploy openstack application."""
         config_key = self.plugin.get_tfvar_config_key()
 
         try:
@@ -189,7 +189,7 @@ class UpdateLDAPDomainStep(BaseStep, JujuStepHelper):
 
 
 class AddLDAPDomainStep(BaseStep, JujuStepHelper):
-    """Generic step to enable OpenStack application using Terraform"""
+    """Generic step to enable OpenStack application using Terraform."""
 
     def __init__(
         self,
@@ -215,7 +215,7 @@ class AddLDAPDomainStep(BaseStep, JujuStepHelper):
         self.tfhelper = self.plugin.deployment.get_tfhelper(self.plugin.tfplan)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to deploy openstack application"""
+        """Apply terraform configuration to deploy openstack application."""
         config_key = self.plugin.get_tfvar_config_key()
 
         try:
@@ -264,7 +264,7 @@ class LDAPPlugin(OpenStackControlPlanePlugin):
         self.config_flags = None
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={
                 "keystone-ldap-k8s": CharmManifest(channel=OPENSTACK_CHANNEL),

--- a/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/loadbalancer/plugin.py
@@ -40,7 +40,7 @@ class LoadbalancerPlugin(OpenStackControlPlanePlugin):
         )
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={"octavia-k8s": CharmManifest(channel=OPENSTACK_CHANNEL)}
         )

--- a/sunbeam-python/sunbeam/plugins/observability/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/observability/plugin.py
@@ -77,7 +77,7 @@ GRAFANA_AGENT_K8S_CHANNEL = "latest/stable"
 
 
 class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
-    """Deploy Observability Stack using Terraform"""
+    """Deploy Observability Stack using Terraform."""
 
     _CONFIG = COS_CONFIG_KEY
 
@@ -142,7 +142,7 @@ class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
 
 
 class UpdateObservabilityModelConfigStep(BaseStep, JujuStepHelper):
-    """Update Observability Model config  using Terraform"""
+    """Update Observability Model config  using Terraform."""
 
     _CONFIG = COS_CONFIG_KEY
 
@@ -206,6 +206,8 @@ class RemoveSaasApplicationsStep(BaseStep):
         self._remote_app_to_delete = []
 
     def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not."""
+        super().is_skip
         model = run_sync(self.jhelper.get_model(self.model))
         remote_applications = model.remote_applications
         LOG.debug(
@@ -242,7 +244,7 @@ class RemoveSaasApplicationsStep(BaseStep):
 
 
 class DeployGrafanaAgentStep(BaseStep, JujuStepHelper):
-    """Deploy Grafana Agent using Terraform"""
+    """Deploy Grafana Agent using Terraform."""
 
     _CONFIG = GRAFANA_AGENT_CONFIG_KEY
 
@@ -304,7 +306,7 @@ class DeployGrafanaAgentStep(BaseStep, JujuStepHelper):
 
 
 class RemoveObservabilityStackStep(BaseStep, JujuStepHelper):
-    """Remove Observability Stack using Terraform"""
+    """Remove Observability Stack using Terraform."""
 
     def __init__(
         self,
@@ -343,7 +345,7 @@ class RemoveObservabilityStackStep(BaseStep, JujuStepHelper):
 
 
 class RemoveGrafanaAgentStep(BaseStep, JujuStepHelper):
-    """Remove Grafana Agent using Terraform"""
+    """Remove Grafana Agent using Terraform."""
 
     def __init__(
         self,
@@ -403,6 +405,7 @@ class ObservabilityPlugin(OpenStackControlPlanePlugin):
 
     @property
     def manifest(self) -> Manifest:
+        """Return the manifest."""
         if self._manifest:
             return self._manifest
 
@@ -410,7 +413,7 @@ class ObservabilityPlugin(OpenStackControlPlanePlugin):
         return self._manifest
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={
                 "cos-traefik-k8s": CharmManifest(channel=COS_CHANNEL),
@@ -492,6 +495,7 @@ class ObservabilityPlugin(OpenStackControlPlanePlugin):
         }
 
     def update_proxy_model_configs(self) -> None:
+        """Update proxy model configs."""
         try:
             if not self.enabled:
                 LOG.debug("Observability plugin is not enabled, nothing to do")
@@ -543,6 +547,7 @@ class ObservabilityPlugin(OpenStackControlPlanePlugin):
         return {}
 
     def run_enable_plans(self):
+        """Run the enablement plans."""
         jhelper = JujuHelper(self.deployment.get_connected_controller())
 
         tfhelper = self.deployment.get_tfhelper(self.tfplan)
@@ -578,6 +583,7 @@ class ObservabilityPlugin(OpenStackControlPlanePlugin):
         click.echo("Observability enabled.")
 
     def run_disable_plans(self):
+        """Run the disablement plans."""
         jhelper = JujuHelper(self.deployment.get_connected_controller())
         tfhelper = self.deployment.get_tfhelper(self.tfplan)
         tfhelper_cos = self.deployment.get_tfhelper(self.tfplan_cos)

--- a/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/orchestration/plugin.py
@@ -40,7 +40,7 @@ class OrchestrationPlugin(OpenStackControlPlanePlugin):
         )
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={"heat-k8s": CharmManifest(channel=OPENSTACK_CHANNEL)}
         )

--- a/sunbeam-python/sunbeam/plugins/pro/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/pro/plugin.py
@@ -47,7 +47,7 @@ UNIT_TIMEOUT = 1200  # 15 minutes, adding / removing units can take a long time
 
 
 class EnableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
-    """Enable Ubuntu Pro application using Terraform"""
+    """Enable Ubuntu Pro application using Terraform."""
 
     def __init__(
         self,
@@ -79,7 +79,7 @@ class EnableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to deploy ubuntu-pro"""
+        """Apply terraform configuration to deploy ubuntu-pro."""
         extra_tfvars = {"token": self.token}
         try:
             self.tfhelper.update_tfvars_and_apply_tf(
@@ -125,7 +125,7 @@ class EnableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
 
 
 class DisableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
-    """Disable Ubuntu Pro application using Terraform"""
+    """Disable Ubuntu Pro application using Terraform."""
 
     def __init__(
         self,
@@ -151,7 +151,7 @@ class DisableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Apply terraform configuration to disable ubuntu-pro"""
+        """Apply terraform configuration to disable ubuntu-pro."""
         extra_tfvars = {"token": ""}
         try:
             self.tfhelper.update_tfvars_and_apply_tf(
@@ -179,6 +179,7 @@ class ProPlugin(EnableDisablePlugin):
 
     @property
     def manifest(self) -> Manifest:
+        """Return the manifest."""
         if self._manifest:
             return self._manifest
 
@@ -186,7 +187,7 @@ class ProPlugin(EnableDisablePlugin):
         return self._manifest
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             terraform={
                 self.tfplan: TerraformManifest(
@@ -196,6 +197,7 @@ class ProPlugin(EnableDisablePlugin):
         )
 
     def run_enable_plans(self):
+        """Run the enablement plans."""
         if self.token is None:
             raise ValueError("Token is required to enable Ubuntu Pro")
         tfhelper = self.deployment.get_tfhelper(self.tfplan)
@@ -221,6 +223,7 @@ class ProPlugin(EnableDisablePlugin):
         click.echo("Ubuntu Pro enabled.")
 
     def run_disable_plans(self):
+        """Run the disablement plans."""
         tfhelper = self.deployment.get_tfhelper(self.tfplan)
         plan = [
             TerraformInitStep(tfhelper),
@@ -253,4 +256,5 @@ class ProPlugin(EnableDisablePlugin):
 
     @click.command()
     def disable_plugin(self) -> None:
+        """Disable Ubuntu Pro across deployment."""
         super().disable_plugin()

--- a/sunbeam-python/sunbeam/plugins/repo/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/repo/plugin.py
@@ -110,7 +110,7 @@ class PluginClassNotLoadedException(Exception):
 
 
 class ExternalRepo:
-    """External repo helper functions"""
+    """External repo helper functions."""
 
     def __init__(
         self,
@@ -225,6 +225,7 @@ class RepoPlugin(BasePlugin):
         super().__init__(self.name, deployment)
 
     def commands(self) -> dict:
+        """Return the commands for the plugin."""
         return {
             "init": [{"name": self.name, "command": self.repo}],
             "init.repo": [
@@ -393,7 +394,7 @@ class AddPluginRepoStep(BaseStep):
         self.plugin = plugin
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Clone and validate the repo"""
+        """Clone and validate the repo."""
         try:
             LOG.debug(f"Cloning the repo {self.repo.git_repo}")
             self.repo.clone_repo()
@@ -428,8 +429,7 @@ class RemovePluginRepoStep(BaseStep):
         self.plugin = plugin
 
     def run(self, status: Optional[Status] = None) -> Result:
-        """Remove the repo if no plugins are enabled"""
-
+        """Remove the repo if no plugins are enabled."""
         enabled_plugins = PluginManager.enabled_plugins(
             self.deployment, [self.repo_name]
         )

--- a/sunbeam-python/sunbeam/plugins/secrets/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/secrets/plugin.py
@@ -39,7 +39,7 @@ class SecretsPlugin(OpenStackControlPlanePlugin):
         )
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={"barbican-k8s": CharmManifest(channel=OPENSTACK_CHANNEL)}
         )

--- a/sunbeam-python/sunbeam/plugins/telemetry/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/telemetry/plugin.py
@@ -48,7 +48,7 @@ class TelemetryPlugin(OpenStackControlPlanePlugin):
         )
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={
                 "aodh-k8s": CharmManifest(channel=OPENSTACK_CHANNEL),

--- a/sunbeam-python/sunbeam/plugins/validation/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/validation/plugin.py
@@ -67,7 +67,7 @@ TEMPEST_VALIDATION_RESULT = "/var/lib/tempest/workspace/tempest-validation.log"
 VALIDATION_PLUGIN_DEPLOY_TIMEOUT = (
     60 * 60
 )  # 60 minutes in seconds, tempest can take some time to initialized
-SUPPORTED_TEMPEST_CONFIG = set(["schedule"])
+SUPPORTED_TEMPEST_CONFIG = {"schedule"}
 
 
 class Profile(pydantic.BaseModel):
@@ -115,7 +115,7 @@ class Config(pydantic.BaseModel):
     schedule: Optional[str] = None
 
     @pydantic.validator("schedule")
-    def validate_schedule(cls, schedule: str) -> str:
+    def validate_schedule(cls, schedule: str) -> str:  # noqa N805
         """Validate the schedule config option.
 
         Return the valid schedule if valid,
@@ -184,8 +184,7 @@ def validated_config_args(args: Dict[str, str]) -> Config:
 
     Raise a click bad argument error if errors.
     """
-
-    unsupported_options = set(list(args.keys())).difference(SUPPORTED_TEMPEST_CONFIG)
+    unsupported_options = set(args.keys()).difference(SUPPORTED_TEMPEST_CONFIG)
     if unsupported_options:
         raise click.ClickException(
             f"{', '.join(unsupported_options)!r} is not a supported config option"
@@ -253,7 +252,7 @@ class ValidationPlugin(OpenStackControlPlanePlugin):
         )
 
     def manifest_defaults(self) -> SoftwareConfig:
-        """Plugin software configuration"""
+        """Plugin software configuration."""
         return SoftwareConfig(
             charms={"tempest-k8s": CharmManifest(channel=TEMPEST_CHANNEL)}
         )

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -143,7 +143,7 @@ console = Console()
 @click.group("cluster", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
 @click.pass_context
 def cluster(ctx):
-    """Manage the Sunbeam Cluster"""
+    """Manage the Sunbeam Cluster."""
 
 
 def remove_trailing_dot(value: str) -> str:
@@ -177,6 +177,7 @@ class LocalProvider(ProviderBase):
         cluster.add_command(refresh_cmds.refresh)
 
     def deployment_type(self) -> Tuple[str, Type[Deployment]]:
+        """Retrieve the deployment type and class."""
         return LOCAL_TYPE, LocalDeployment
 
 

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -87,6 +87,7 @@ class LocalDeployment(Deployment):
             return None
 
     def reload_juju_credentials(self):
+        """Refresh instance juju credentials."""
         self.juju_account = self._load_juju_account()
         self.juju_controller = self._load_juju_controller()
 
@@ -263,7 +264,7 @@ class LocalDeployment(Deployment):
         return preseed_content_final
 
     def get_default_proxy_settings(self) -> dict:
-        """Return default proxy settings"""
+        """Return default proxy settings."""
         with open("/etc/environment", mode="r", encoding="utf-8") as file:
             current_env = dict(
                 line.strip().split("=", 1) for line in file if "=" in line

--- a/sunbeam-python/sunbeam/provider/local/steps.py
+++ b/sunbeam-python/sunbeam/provider/local/steps.py
@@ -60,6 +60,7 @@ class NicPrompt(PromptBase[str]):
 
         Args:
             default (Any, optional): Optional default value.
+            stream (TextIO, optional): Optional stream to write to.
 
         Returns:
             PromptType: Processed value.
@@ -99,6 +100,7 @@ class NicQuestion(sunbeam.jobs.questions.Question):
 
     @property
     def question_function(self):
+        """Override the question function to use the NicPrompt."""
         return NicPrompt.ask
 
 
@@ -132,6 +134,7 @@ class LocalSetHypervisorUnitsOptionsStep(SetHypervisorUnitsOptionsStep):
         self.join_mode = join_mode
 
     def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user."""
         return True
 
     def prompt_for_nic(self) -> None:
@@ -163,6 +166,7 @@ class LocalSetHypervisorUnitsOptionsStep(SetHypervisorUnitsOptionsStep):
         return nic
 
     def prompt(self, console: Optional[Console] = None) -> None:
+        """Determines if the step can take input from the user."""
         # If adding a node before configure step has run then answers will
         # not be populated yet.
         self.variables = sunbeam.jobs.questions.load_answers(

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -110,11 +110,11 @@ class MaasClient:
         return ip_ranges
 
     def get_dns_servers(self) -> list[str]:
-        """Get configured upstream dns"""
+        """Get configured upstream dns."""
         return self._client.maas.get_upstream_dns()  # type: ignore
 
     def get_http_proxy(self) -> str | None:
-        """Get configured http proxy"""
+        """Get configured http proxy."""
         return self._client.maas.get_http_proxy()  # type: ignore
 
     @classmethod

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -156,7 +156,7 @@ console = Console()
 @click.group("cluster", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
 @click.pass_context
 def cluster(ctx):
-    """Manage the Sunbeam Cluster"""
+    """Manage the Sunbeam Cluster."""
 
 
 @click.group("machine", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
@@ -189,6 +189,7 @@ def network(ctx):
 
 class MaasProvider(ProviderBase):
     def register_add_cli(self, add: click.Group) -> None:
+        """Register to cli add commands."""
         add.add_command(add_maas)
 
     def register_cli(
@@ -197,6 +198,7 @@ class MaasProvider(ProviderBase):
         configure: click.Group,
         deployment: click.Group,
     ):
+        """Register to main cli maas commands."""
         init.add_command(cluster)
         cluster.add_command(bootstrap)
         cluster.add_command(deploy)
@@ -218,6 +220,7 @@ class MaasProvider(ProviderBase):
         deployment.add_command(validate_deployment_cmd)
 
     def deployment_type(self) -> Tuple[str, Type[Deployment]]:
+        """Return the deployment type."""
         return MAAS_TYPE, MaasDeployment
 
 
@@ -240,7 +243,6 @@ def bootstrap(
 
     Initialize the sunbeam cluster.
     """
-
     deployment: MaasDeployment = ctx.obj
     # Validate manifest file
     manifest = deployment.get_manifest(manifest_path)
@@ -659,7 +661,6 @@ def configure_cmd(
     manifest_path: Path | None = None,
     accept_defaults: bool = False,
 ) -> None:
-
     deployment: Deployment = ctx.obj
     client = deployment.get_client()
     maas_client = MaasClient.from_deployment(deployment)
@@ -863,7 +864,7 @@ def _zones_roles_table(zone_machines: dict[str, list[dict]]) -> Table:
     table = Table(padding=(0, 0), show_header=False)
 
     zone_table = Table(
-        title="\u00A0",  # non-breaking space to have zone same height as roles
+        title="\u00a0",  # non-breaking space to have zone same height as roles
         show_edge=False,
         show_header=False,
         expand=True,

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -114,7 +114,7 @@ class MaasDeployment(Deployment):
         return self.resource_pool + "-internal-api"
 
     @pydantic.validator("type")
-    def type_validator(cls, v: str, values: dict) -> str:
+    def type_validator(cls, v: str, values: dict) -> str:  # noqa N805
         if v != MAAS_TYPE:
             raise ValueError("Deployment type must be MAAS.")
         return v
@@ -235,7 +235,7 @@ class MaasDeployment(Deployment):
         return preseed_content_final
 
     def get_default_proxy_settings(self) -> dict:
-        """Return default proxy settings"""
+        """Return default proxy settings."""
         # to avoid circular import
         from sunbeam.provider.maas.client import MaasClient
 

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -82,6 +82,8 @@ More on assigning tags: https://maas.io/docs/how-to-use-machine-tags
 
 
 class AddMaasDeployment(BaseStep):
+    """Perform various checks and add MAAS-backed deployment."""
+
     def __init__(
         self,
         deployments_config: DeploymentsConfig,
@@ -96,7 +98,6 @@ class AddMaasDeployment(BaseStep):
 
     def is_skip(self, status: Status | None = None) -> Result:
         """Check if deployment is already added."""
-
         try:
             self.deployments_config.get_deployment(self.deployment.name)
             return Result(
@@ -222,6 +223,8 @@ class MachineRolesCheck(DiagnosticsCheck):
         self.machine = machine
 
     def run(self) -> DiagnosticsResult:
+        """List machines roles, fail if machine is missing roles."""
+        super().run
         assigned_roles = self.machine["roles"]
         LOG.debug(f"{self.machine['hostname']=!r} assigned roles: {assigned_roles!r}")
         if not assigned_roles:
@@ -735,7 +738,6 @@ class IpRangesCheck(DiagnosticsCheck):
         self,
     ) -> DiagnosticsResult:
         """Check Public and Internal ip ranges are set."""
-
         public_space = self.deployment.network_mapping.get(Networks.PUBLIC.value)
         internal_space = self.deployment.network_mapping.get(Networks.INTERNAL.value)
         if public_space is None or internal_space is None:
@@ -804,7 +806,7 @@ class DeploymentTopologyCheck(DiagnosticsCheck):
         self.machines = machines
 
     def run(self) -> list[DiagnosticsResult]:
-        """Run a sequence of checks to validate deployment topology.""" ""
+        """Run a sequence of checks to validate deployment topology."""
         machines_by_zone = maas_client._group_machines_by_zone(self.machines)
         checks = []
         checks.append(
@@ -1295,7 +1297,7 @@ class MaasDeployMachinesStep(BaseStep):
 
 
 class MaasConfigureMicrocephOSDStep(BaseStep):
-    """Configure Microceph OSD disks"""
+    """Configure Microceph OSD disks."""
 
     def __init__(
         self,
@@ -1474,7 +1476,6 @@ class MaasConfigureMicrocephOSDStep(BaseStep):
 
     def run(self, status: Status | None = None) -> Result:
         """Configure local disks on microceph."""
-
         for unit, disks in self.disks_to_configure.items():
             try:
                 LOG.debug("Running action add-osd on %r", unit)
@@ -1498,7 +1499,7 @@ class MaasConfigureMicrocephOSDStep(BaseStep):
 
 
 class MaasDeployMicrok8sApplicationStep(microk8s.DeployMicrok8sApplicationStep):
-    """Deploy Microk8s application using Terraform"""
+    """Deploy Microk8s application using Terraform."""
 
     deployment: maas_deployment.MaasDeployment
 
@@ -1528,6 +1529,7 @@ class MaasDeployMicrok8sApplicationStep(microk8s.DeployMicrok8sApplicationStep):
         self.ranges = None
 
     def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
         if self.ranges is None:
             raise ValueError("No ip ranges found")
         tfvars = super().extra_tfvars()
@@ -1623,7 +1625,7 @@ class MaasDeployMicrok8sApplicationStep(microk8s.DeployMicrok8sApplicationStep):
 
 
 class MaasDeployK8SApplicationStep(k8s.DeployK8SApplicationStep):
-    """Deploy K8S application using Terraform"""
+    """Deploy K8S application using Terraform."""
 
     deployment: maas_deployment.MaasDeployment
 
@@ -1737,6 +1739,8 @@ class MaasDeployK8SApplicationStep(k8s.DeployK8SApplicationStep):
 
 
 class MaasEnableK8SFeatures(k8s.EnableK8SFeatures):
+    """Enable specific features on the K8S cluster."""
+
     def __init__(
         self,
         client: Client,
@@ -1798,6 +1802,8 @@ class MaasEnableK8SFeatures(k8s.EnableK8SFeatures):
 
 
 class MaasSetHypervisorUnitsOptionsStep(SetHypervisorUnitsOptionsStep):
+    """Configure hypervisor settings on the machines."""
+
     def __init__(
         self,
         client: Client,
@@ -1883,6 +1889,7 @@ class MaasUserQuestions(BaseStep):
         self.preseed = deployment_preseed or {}
 
     def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user."""
         return True
 
     def prompt(self, console: Console | None = None) -> None:
@@ -1945,13 +1952,13 @@ class MaasUserQuestions(BaseStep):
             "external_network"
         ]["physical_network"]
 
-        self.variables["external_network"][
-            "network_type"
-        ] = ext_net_bank.network_type.ask()
+        self.variables["external_network"]["network_type"] = (
+            ext_net_bank.network_type.ask()
+        )
         if self.variables["external_network"]["network_type"] == "vlan":
-            self.variables["external_network"][
-                "segmentation_id"
-            ] = ext_net_bank.segmentation_id.ask()
+            self.variables["external_network"]["segmentation_id"] = (
+                ext_net_bank.segmentation_id.ask()
+            )
         else:
             self.variables["external_network"]["segmentation_id"] = 0
 
@@ -1961,16 +1968,17 @@ class MaasUserQuestions(BaseStep):
             self.variables["user"]["username"] = user_bank.username.ask()
             self.variables["user"]["password"] = user_bank.password.ask()
             self.variables["user"]["cidr"] = user_bank.cidr.ask()
-            self.variables["user"][
-                "dns_nameservers"
-            ] = user_bank.nameservers.ask().split()
-            self.variables["user"][
-                "security_group_rules"
-            ] = user_bank.security_group_rules.ask()
+            self.variables["user"]["dns_nameservers"] = (
+                user_bank.nameservers.ask().split()
+            )
+            self.variables["user"]["security_group_rules"] = (
+                user_bank.security_group_rules.ask()
+            )
 
         sunbeam.jobs.questions.write_answers(
             self.client, CLOUD_CONFIG_SECTION, self.variables
         )
 
     def run(self, status: Status | None = None) -> Result:
+        """Run the step to completion."""
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -73,7 +73,7 @@ def get_hypervisor_hostname() -> str:
 
 
 def get_fqdn(cidr: str | None = None) -> str:
-    """Get FQDN of the machine"""
+    """Get FQDN of the machine."""
     # If the fqdn returned by this function and from libvirt are different,
     # the hypervisor name and the one registered in OVN will be different
     # which leads to port binding errors,
@@ -214,7 +214,7 @@ def get_local_ip_by_cidr(cidr: str) -> str:
 
 
 def get_local_cidr_by_default_route() -> str:
-    """Get CIDR of host associated with default gateway"""
+    """Get CIDR of host associated with default gateway."""
     conf = get_ifaddresses_by_default_route()
     ip = conf["addr"]
     netmask = conf["netmask"]
@@ -310,6 +310,7 @@ class CatchGroup(click.Group):
     """Catch exceptions and print them to stderr."""
 
     def __call__(self, *args, **kwargs):
+        """Don't display traceback on exceptions."""
         try:
             return self.main(*args, **kwargs)
         except SunbeamException as e:

--- a/sunbeam-python/test-requirements.txt
+++ b/sunbeam-python/test-requirements.txt
@@ -18,8 +18,11 @@ pytest
 pytest-mock
 pytest-asyncio
 
-# Type stubs for requests
+# Type stubs
 types-requests
+types-pyyaml
 
 # For validation plugin
 croniter
+
+ruff

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_configure.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_configure.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_generate_cloud_config.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_generate_cloud_config.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_hypervisor.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_hypervisor.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_juju.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_k8s.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright (c) 2024 Canonical Ltd. Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_microceph.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_microceph.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_microk8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_microk8s.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_mysql.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_mysql.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -275,8 +275,6 @@ class TestDeployControlPlaneStep(unittest.TestCase):
 
 
 class PatchLoadBalancerServicesStepTest(unittest.TestCase):
-    """"""
-
     def __init__(self, methodName: str = "runTest") -> None:
         super().__init__(methodName)
         self.read_config = patch(

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_terraform.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_terraform.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -95,9 +95,10 @@ class TestTerraformHelper:
         manifest = deployment.get_manifest()
 
         tfhelper = deployment.get_tfhelper(tfplan)
-        with patch.object(tfhelper, "write_tfvars") as write_tfvars, patch.object(
-            tfhelper, "apply"
-        ) as apply:
+        with (
+            patch.object(tfhelper, "write_tfvars") as write_tfvars,
+            patch.object(tfhelper, "apply") as apply,
+        ):
             tfhelper.update_tfvars_and_apply_tf(
                 client, manifest, "fake-config", extra_tfvars
             )

--- a/sunbeam-python/tests/unit/sunbeam/commands/upgrades/test_base.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/upgrades/test_base.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/conftest.py
+++ b/sunbeam-python/tests/unit/sunbeam/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/jobs/test_deployment.py
+++ b/sunbeam-python/tests/unit/sunbeam/jobs/test_deployment.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright (c) 2024 Canonical Ltd. Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,7 +71,6 @@ def deployment(mocker, snap):
 
 
 class TestDeployment:
-
     def test_get_default_manifest(self, deployment: Deployment):
         manifest = deployment.get_manifest()
 

--- a/sunbeam-python/tests/unit/sunbeam/jobs/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/jobs/test_juju.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -497,10 +497,13 @@ async def test_jhelper_wait_ready(
 async def test_jhelper_wait_application_ready_timeout(
     jhelper: juju.JujuHelper, model: Model, method: str, entity: str, error: str, args
 ):
-    with pytest.raises(
-        juju.TimeoutException,
-        match=f"Timed out while waiting for {error} to be ready",
-    ), patch.object(jhelper, "get_unit", side_effect=_unit_getter):
+    with (
+        pytest.raises(
+            juju.TimeoutException,
+            match=f"Timed out while waiting for {error} to be ready",
+        ),
+        patch.object(jhelper, "get_unit", side_effect=_unit_getter),
+    ):
         await getattr(jhelper, method)(entity, "control-plane", *args)
     assert model.block_until.call_count == 1
     assert model.block_until.result is False

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_base.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_base.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -410,11 +410,11 @@ class TestEnableDisablePlugin:
     def test_check_plugin_is_automatically_enableable_with_non_automatically_enableable_plugin(  # noqa: E501
         self, deployment
     ):
-        class DummyPlugin_(DummyPlugin):
+        class DummyPluginInner(DummyPlugin):
             def enable_plugin(self, necessary_arg) -> None:
                 return super().enable_plugin()
 
-        required_plugin = DummyPlugin_(name="test_plugin", deployment=deployment)
+        required_plugin = DummyPluginInner(name="test_plugin", deployment=deployment)
 
         plugin = DummyPlugin("test_plugin", deployment)
         with pytest.raises(NotAutomaticPluginError):

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_ldap.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_ldap.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_openstack.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_pro.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_pro.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_repo.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_repo.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_validation.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright (c) 2024 Canonical Ltd. Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -129,7 +129,7 @@ class TestAddMaasDeployment:
         mocker.patch(
             "sunbeam.provider.maas.client.MaasClient",
             side_effect=CallError(
-                request=dict(method="GET", uri="http://localhost:5240/MAAS"),
+                request={"method": "GET", "uri": "http://localhost:5240/MAAS"},
                 response=Mock(status=401, reason="unauthorized"),
                 content=b"",
                 call=None,

--- a/sunbeam-python/tests/unit/sunbeam/test_utils.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright (c) 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sunbeam-python/tox.ini
+++ b/sunbeam-python/tox.ini
@@ -24,60 +24,19 @@ deps =
 commands = python -m pytest {posargs}
 
 [testenv:fmt]
-setenv = VIRTUAL_ENV={envdir}
-envdir = {toxworkdir}/pep8
 description = Apply coding style standards to code
 deps =
-    black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
-
-[testenv:fast8]
-# Use same environment directory as pep8 env to save space and install time
-setenv = VIRTUAL_ENV={envdir}
-envdir = {toxworkdir}/pep8
-commands =
-  {toxinidir}/tools/fast8.sh
+  ruff check --select I --fix {[vars]all_path} # run isort
+  ruff format {[vars]all_path}
 
 [testenv:pep8]
 deps =
-  black
-  hacking>=2.0.0
-  bandit!=1.6.0,>=1.1.0
-  flake8-import-order>=0.13 # LGPLv3
+  ruff
 commands =
-  flake8
-  black --check --diff {[vars]src_path}
-  bandit -r sunbeam -x tests -s B105,B106,B107,B401,B404,B603,B606,B607,B110,B605,B101
-
-[testenv:bandit]
-# This command runs the bandit security linter against the sunbeam
-# codebase minus the tests directory. Some tests are being excluded to
-# reduce the number of positives before a team inspection, and to ensure a
-# passing gate job for initial addition. The excluded tests are:
-# B105-B107: hardcoded password checks - likely to generate false positives
-#            in a gate environment
-# B401: import subprocess - not necessarily a security issue; this plugin is
-#       mainly used for penetration testing workflow
-# B603,B606: process without shell - not necessarily a security issue; this
-#            plugin is mainly used for penetration testing workflow
-# B607: start process with a partial path - this should be a project level
-#       decision
-# NOTE(elmiko): The following tests are being excluded specifically for
-# python-sunbeam, they are being excluded to ensure that voting jobs
-# in the project and in bandit integration tests continue to pass. These
-# tests have generated issue within the project and should be investigated
-# by the project.
-# B110: try, except, pass detected - possible security issue; this should be
-#       investigated by the project for possible exploitation
-# B605: process with a shell - possible security issue; this should be
-#       investigated by the project for possible exploitation
-# B101: use of assert - this code will be removed when compiling to optimized
-#       byte code
-commands =
-    bandit -r sunbeam -x tests -s B105,B106,B107,B401,B404,B603,B606,B607,B110,B605,B101
+  ruff format --diff {[vars]all_path}
+  ruff check {[vars]all_path}
 
 [testenv:venv]
 # -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
@@ -117,15 +76,3 @@ deps =
   -r{toxinidir}/doc/requirements.txt
 commands =
   sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
-
-[flake8]
-max-line-length = 88
-show-source = True
-# H203: Use assertIs(Not)None to check for None
-enable-extensions = H203
-extend-ignore = E203
-exclude = .venv,.git,.tox,dist,doc,*lib/python*,*egg,build,tools,releasenotes
-# W504 is disabled since you must choose between this or W503
-ignore = W504, F821, H301, H306
-import-order-style = pep8
-application_import_names = sunbeam


### PR DESCRIPTION
Migrate default linter from a combination of black, isort, flake8 (+plugins) and bandit to ruff.

Ruff is a newer generation linter, faster, and supporting all flake8 plugins we needed.