### PR TITLE
Correct plan name for inter channel upgrades

### DIFF
--- a/sunbeam-python/sunbeam/commands/upgrades/inter_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/inter_channel.py
@@ -481,7 +481,7 @@ class ChannelUpgradeCoordinator(UpgradeCoordinator):
             [
                 UpgradeOpenstackHypervisorCharm(
                     self.client,
-                    get_tf("openstack-hypervisor-plan"),
+                    get_tf("hypervisor-plan"),
                     self.jhelper,
                     self.manifest,
                     "controller",


### PR DESCRIPTION
Drop "openstack" prefix for hypervisor plan as this is not correct.