### PR TITLE
Only check group belonging when creating a client from socket

### DIFF
--- a/sunbeam-python/sunbeam/commands/inspect.py
+++ b/sunbeam-python/sunbeam/commands/inspect.py
@@ -29,12 +29,10 @@ from snaphelpers import Snap
 from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.commands.juju import WriteCharmLogStep, WriteJujuStatusStep
 from sunbeam.commands.openstack import OPENSTACK_MODEL
-from sunbeam.jobs.checks import DaemonGroupCheck
 from sunbeam.jobs.common import (
     FORMAT_TABLE,
     FORMAT_YAML,
     run_plan,
-    run_preflight_checks,
 )
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import JujuHelper
@@ -53,13 +51,10 @@ def inspect(ctx: click.Context) -> None:
     it finds, and create a tarball of logs and traces which can be
     attached to an issue filed against the sunbeam project.
     """
-    preflight_checks = []
-    preflight_checks.append(DaemonGroupCheck())
-    run_preflight_checks(preflight_checks, console)
+    deployment: Deployment = ctx.obj
 
     if ctx.invoked_subcommand is not None:
         return
-    deployment: Deployment = ctx.obj
     jhelper = JujuHelper(deployment.get_connected_controller())
 
     time_stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/sunbeam-python/sunbeam/commands/manifest.py
+++ b/sunbeam-python/sunbeam/commands/manifest.py
@@ -27,8 +27,7 @@ from sunbeam.clusterd.service import (
     ClusterServiceUnavailableException,
     ManifestItemNotFoundException,
 )
-from sunbeam.jobs.checks import DaemonGroupCheck
-from sunbeam.jobs.common import FORMAT_TABLE, FORMAT_YAML, run_preflight_checks
+from sunbeam.jobs.common import FORMAT_TABLE, FORMAT_YAML
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.manifest import Manifest
 
@@ -85,9 +84,6 @@ def list(ctx: click.Context, format: str) -> None:
     client = deployment.get_client()
     manifests = []
 
-    preflight_checks = [DaemonGroupCheck()]
-    run_preflight_checks(preflight_checks, console)
-
     try:
         manifests = client.cluster.list_manifests()
     except ClusterServiceUnavailableException:
@@ -117,9 +113,6 @@ def show(ctx: click.Context, id: str) -> None:
     """
     deployment: Deployment = ctx.obj
     client = deployment.get_client()
-
-    preflight_checks = [DaemonGroupCheck()]
-    run_preflight_checks(preflight_checks, console)
 
     try:
         manifest = client.cluster.get_manifest(id)
