### PR TITLE
Scale MySQL depending on the scale of the cluster 

### DIFF
--- a/sunbeam-python/sunbeam/core/terraform.py
+++ b/sunbeam-python/sunbeam/core/terraform.py
@@ -361,7 +361,6 @@ class TerraformHelper:
         :param tf_apply_extra_args: Extra args to terraform apply command
         :type tf_apply_extra_args: list or None
         """
-        current_tfvars = None
         updated_tfvars = {}
         if tfvar_config:
             try:

--- a/sunbeam-python/sunbeam/features/caas/feature.py
+++ b/sunbeam-python/sunbeam/features/caas/feature.py
@@ -196,6 +196,12 @@ class CaasFeature(OpenStackControlPlaneFeature):
         """Set terraform variables to resize the application."""
         return {}
 
+    def get_database_charm_processes(self) -> dict[str, dict[str, int]]:
+        """Returns the database processes accessing this service."""
+        return {
+            "magnum": {"magnum-k8s": 10},
+        }
+
     @click.command()
     @pass_method_obj
     def enable_cmd(self, deployment: Deployment) -> None:

--- a/sunbeam-python/sunbeam/features/dns/feature.py
+++ b/sunbeam-python/sunbeam/features/dns/feature.py
@@ -156,6 +156,12 @@ class DnsFeature(OpenStackControlPlaneFeature):
         """Set terraform variables to resize the application."""
         return {}
 
+    def get_database_charm_processes(self) -> dict[str, dict[str, int]]:
+        """Returns the database processes accessing this service."""
+        return {
+            "designate": {"designate-k8s": 8},
+        }
+
     @click.command()
     @argument_with_deprecated_option(
         "nameservers",

--- a/sunbeam-python/sunbeam/features/loadbalancer/feature.py
+++ b/sunbeam-python/sunbeam/features/loadbalancer/feature.py
@@ -86,6 +86,12 @@ class LoadbalancerFeature(OpenStackControlPlaneFeature):
         """Set terraform variables to resize the application."""
         return {}
 
+    def get_database_charm_processes(self) -> dict[str, dict[str, int]]:
+        """Returns the database processes accessing this service."""
+        return {
+            "octavia": {"octavia-k8s": 6},
+        }
+
     @click.command()
     @pass_method_obj
     def enable_cmd(self, deployment: Deployment) -> None:

--- a/sunbeam-python/sunbeam/features/optimization/feature.py
+++ b/sunbeam-python/sunbeam/features/optimization/feature.py
@@ -100,6 +100,12 @@ class ResourceOptimizationFeature(OpenStackControlPlaneFeature):
         """Set terraform variables to resize the application."""
         return {}
 
+    def get_database_charm_processes(self) -> dict[str, dict[str, int]]:
+        """Returns the database processes accessing this service."""
+        return {
+            "watcher": {"watcher-k8s": 8},
+        }
+
     @click.command()
     @pass_method_obj
     def enable_cmd(self, deployment: Deployment) -> None:

--- a/sunbeam-python/sunbeam/features/orchestration/feature.py
+++ b/sunbeam-python/sunbeam/features/orchestration/feature.py
@@ -86,6 +86,12 @@ class OrchestrationFeature(OpenStackControlPlaneFeature):
         """Set terraform variables to resize the application."""
         return {}
 
+    def get_database_charm_processes(self) -> dict[str, dict[str, int]]:
+        """Returns the database processes accessing this service."""
+        return {
+            "heat": {"heat-k8s": 8},
+        }
+
     @click.command()
     @pass_method_obj
     def enable_cmd(self, deployment: Deployment) -> None:

--- a/sunbeam-python/sunbeam/features/secrets/feature.py
+++ b/sunbeam-python/sunbeam/features/secrets/feature.py
@@ -80,6 +80,12 @@ class SecretsFeature(OpenStackControlPlaneFeature):
         """Set terraform variables to resize the application."""
         return {}
 
+    def get_database_charm_processes(self) -> dict[str, dict[str, int]]:
+        """Returns the database processes accessing this service."""
+        return {
+            "barbican": {"barbican-k8s": 9},
+        }
+
     @click.command()
     @pass_method_obj
     def enable_cmd(self, deployment: Deployment) -> None:

--- a/sunbeam-python/sunbeam/features/telemetry/feature.py
+++ b/sunbeam-python/sunbeam/features/telemetry/feature.py
@@ -172,6 +172,13 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
         """Set terraform variables to resize the application."""
         return {}
 
+    def get_database_charm_processes(self) -> dict[str, dict[str, int]]:
+        """Returns the database processes accessing this service."""
+        return {
+            "aodh": {"aodh-k8s": 8},
+            "gnocchi": {"gnocchi-k8s": 8},
+        }
+
     @click.command()
     @pass_method_obj
     def enable_cmd(self, deployment: Deployment) -> None:

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -146,7 +146,6 @@ from sunbeam.steps.microk8s import (
     RemoveMicrok8sUnitsStep,
     StoreMicrok8sConfigStep,
 )
-from sunbeam.steps.mysql import ConfigureMySQLStep
 from sunbeam.steps.openstack import (
     DeployControlPlaneStep,
     OpenStackPatchLoadBalancerServicesStep,
@@ -650,7 +649,6 @@ def bootstrap(
     plan5: list[BaseStep] = []
 
     if is_control_node:
-        plan5.append(ConfigureMySQLStep(jhelper))
         plan5.append(OpenStackPatchLoadBalancerServicesStep(client))
 
     # NOTE(jamespage):

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -144,7 +144,6 @@ from sunbeam.steps.microk8s import (
     AddMicrok8sUnitsStep,
     StoreMicrok8sConfigStep,
 )
-from sunbeam.steps.mysql import ConfigureMySQLStep
 from sunbeam.steps.openstack import (
     DeployControlPlaneStep,
     OpenStackPatchLoadBalancerServicesStep,
@@ -706,7 +705,6 @@ def deploy(
             refresh=True,
         )
     )
-    plan2.append(ConfigureMySQLStep(jhelper))
     plan2.append(OpenStackPatchLoadBalancerServicesStep(client))
     plan2.append(TerraformInitStep(tfhelper_hypervisor_deploy))
     plan2.append(


### PR DESCRIPTION
mysql-k8s-operator needs to be scaled depending on the number of
connections services need.
MySQL takes two config options:
- profile-limit-memory: how much memory to configure MySQL with
- experimental-max-connections: how many max connections to configure

If experimental-max-connections is set, the needed memory will be taken
from the profile-limit-memory. What remains will be used to configure
the respecting buffers.