### PR TITLE
Implement mTLS for all remote calls to microcluster

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -77,12 +77,13 @@ jobs:
           sg snap_daemon "openstack.sunbeam enable observability"
           sg snap_daemon "openstack.sunbeam enable vault"
           sg snap_daemon "openstack.sunbeam enable secrets"
-          sg snap_daemon "openstack.sunbeam enable caas"
+          # Disable caas temporarily while MySQL memory gets adjusted
+          # sg snap_daemon "openstack.sunbeam enable caas"
           # sg snap_daemon "openstack.sunbeam enable validation"
           # If smoke tests fails, logs should be collected via sunbeam command in "Collect logs"
           # sg snap_daemon "openstack.sunbeam validation run smoke"
           # sg snap_daemon "openstack.sunbeam validation run --output tempest_validation.log"
-          sg snap_daemon "openstack.sunbeam disable caas"
+          # sg snap_daemon "openstack.sunbeam disable caas"
           sg snap_daemon "openstack.sunbeam disable secrets"
           sg snap_daemon "openstack.sunbeam disable vault"
           # Commented disabling observability due to LP#1998282

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -132,7 +132,7 @@ parts:
     source: https://github.com/hashicorp/terraform
     source-depth: 1
     source-type: git
-    source-tag: "v1.3.7"
+    source-tag: "v1.5.7"
     build-snaps: [go]
     build-environment:
       - CGO_ENABLED: "0"

--- a/sunbeam-microcluster/access/handler.go
+++ b/sunbeam-microcluster/access/handler.go
@@ -1,0 +1,101 @@
+// Package access implements the access control logic for the extended apis
+package access
+
+import (
+	"crypto/x509"
+	"net/http"
+	"strings"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/logger"
+
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/rest/access"
+	"github.com/canonical/microcluster/state"
+
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/client"
+)
+
+// AuthenticateClusterCAHandler authenticates the cluster CA for incoming requests.
+// It checks if the request is trusted and verifies the client certificate against the cluster CA.
+// If the request is trusted or the client certificate is successfully verified, it allows the request.
+// Otherwise, it returns a forbidden response.
+func AuthenticateClusterCAHandler(state *state.State, r *http.Request) response.Response {
+
+	resp := access.AllowAuthenticated(state, r)
+
+	// AllowAuthenticated returns EmptySyncResponse if the request is trusted.
+	if resp == response.EmptySyncResponse {
+		return resp
+	}
+
+	leader, err := state.Leader()
+
+	if err != nil {
+		logger.Errorf("Failed to get leader client: %v", err)
+		return response.InternalError(err)
+	}
+
+	// If this takes too long, we should look into caching the cluster CA.
+	clusterCA, err := client.ConfigClusterCAGet(state.Context, leader)
+	if err != nil {
+		// If no CA is configured, simply reject the request
+		if strings.Contains(err.Error(), "not found") {
+			logger.Debug("No cluster CA configured, rejecting request")
+			return response.Forbidden(nil)
+		}
+		logger.Errorf("Failed to get cluster CA: %v", err)
+		return response.InternalError(nil)
+	}
+
+	roots := x509.NewCertPool()
+	ok := roots.AppendCertsFromPEM([]byte(clusterCA))
+	if !ok {
+		logger.Error("Failed to parse cluster CA")
+		return response.InternalError(nil)
+	}
+
+	if r.TLS == nil {
+		logger.Error("Rejecting request without TLS")
+		return response.Forbidden(nil)
+	}
+
+	if len(r.TLS.PeerCertificates) > 10 {
+		logger.Error("Rejecting request with too many certificates")
+		return response.Forbidden(nil)
+	}
+
+	opts := x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: x509.NewCertPool(),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+	}
+
+	for _, cert := range r.TLS.PeerCertificates {
+		_, err := cert.Verify(opts)
+		if err == nil {
+			logger.Debug("Allowing request authenticated using cluster CA")
+			return response.EmptySyncResponse
+		}
+	}
+
+	return response.Forbidden(nil)
+}
+
+// AuthenticateUnixHandler only allow requests coming from the unix socket.
+func AuthenticateUnixHandler(_ *state.State, r *http.Request) response.Response {
+	if r.RemoteAddr == "@" {
+		return response.EmptySyncResponse
+	}
+	return response.Forbidden(nil)
+}
+
+// ClusterCATrustedEndpoint is a helper to simplify the creation of a cluster peer endpoint.
+func ClusterCATrustedEndpoint(handler func(state *state.State, r *http.Request) response.Response, proxyTarget bool) rest.EndpointAction {
+	return rest.EndpointAction{
+		Handler:        handler,
+		AccessHandler:  AuthenticateClusterCAHandler,
+		AllowUntrusted: true,
+		ProxyTarget:    proxyTarget,
+	}
+}