@@ -156,9 +149,6 @@ def generate(
 
     LOG.debug(f"Creating {manifest_file} parent directory if it does not exist")
     manifest_file.parent.mkdir(mode=0o775, parents=True, exist_ok=True)
-
-    preflight_checks = [DaemonGroupCheck()]
-    run_preflight_checks(preflight_checks, console)
 
     manifest = deployment.get_manifest()
 

--- a/sunbeam-python/sunbeam/commands/openrc.py
+++ b/sunbeam-python/sunbeam/commands/openrc.py
@@ -21,7 +21,7 @@ from rich.console import Console
 from sunbeam.commands.configure import retrieve_admin_credentials
 from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.jobs import juju
-from sunbeam.jobs.checks import DaemonGroupCheck, VerifyBootstrappedCheck
+from sunbeam.jobs.checks import VerifyBootstrappedCheck
 from sunbeam.jobs.common import run_preflight_checks
 from sunbeam.jobs.deployment import Deployment
 
@@ -36,7 +36,6 @@ def openrc(ctx: click.Context) -> None:
     deployment: Deployment = ctx.obj
     client = deployment.get_client()
     preflight_checks = []
-    preflight_checks.append(DaemonGroupCheck())
     preflight_checks.append(VerifyBootstrappedCheck(client))
     run_preflight_checks(preflight_checks, console)
 

--- a/sunbeam-python/sunbeam/commands/proxy.py
+++ b/sunbeam-python/sunbeam/commands/proxy.py
@@ -29,7 +29,7 @@ from sunbeam.commands.juju import UpdateJujuModelConfigStep
 from sunbeam.commands.openstack import UpdateOpenStackModelConfigStep
 from sunbeam.commands.sunbeam_machine import DeploySunbeamMachineApplicationStep
 from sunbeam.commands.terraform import TerraformInitStep
-from sunbeam.jobs.checks import DaemonGroupCheck, VerifyBootstrappedCheck
+from sunbeam.jobs.checks import VerifyBootstrappedCheck
 from sunbeam.jobs.common import (
     FORMAT_TABLE,
     FORMAT_YAML,
@@ -68,10 +68,7 @@ def _preflight_checks(deployment: Deployment):
                 "completed succesfully. Please run `sunbeam cluster bootstrap`"
             )
             raise click.ClickException(message)
-        else:
-            preflight_checks = [VerifyBootstrappedCheck(client)]
-    else:
-        preflight_checks = [DaemonGroupCheck(), VerifyBootstrappedCheck(client)]
+    preflight_checks = [VerifyBootstrappedCheck(client)]
 
     run_preflight_checks(preflight_checks, console)
 

--- a/sunbeam-python/sunbeam/plugins/repo/plugin.py
+++ b/sunbeam-python/sunbeam/plugins/repo/plugin.py
@@ -33,7 +33,7 @@ from rich.table import Table
 from snaphelpers import Snap
 
 from sunbeam.clusterd.client import Client
-from sunbeam.jobs.checks import DaemonGroupCheck, VerifyBootstrappedCheck
+from sunbeam.jobs.checks import VerifyBootstrappedCheck
 from sunbeam.jobs.common import (
     FORMAT_TABLE,
     FORMAT_YAML,
@@ -251,7 +251,6 @@ class RepoPlugin(BasePlugin):
     def add(self, name: str, repo: str, branch: str) -> None:
         """Add external plugin repo."""
         preflight_checks = []
-        preflight_checks.append(DaemonGroupCheck())
         preflight_checks.append(VerifyBootstrappedCheck(self.deployment.get_client()))
         run_preflight_checks(preflight_checks, console)
 
@@ -276,7 +275,6 @@ class RepoPlugin(BasePlugin):
     def remove(self, name: str) -> None:
         """Remove external plugin repo."""
         preflight_checks = []
-        preflight_checks.append(DaemonGroupCheck())
         preflight_checks.append(VerifyBootstrappedCheck(self.deployment.get_client()))
         run_preflight_checks(preflight_checks, console)
 
@@ -302,7 +300,6 @@ class RepoPlugin(BasePlugin):
     def list_repos(self, format: str, plugins: bool, include_core: bool) -> None:
         """List external plugin repo."""
         preflight_checks = []
-        preflight_checks.append(DaemonGroupCheck())
         preflight_checks.append(VerifyBootstrappedCheck(self.deployment.get_client()))
         run_preflight_checks(preflight_checks, console)
         repos = PluginManager.get_all_external_repos(
@@ -359,7 +356,6 @@ class RepoPlugin(BasePlugin):
     def update(self, name: str) -> None:
         """Update external plugin repo."""
         preflight_checks = []
-        preflight_checks.append(DaemonGroupCheck())
         preflight_checks.append(VerifyBootstrappedCheck(self.deployment.get_client()))
         run_preflight_checks(preflight_checks, console)
 

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -82,7 +82,6 @@ from sunbeam.commands.sunbeam_machine import (
 )
 from sunbeam.commands.terraform import TerraformInitStep
 from sunbeam.jobs.checks import (
-    DaemonGroupCheck,
     DiagnosticsCheck,
     DiagnosticsResult,
     JujuSnapCheck,
@@ -699,7 +698,6 @@ def configure_cmd(
     client = deployment.get_client()
     maas_client = MaasClient.from_deployment(deployment)
     preflight_checks = []
-    preflight_checks.append(DaemonGroupCheck())
     preflight_checks.append(VerifyBootstrappedCheck(client))
     run_preflight_checks(preflight_checks, console)
 


### PR DESCRIPTION
snap_daemon group is only needed to talk over the control socket. This socket is only accessed in local mode. Simplify this check by only performing when we create an http client for the socket.

Closes-Bug: #2066541