### PR TITLE
Allow overriding mysql-config-map with the manifest

### DIFF
--- a/sunbeam-python/sunbeam/jobs/manifest.py
+++ b/sunbeam-python/sunbeam/jobs/manifest.py
@@ -63,6 +63,8 @@ class JujuManifest(pydantic.BaseModel):
 
 
 class CharmManifest(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="allow")
+
     channel: str | None = Field(default=None, description="Channel for the charm")
     revision: int | None = Field(
         default=None, description="Revision number of the charm"

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -149,6 +149,8 @@ DEPLOY_OPENSTACK_TFVAR_MAP = {
         for charm, channel in K8S_CHARMS.items()
     }
 }
+# mysql-k8s supports a config map when deployed in many-mysql mode
+DEPLOY_OPENSTACK_TFVAR_MAP["charms"]["mysql-k8s"]["config-map"] = "mysql-config-map"
 DEPLOY_OPENSTACK_TFVAR_MAP["charms"]["self-signed-certificates"] = {
     "channel": "certificate-authority-channel",
     "revision": "certificate-authority-revision",


### PR DESCRIPTION
Map the terraform key `mysql-config-map` to `config-map` of the mysql-k8s charm, to allow the manifest overriding this value.

This config map works the same a config, but for each individual mysql database when deployed with many-mysql.