--- a/sunbeam-microcluster/api/certificates.go
+++ b/sunbeam-microcluster/api/certificates.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/access"
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/api/types"
+)
+
+// url path: /local/certpair/server
+var certPair = rest.Endpoint{
+	Path: "certpair/server",
+
+	Get: rest.EndpointAction{
+		Handler:       cmdGetMemberServerCertPair,
+		AccessHandler: access.AuthenticateUnixHandler,
+	},
+}
+
+// Return the member server certpair, should only be allowed over the Unix socket.
+func cmdGetMemberServerCertPair(s *state.State, _ *http.Request) response.Response {
+	certs := s.ServerCert()
+
+	if certs == nil {
+		logger.Error("Failed to get server certpair")
+		return response.InternalError(nil)
+	}
+
+	return response.SyncResponse(true, types.CertPair{
+		Certificate: string(certs.PublicKey()),
+		PrivateKey:  string(certs.PrivateKey()),
+	})
+}

--- a/sunbeam-microcluster/api/config.go
+++ b/sunbeam-microcluster/api/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/microcluster/state"
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/access"
 	"github.com/canonical/snap-openstack/sunbeam-microcluster/sunbeam"
 )
 
@@ -18,9 +19,9 @@ import (
 var configCmd = rest.Endpoint{
 	Path: "config/{key}",
 
-	Get:    rest.EndpointAction{Handler: cmdConfigGet, ProxyTarget: true, AllowUntrusted: true},
-	Put:    rest.EndpointAction{Handler: cmdConfigPut, ProxyTarget: true, AllowUntrusted: true},
-	Delete: rest.EndpointAction{Handler: cmdConfigDelete, ProxyTarget: true, AllowUntrusted: true},
+	Get:    access.ClusterCATrustedEndpoint(cmdConfigGet, true),
+	Put:    access.ClusterCATrustedEndpoint(cmdConfigPut, true),
+	Delete: access.ClusterCATrustedEndpoint(cmdConfigDelete, true),
 }
 
 func cmdConfigGet(s *state.State, r *http.Request) response.Response {

--- a/sunbeam-microcluster/api/jujuuser.go
+++ b/sunbeam-microcluster/api/jujuuser.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/microcluster/state"
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/access"
 	"github.com/canonical/snap-openstack/sunbeam-microcluster/api/types"
 	"github.com/canonical/snap-openstack/sunbeam-microcluster/sunbeam"
 )
@@ -19,16 +20,16 @@ import (
 var jujuusersCmd = rest.Endpoint{
 	Path: "jujuusers",
 
-	Get:  rest.EndpointAction{Handler: cmdJujuUsersGetAll, ProxyTarget: true},
-	Post: rest.EndpointAction{Handler: cmdJujuUsersPost, ProxyTarget: true},
+	Get:  access.ClusterCATrustedEndpoint(cmdJujuUsersGetAll, true),
+	Post: access.ClusterCATrustedEndpoint(cmdJujuUsersPost, true),
 }
 
 // /1.0/jujuusers/<name> endpoint.
 var jujuuserCmd = rest.Endpoint{
 	Path: "jujuusers/{name}",
 
-	Get:    rest.EndpointAction{Handler: cmdJujuUsersGet, ProxyTarget: true},
-	Delete: rest.EndpointAction{Handler: cmdJujuUsersDelete, ProxyTarget: true},
+	Get:    access.ClusterCATrustedEndpoint(cmdJujuUsersGet, true),
+	Delete: access.ClusterCATrustedEndpoint(cmdJujuUsersDelete, true),
 }
 
 func cmdJujuUsersGetAll(s *state.State, _ *http.Request) response.Response {

--- a/sunbeam-microcluster/api/manifests.go
+++ b/sunbeam-microcluster/api/manifests.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/microcluster/state"
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/access"
 	"github.com/canonical/snap-openstack/sunbeam-microcluster/api/types"
 	"github.com/canonical/snap-openstack/sunbeam-microcluster/sunbeam"
 )
@@ -19,8 +20,8 @@ import (
 var manifestsCmd = rest.Endpoint{
 	Path: "manifests",
 
-	Get:  rest.EndpointAction{Handler: cmdManifestsGetAll, ProxyTarget: true, AllowUntrusted: true},
-	Post: rest.EndpointAction{Handler: cmdManifestsPost, ProxyTarget: true, AllowUntrusted: true},
+	Get:  access.ClusterCATrustedEndpoint(cmdManifestsGetAll, true),
+	Post: access.ClusterCATrustedEndpoint(cmdManifestsPost, true),
 }
 
 // /1.0/manifests/<manifestid> endpoint.
@@ -28,8 +29,8 @@ var manifestsCmd = rest.Endpoint{
 var manifestCmd = rest.Endpoint{
 	Path: "manifests/{manifestid}",
 
-	Get:    rest.EndpointAction{Handler: cmdManifestGet, ProxyTarget: true, AllowUntrusted: true},
-	Delete: rest.EndpointAction{Handler: cmdManifestDelete, ProxyTarget: true, AllowUntrusted: true},
+	Get:    access.ClusterCATrustedEndpoint(cmdManifestGet, true),
+	Delete: access.ClusterCATrustedEndpoint(cmdManifestDelete, true),
 }
 
 func cmdManifestsGetAll(s *state.State, _ *http.Request) response.Response {

--- a/sunbeam-microcluster/api/nodes.go
+++ b/sunbeam-microcluster/api/nodes.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/microcluster/state"
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/access"
 	"github.com/canonical/snap-openstack/sunbeam-microcluster/api/types"
 	"github.com/canonical/snap-openstack/sunbeam-microcluster/sunbeam"
 )
@@ -19,17 +20,17 @@ import (
 var nodesCmd = rest.Endpoint{
 	Path: "nodes",
 
-	Get:  rest.EndpointAction{Handler: cmdNodesGetAll, ProxyTarget: true, AllowUntrusted: true},
-	Post: rest.EndpointAction{Handler: cmdNodesPost, ProxyTarget: true, AllowUntrusted: true},
+	Get:  access.ClusterCATrustedEndpoint(cmdNodesGetAll, true),
+	Post: access.ClusterCATrustedEndpoint(cmdNodesPost, true),
 }
 
 // /1.0/nodes/<name> endpoint.
 var nodeCmd = rest.Endpoint{
 	Path: "nodes/{name}",
 
-	Get:    rest.EndpointAction{Handler: cmdNodesGet, ProxyTarget: true, AllowUntrusted: true},
-	Put:    rest.EndpointAction{Handler: cmdNodesPut, ProxyTarget: true, AllowUntrusted: true},
-	Delete: rest.EndpointAction{Handler: cmdNodesDelete, ProxyTarget: true, AllowUntrusted: true},
+	Get:    access.ClusterCATrustedEndpoint(cmdNodesGet, true),
+	Put:    access.ClusterCATrustedEndpoint(cmdNodesPut, true),
+	Delete: access.ClusterCATrustedEndpoint(cmdNodesDelete, true),
 }
 
 func cmdNodesGetAll(s *state.State, r *http.Request) response.Response {

--- a/sunbeam-microcluster/api/servers.go
+++ b/sunbeam-microcluster/api/servers.go
@@ -29,6 +29,12 @@ var Servers = []rest.Server{
 					manifestCmd,
 				},
 			},
+			{
+				PathPrefix: types.LocalPathPrefix,
+				Endpoints: []rest.Endpoint{
+					certPair,
+				},
+			},
 		},
 	},
 }

--- a/sunbeam-microcluster/api/terraform.go
+++ b/sunbeam-microcluster/api/terraform.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/microcluster/state"
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/access"
 	"github.com/canonical/snap-openstack/sunbeam-microcluster/sunbeam"
 )
 
@@ -20,7 +21,7 @@ import (
 var terraformStateListCmd = rest.Endpoint{
 	Path: "terraformstate",
 
-	Get: rest.EndpointAction{Handler: cmdStateList, AllowUntrusted: true},
+	Get: access.ClusterCATrustedEndpoint(cmdStateList, false),
 }
 
 // /1.0/terraformstate/{name} endpoint.
@@ -36,31 +37,31 @@ var terraformStateListCmd = rest.Endpoint{
 var terraformStateCmd = rest.Endpoint{
 	Path: "terraformstate/{name}",
 
-	Get:    rest.EndpointAction{Handler: cmdStateGet, AllowUntrusted: true},
-	Put:    rest.EndpointAction{Handler: cmdStatePut, AllowUntrusted: true},
-	Delete: rest.EndpointAction{Handler: cmdStateDelete, AllowUntrusted: true},
+	Get:    access.ClusterCATrustedEndpoint(cmdStateGet, false),
+	Put:    access.ClusterCATrustedEndpoint(cmdStatePut, false),
+	Delete: access.ClusterCATrustedEndpoint(cmdStateDelete, false),
 }
 
 // /1.0/terraformlock endpoint.
 var terraformLockListCmd = rest.Endpoint{
 	Path: "terraformlock",
 
-	Get: rest.EndpointAction{Handler: cmdLockList, AllowUntrusted: true},
+	Get: access.ClusterCATrustedEndpoint(cmdLockList, false),
 }
 
 // /1.0/terraformlock/{name} endpoint.
 var terraformLockCmd = rest.Endpoint{
 	Path: "terraformlock/{name}",
 
-	Get: rest.EndpointAction{Handler: cmdLockGet, AllowUntrusted: true},
-	Put: rest.EndpointAction{Handler: cmdLockPut, AllowUntrusted: true},
+	Get: access.ClusterCATrustedEndpoint(cmdLockGet, false),
+	Put: access.ClusterCATrustedEndpoint(cmdLockPut, false),
 }
 
 // /1.0/terraformunlock/{name} endpoint.
 var terraformUnlockCmd = rest.Endpoint{
 	Path: "terraformunlock/{name}",
 
-	Put: rest.EndpointAction{Handler: cmdUnlockPut, AllowUntrusted: true},
+	Put: access.ClusterCATrustedEndpoint(cmdUnlockPut, false),
 }
 
 func cmdStateList(s *state.State, _ *http.Request) response.Response {

--- a/sunbeam-microcluster/api/types/certificates.go
+++ b/sunbeam-microcluster/api/types/certificates.go
@@ -1,0 +1,8 @@
+// Package types provides shared types and structs.
+package types
+
+// CertPair is a struct to hold a certificate and private key pair.
+type CertPair struct {
+	Certificate string `json:"certificate" yaml:"certificate"`
+	PrivateKey  string `json:"private-key" yaml:"private-key"`
+}

--- a/sunbeam-microcluster/api/types/endpoint_prefix.go
+++ b/sunbeam-microcluster/api/types/endpoint_prefix.go
@@ -7,4 +7,6 @@ import (
 const (
 	// ExtendedPathPrefix is the prefix for all extended API paths.
 	ExtendedPathPrefix types.EndpointPrefix = "1.0"
+	// LocalPathPrefix is the prefix for all local API paths.
+	LocalPathPrefix types.EndpointPrefix = "local"
 )

--- a/sunbeam-microcluster/client/config.go
+++ b/sunbeam-microcluster/client/config.go
@@ -1,0 +1,45 @@
+// Package client contains helper functions to configure the microcluster
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+	microCli "github.com/canonical/microcluster/client"
+
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/api/types"
+)
+
+const (
+	// ClusterCA is the key for the cluster CA configuration.
+	ClusterCA = "cluster-ca"
+)
+
+// ConfigClusterCASet configures the cluster ca.
+// This CA is used to validate incoming queries to extended endpoints.
+func ConfigClusterCASet(ctx context.Context, c *microCli.Client, data string) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*60)
+	defer cancel()
+
+	err := c.Query(queryCtx, "PUT", types.ExtendedPathPrefix, api.NewURL().Path("config", ClusterCA), data, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ConfigClusterCAGet fetches the cluster ca.
+func ConfigClusterCAGet(ctx context.Context, c *microCli.Client) (string, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*60)
+	defer cancel()
+
+	var data string
+	err := c.Query(queryCtx, "GET", types.ExtendedPathPrefix, api.NewURL().Path("config", ClusterCA), nil, &data)
+	if err != nil {
+		return "", err
+	}
+
+	return data, nil
+}

--- a/sunbeam-python/sunbeam/clusterd/client.py
+++ b/sunbeam-python/sunbeam/clusterd/client.py
@@ -13,34 +13,94 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
+import os
+import ssl
+import tempfile
 from urllib.parse import quote
 
 import requests
+import requests.adapters
 import requests_unixsocket
-import urllib3
 from snaphelpers import Snap
+from urllib3 import poolmanager
 
 from sunbeam.clusterd.cluster import ClusterService
+
+
+class MTLSAdapter(requests.adapters.HTTPAdapter):
+    def __init__(self, *args, **kwargs):
+        self.certificate_authority = kwargs.pop("certificate_authority", None)
+        if self.certificate_authority is None:
+            raise ValueError("certificate_authority is required")
+        super().__init__(*args, **kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        """Create and initialize the urllib3 PoolManager."""
+        ctx = ssl.create_default_context(cadata=self.certificate_authority)
+        ctx.verify_mode = ssl.CERT_REQUIRED
+        # Microcluster cluster certificate does not respect hostname
+        # The certificate is shared by every member of the cluster
+        ctx.check_hostname = False
+        assert_hostname = False
+        self.poolmanager = poolmanager.PoolManager(
+            num_pools=connections,
+            maxsize=maxsize,
+            block=block,
+            ssl_version=ssl.PROTOCOL_TLS_CLIENT,
+            ssl_context=ctx,
+            assert_hostname=assert_hostname,
+        )
+
+
+def to_file_path_certs(certificate: str, private_key: str) -> tuple[str, str]:
+    """Template certpair in tmp files, return the path."""
+    cert_fd, cert_path = tempfile.mkstemp(suffix=".crt")
+    pk_fd, pk_path = tempfile.mkstemp(suffix=".key")
+    with os.fdopen(cert_fd, "w") as cert_file:
+        cert_file.write(certificate)
+    with os.fdopen(pk_fd, "w") as pk_file:
+        pk_file.write(private_key)
+    atexit.register(lambda: os.remove(cert_path))
+    atexit.register(lambda: os.remove(pk_path))
+    return cert_path, pk_path
 
 
 class Client:
     """A client for interacting with the remote client API."""
 
-    def __init__(self, endpoint: str):
+    def __init__(
+        self,
+        endpoint: str,
+        certificate_authority: str | None = None,
+        certificate: str | None = None,
+        private_key: str | None = None,
+    ):
         super(Client, self).__init__()
         self._endpoint = endpoint
+        self._certs = None
         self._session = requests.sessions.Session()
-        if self._endpoint.startswith("http+unix://"):
+        if self._endpoint.startswith(requests_unixsocket.DEFAULT_SCHEME):
             self._session.mount(
                 requests_unixsocket.DEFAULT_SCHEME, requests_unixsocket.UnixAdapter()
             )
         else:
-            # TODO(gboutry): remove this when proper TLS communication is
-            # implemented
-            urllib3.disable_warnings()
-            self._session.verify = False
+            if (
+                certificate_authority is None
+                or certificate is None
+                or private_key is None
+            ):
+                raise ValueError(
+                    "Certificate, private key and certificate authority"
+                    " are required http mode."
+                )
+            self._certs = to_file_path_certs(certificate, private_key)
+            self._session.mount(
+                "https://",
+                MTLSAdapter(certificate_authority=certificate_authority),
+            )
 
-        self.cluster = ClusterService(self._session, self._endpoint)
+        self.cluster = ClusterService(self._session, self._endpoint, self._certs)
 
     @classmethod
     def from_socket(cls) -> "Client":
@@ -51,6 +111,16 @@ class Client:
         return cls("http+unix://" + escaped_socket_path)
 
     @classmethod
-    def from_http(cls, endpoint: str) -> "Client":
-        """Return a client initiliazed to the clusterd http endpoint."""
-        return cls(endpoint)
+    def from_http(
+        cls,
+        endpoint: str,
+        certificate_authority: str | None = None,
+        certificate: str | None = None,
+        private_key: str | None = None,
+    ) -> "Client":
+        """Return a client initiliazed to the clusterd http endpoint.
+
+        If both certificate and private_key are provided, the client will
+        use them to authenticate to the server.
+        """
+        return cls(endpoint, certificate_authority, certificate, private_key)

--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -231,6 +231,14 @@ class ExtendedAPIService(service.BaseService):
         """Remove manifest from database."""
         self._delete(f"/1.0/manifest/{manifest_id}")
 
+    def get_server_certpair(self) -> dict:
+        """Fetch server certpair from cluster.
+
+        This will always raise a 403 exception if not used over
+        the unix socket.
+        """
+        return self._get("/local/certpair/server", redact_response=True).get("metadata")
+
 
 class ClusterService(MicroClusterService, ExtendedAPIService):
     """Lists and manages cluster."""

--- a/sunbeam-python/sunbeam/commands/certificates.py
+++ b/sunbeam-python/sunbeam/commands/certificates.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from sunbeam.jobs.common import BaseStep, Result, ResultType, Status
+from sunbeam.jobs.juju import (
+    ApplicationNotFoundException,
+    JujuHelper,
+    JujuWaitException,
+    TimeoutException,
+    run_sync,
+)
+from sunbeam.jobs.manifest import CharmManifest, Manifest
+
+LOG = logging.getLogger(__name__)
+APPLICATION = "tls-operator"
+CHARM = "self-signed-certificates"
+CERTIFICATES_APP_TIMEOUT = 1200
+
+
+class DeployCertificatesProviderApplicationStep(BaseStep):
+    """Deploy tls operator application."""
+
+    def __init__(
+        self,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+        model: str,
+    ):
+        super().__init__(
+            "Deploy tls operator",
+            "Deploying TLS Operator",
+        )
+        self.jhelper = jhelper
+        self.manifest = manifest
+        self.model = model
+        self.app = APPLICATION
+
+    def _get_controller_machines(self) -> list[str]:
+        """Get controller machines."""
+        controller = run_sync(self.jhelper.get_application("controller", self.model))
+        machines = []
+        for unit in controller.units:
+            machines.append(str(unit.machine.id))
+        return sorted(machines)
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Check whether or not to deploy tls operator."""
+        try:
+            run_sync(self.jhelper.get_application(self.app, self.model))
+        except ApplicationNotFoundException:
+            return Result(ResultType.COMPLETED)
+        return Result(ResultType.SKIPPED)
+
+    def run(self, status: Status | None = None) -> Result:
+        """Deploy sunbeam clusterd to controller machines."""
+        self.update_status(status, "fetching controller application")
+        machines = self._get_controller_machines()
+
+        if len(machines) == 0:
+            return Result(ResultType.FAILED, "No controller machines found")
+
+        # Deploy on first controller machine
+        machines = machines[:1]
+        self.update_status(status, "deploying application")
+        charm_manifest: CharmManifest = self.manifest.software.charms[CHARM]
+        run_sync(
+            self.jhelper.deploy(
+                APPLICATION,
+                CHARM,
+                self.model,
+                1,
+                channel=charm_manifest.channel,
+                revision=charm_manifest.revision,
+                to=machines,
+                config=charm_manifest.config,
+            )
+        )
+
+        apps = run_sync(self.jhelper.get_application_names(self.model))
+        try:
+            run_sync(
+                self.jhelper.wait_until_active(
+                    self.model,
+                    apps,
+                    timeout=CERTIFICATES_APP_TIMEOUT,
+                )
+            )
+        except (JujuWaitException, TimeoutException) as e:
+            LOG.warning(str(e))
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -601,6 +601,7 @@ class DeploySunbeamClusterdApplicationStep(BaseStep):
                 self.model,
                 num_units,
                 channel=charm_manifest.channel,
+                revision=charm_manifest.revision,
                 to=machines,
                 config=charm_config,
             )

--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -395,7 +395,7 @@ async def update_status_background(
     return asyncio.create_task(_update_status_background_coro())
 
 
-def str_presenter(dumper: yaml.Dumper, data: str) -> yaml.ScalarNode:
+def str_presenter(dumper: yaml.Dumper | yaml.SafeDumper, data: str) -> yaml.ScalarNode:
     """Return multiline string as '|' literal block.
 
     Ref: https://stackoverflow.com/questions/8640959/how-can-i-control-what-scalar-form-pyyaml-uses-for-my-data

--- a/sunbeam-python/sunbeam/jobs/deployments.py
+++ b/sunbeam-python/sunbeam/jobs/deployments.py
@@ -22,7 +22,7 @@ import pydantic
 import yaml
 from snaphelpers import Snap
 
-from sunbeam.jobs.common import SHARE_PATH
+from sunbeam.jobs.common import SHARE_PATH, str_presenter
 from sunbeam.jobs.deployment import Deployment
 
 LOG = logging.getLogger(__name__)
@@ -65,12 +65,13 @@ class DeploymentsConfig(pydantic.BaseModel):
         Writing to temporary file first in case there's an error during write.
         Not to lose the original file.
         """
-        self_dict = self.dict()
+        self_dict = self.model_dump()
         # self_dict has deployments with Deployment dict but not of provider
         # so workaround to add each deployment based on provider
-        deployments = [d.dict() for d in self.deployments]
+        deployments = [d.model_dump() for d in self.deployments]
         self_dict["deployments"] = deployments
         LOG.debug(f"Writing deployment configuration to {str(self.path)!r}")
+        yaml.SafeDumper.add_representer(str, str_presenter)
         with tempfile.NamedTemporaryFile("w") as tmp:
             yaml.safe_dump(self_dict, tmp)
             tmp.flush()

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -333,7 +333,7 @@ def bootstrap(
     )
     run_plan(plan3, console)
 
-    deployment.reload_juju_credentials()
+    deployment.reload_credentials()
     jhelper = JujuHelper(deployment.get_connected_controller())
     plan4 = []
     plan4.append(
@@ -666,7 +666,7 @@ def join(
     ]
     plan1_results = run_plan(plan1, console)
 
-    deployment.reload_juju_credentials()
+    deployment.reload_credentials()
 
     # Get manifest object once the cluster is joined
     manifest = deployment.get_manifest()

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -96,6 +96,7 @@ class MaasDeployment(Deployment):
     resource_pool: str
     network_mapping: dict[str, str | None] = {}
     clusterd_address: str | None = None
+    clusterd_certificate_authority: str | None = None
     _client: Client | None = pydantic.PrivateAttr(default=None)
 
     @property
@@ -140,8 +141,17 @@ class MaasDeployment(Deployment):
         """Return a client for the deployment."""
         if self.clusterd_address is None:
             raise ValueError("Clusterd address not set.")
+        if self.clusterd_certificate_authority is None:
+            raise ValueError("Clusterd certificate authority not set.")
+        if self.clusterd_certpair is None:
+            raise ValueError("Clusterd certificate not set.")
         if self._client is None:
-            self._client = Client.from_http(self.clusterd_address)
+            certificate_authority = self.clusterd_certificate_authority
+            certificate = self.clusterd_certpair.certificate
+            private_key = self.clusterd_certpair.private_key
+            self._client = Client.from_http(
+                self.clusterd_address, certificate_authority, certificate, private_key
+            )
         return self._client
 
     def get_clusterd_http_address(self) -> str:


### PR DESCRIPTION
Microcluster is a central part of a sunbeam deployment. It is used for clustering and as a state database.
In local mode, only terraform performs remote calls to store its state. In MAAS mode, all communication from the sunbeam client are remote calls.

This change includes for any mode:
- Endpoint protection for microcluster endpoints
- New endpoint types: local <-- endpoint only allowed via the control socket
- New endpoint /local/certpair/server <-- gets the server certpair
- Terraform upgrade to 1.5.7 to support mTLS to remote backend
- TerraformHelper configures its environment variables with the certificate pair

In local mode:
- Call to the certpair endpoint, gets server certpair to configure terraform
- Remote call in this mode are actually trusted by microcluster internal apis

In MAAS mode:
- Deployment of a self-signed-certificates operator in the controller model, related to the sunbeam-clusterd operator
- MaasSaveClusterdAddressStep changed to save all the credentials to the deployment file
- All remote calls are protected via mTLS, with hostname verification disable (the cluster cert is shared by every member of the microcluster)

Requires in MAAS mode:
- https://review.opendev.org/c/openstack/sunbeam-charms/+/922940