### PR TITLE
Add support to enable rgw

### DIFF
--- a/cloud/etc/deploy-microceph/main.tf
+++ b/cloud/etc/deploy-microceph/main.tf
@@ -55,3 +55,31 @@ resource "juju_offer" "microceph_offer" {
   endpoint         = "ceph"
   model            = data.juju_model.machine_model.name
 }
+
+resource "juju_integration" "microceph-identity" {
+  count = (var.keystone-endpoints-offer-url != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.microceph.name
+    endpoint = "identity-service"
+  }
+
+  application {
+    offer_url = var.keystone-endpoints-offer-url
+  }
+}
+
+resource "juju_integration" "microceph-traefik-rgw" {
+  count = (var.ingress-rgw-offer-url != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.microceph.name
+    endpoint = "traefik-route-rgw"
+  }
+
+  application {
+    offer_url = var.ingress-rgw-offer-url
+  }
+}

--- a/cloud/etc/deploy-microceph/variables.tf
+++ b/cloud/etc/deploy-microceph/variables.tf
@@ -52,3 +52,15 @@ variable "endpoint_bindings" {
   type        = set(map(string))
   default     = null
 }
+
+variable "keystone-endpoints-offer-url" {
+  description = "Offer URL for openstack keystone endpoints"
+  type        = string
+  default     = null
+}
+
+variable "ingress-rgw-offer-url" {
+  description = "Offer URL for Traefik RGW"
+  type        = string
+  default     = null
+}

--- a/sunbeam-python/sunbeam/commands/microceph.py
+++ b/sunbeam-python/sunbeam/commands/microceph.py
@@ -169,7 +169,7 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
                     "space": self.deployment.get_space(Networks.STORAGE),
                 },
             ],
-            "charm_microceph_config": {"enable-rgw": "*", "namespace-tenants": True},
+            "charm_microceph_config": {"enable-rgw": "*", "namespace-projects": True},
         }
 
         if keystone_endpoints_offer_url:

--- a/sunbeam-python/sunbeam/plugins/ca/README.md
+++ b/sunbeam-python/sunbeam/plugins/ca/README.md
@@ -17,12 +17,18 @@ To integrate with internal traefik instances as well, install the plugin with:
 sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal
 ```
 
+To integrate with internal and rgw traefik instances as well, install the plugin with:
+
+```bash
+sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal --endpoint rgw
+```
+
 ## Configure
 
 To apply tls certificate on the traefik instances, run the following command:
 
 ```bash
-sunbeam tls ca
+sunbeam tls ca unit_certs
 ```
 
 The above command will prompt the user for TLS Certificate for each traefik unit.

--- a/sunbeam-python/sunbeam/plugins/ca/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/ca/plugin.py
@@ -287,7 +287,7 @@ class CaTlsPlugin(TlsPluginGroup):
         "endpoints",
         multiple=True,
         default=["public"],
-        type=click.Choice(["public", "internal"], case_sensitive=False),
+        type=click.Choice(["public", "internal", "rgw"], case_sensitive=False),
         help="Specify endpoints to apply tls.",
     )
     @click.option(
@@ -328,6 +328,8 @@ class CaTlsPlugin(TlsPluginGroup):
             tfvars.update({"enable-tls-for-public-endpoint": True})
         if "internal" in self.endpoints:
             tfvars.update({"enable-tls-for-internal-endpoint": True})
+        if "rgw" in self.endpoints:
+            tfvars.update({"enable-tls-for-rgw-endpoint": True})
 
         return tfvars
 
@@ -338,6 +340,8 @@ class CaTlsPlugin(TlsPluginGroup):
             tfvars.update({"enable-tls-for-public-endpoint": False})
         if "internal" in self.endpoints:
             tfvars.update({"enable-tls-for-internal-endpoint": False})
+        if "rgw" in self.endpoints:
+            tfvars.update({"enable-tls-for-rgw-endpoint": False})
 
         return tfvars
 

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -481,6 +481,17 @@ def bootstrap(
                 proxy_settings=proxy_settings,
             )
         )
+        plan4.append(
+            DeployMicrocephApplicationStep(
+                deployment,
+                client,
+                microceph_tfhelper,
+                jhelper,
+                manifest,
+                deployment.infrastructure_model,
+                refresh=True,
+            )
+        )
 
     run_plan(plan4, console)
 

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -481,6 +481,9 @@ def bootstrap(
                 proxy_settings=proxy_settings,
             )
         )
+        # Redeploy of Microceph is required to fill terraform vars
+        # related to traefik-rgw/keystone-endpoints offers from
+        # openstack model
         plan4.append(
             DeployMicrocephApplicationStep(
                 deployment,

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -610,6 +610,17 @@ def deploy(
             proxy_settings=proxy_settings,
         )
     )
+    plan2.append(
+        DeployMicrocephApplicationStep(
+            deployment,
+            client,
+            tfhelper_microceph,
+            jhelper,
+            manifest,
+            deployment.infrastructure_model,
+            refresh=True,
+        )
+    )
     plan2.append(ConfigureMySQLStep(jhelper))
     plan2.append(PatchLoadBalancerServicesStep(client))
     plan2.append(TerraformInitStep(tfhelper_hypervisor_deploy))

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -610,6 +610,9 @@ def deploy(
             proxy_settings=proxy_settings,
         )
     )
+    # Redeploy of Microceph is required to fill terraform vars
+    # related to traefik-rgw/keystone-endpoints offers from
+    # openstack model
     plan2.append(
         DeployMicrocephApplicationStep(
             deployment,


### PR DESCRIPTION
Update microceph terraform plans to add
integrations to identity service and
traefik-route-rgw.
Redeploy microceph once openstack plan is
deployed. This is to pick up the ingress-traefik-rgw and keystone-endpoints remote offers from openstack plan and integrate microceph with the latest available offers.

The offers from openstack plan is passed as
variables to microceph plan instead of retrieving
them directly in terraform plan from openstack
backend as the terraform plan fails if the openstack backend does not exist and this cannot be handled
in try clause.

Depends On:
- [x] https://github.com/canonical/microceph/pull/363
- [x] https://github.com/canonical/charm-microceph/pull/86
- [x] https://github.com/canonical/charm-microceph/pull/87
- [x] https://github.com/canonical/sunbeam-terraform/pull/76
- [x] https://github.com/canonical/sunbeam-terraform/pull/78