### PR TITLE
refactor cluster list, implement for MAAS

### DIFF
--- a/sunbeam-microcluster/api/servers.go
+++ b/sunbeam-microcluster/api/servers.go
@@ -27,6 +27,7 @@ var Servers = []rest.Server{
 					configCmd,
 					manifestsCmd,
 					manifestCmd,
+					statusCmd,
 				},
 			},
 			{

--- a/sunbeam-microcluster/api/status.go
+++ b/sunbeam-microcluster/api/status.go
@@ -1,0 +1,44 @@
+// Package api provides the REST API endpoints.
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/state"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+
+	"github.com/canonical/snap-openstack/sunbeam-microcluster/access"
+)
+
+var statusCmd = rest.Endpoint{
+	Path: "status",
+
+	Get: access.ClusterCATrustedEndpoint(cmdGetStatus, false),
+}
+
+func cmdGetStatus(s *state.State, _ *http.Request) response.Response {
+	leader, err := s.Leader()
+
+	if err != nil {
+		logger.Errorf("Failed to get leader client: %v", err)
+		return response.InternalError(err)
+	}
+
+	queryCtx, cancel := context.WithTimeout(s.Context, time.Second*30)
+	defer cancel()
+
+	var data []map[string]interface{}
+	err = leader.Query(queryCtx, "GET", "cluster/1.0", api.NewURL().Path("cluster"), nil, &data)
+	if err != nil {
+		logger.Errorf("Failed to get cluster status: %v", err)
+		return response.InternalError(err)
+	}
+
+	return response.SyncResponse(true, data)
+}

--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -239,6 +239,12 @@ class ExtendedAPIService(service.BaseService):
         """
         return self._get("/local/certpair/server", redact_response=True).get("metadata")
 
+    def get_status(self) -> dict[str, dict]:
+        """Get status of the cluster."""
+        cluster = self._get("/1.0/status")
+        members = cluster.get("metadata", {})
+        return {member["name"]: {"status": member["status"]} for member in members}
+
 
 class ClusterService(MicroClusterService, ExtendedAPIService):
     """Lists and manages cluster."""

--- a/sunbeam-python/sunbeam/commands/cluster_status.py
+++ b/sunbeam-python/sunbeam/commands/cluster_status.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import abc
+import functools
+import logging
+
+import rich.console
+import rich.table
+import rich.text
+import yaml
+from rich.console import Console
+from rich.status import Status
+
+from sunbeam.clusterd.service import ClusterServiceUnavailableException
+from sunbeam.commands import clusterd, hypervisor, k8s, microceph, microk8s
+from sunbeam.jobs.common import (
+    FORMAT_TABLE,
+    FORMAT_YAML,
+    Result,
+    ResultType,
+    SunbeamException,
+)
+from sunbeam.jobs.deployment import Deployment
+from sunbeam.jobs.juju import JujuHelper, run_sync
+from sunbeam.jobs.steps import BaseStep
+from sunbeam.utils import merge_dict
+
+LOG = logging.getLogger(__name__)
+
+GREEN = "[green]{}[/green]"
+ORANGE = "[orange1]{}[/orange1]"
+RED = "[red]{}[/red]"
+
+
+def _to_status(status: dict, application_column_mapping: dict) -> dict:
+    """Return dict to the correct status format.
+
+    Return format:
+    <model>:
+        <machine_id>:
+            hostname: <machine_hostname>
+            status:
+                <role>: <status>
+    """
+    formatted_status = {}
+    for model, model_status in status.items():
+        formatted_status[model] = {}
+        for machine, machine_status in model_status.items():
+            _status = {}
+            if mac_status := machine_status.get("status"):
+                _status["machine"] = mac_status
+            if clusterd_status := machine_status.get("clusterd-status"):
+                _status["cluster"] = clusterd_status
+            if machines_applications := machine_status.get("applications", {}):
+                for app, app_status in machines_applications.items():
+                    column = application_column_mapping.get(app)
+                    if column is None:
+                        continue
+                    _status[column] = app_status["status"]
+            formatted_status[model][machine] = {
+                "hostname": machine_status["name"],
+                "status": _status,
+            }
+    return formatted_status
+
+
+def color_status(status: str | None) -> str:
+    match status:
+        case "active" | "running" | "ONLINE":
+            return GREEN.format(status)
+        case "waiting" | "maintenance":
+            return ORANGE.format(status)
+        case None:
+            return ""
+        case _:
+            return RED.format(status)
+
+
+def _cmp(a: str, b: str) -> int:
+    if a in {"cluster", "machine"}:
+        return -1
+    if b in {"cluster", "machine"}:
+        return 1
+    if a == b:
+        return 0
+    if a > b:
+        return 1
+    return -1
+
+
+def _capitalize(s: str) -> str:
+    return " ".join(word.capitalize() for word in s.split("-"))
+
+
+def format_status(
+    deployment: Deployment,
+    status: dict,
+    format: str,
+    mandatory_columns: frozenset[str] = frozenset(("compute", "storage", "control")),
+) -> list[rich.console.RenderableType]:
+    """Return a list renderables for the status.
+
+    Mandatory columns are always displayed on the infrastructure model, even if no
+    member of the cluster has that role.
+
+    Status format is:
+    <model>:
+        <machine_id>:
+            machineid: <machineid>
+            role: [<role>, ...]
+            status:
+                <role>: <status>
+    """
+    if format == FORMAT_TABLE:
+        tables = []
+        for model, model_status in sorted(status.items()):
+            table = rich.table.Table(
+                title=model,
+            )
+            table.add_column("Node", justify="left")
+            column_set: set[str] = set()
+            for status_name in model_status.values():
+                column_set.update(status_name.get("status", {}).keys())
+            if model == deployment.infrastructure_model:
+                column_set.update(mandatory_columns)
+            columns: list[str] = sorted(column_set, key=functools.cmp_to_key(_cmp))
+            for column in columns:
+                table.add_column(_capitalize(column), justify="center")
+            for id, node in model_status.items():
+                table.add_row(
+                    node.get("hostname", id),
+                    *(
+                        color_status(node.get("status", {}).get(column))
+                        for column in columns
+                    ),
+                )
+            tables.append(table)
+        return tables
+    elif format == FORMAT_YAML:
+        return [yaml.dump(status, sort_keys=True)]
+    else:
+        return [str(status)]
+
+
+class ClusterStatusStep(abc.ABC, BaseStep):
+    def __init__(
+        self, deployment: Deployment, jhelper: JujuHelper, console: Console, format: str
+    ):
+        super().__init__("Cluster Status", "Querying cluster status")
+        self.deployment = deployment
+        self.jhelper = jhelper
+        self.console = console
+        self.format = format
+
+    @abc.abstractmethod
+    def models(self) -> list[str]:
+        """List of models to query status from."""
+        raise NotImplementedError
+
+    def applications_to_columns(self) -> dict:
+        """Mapping of applications to columns."""
+        return {
+            clusterd.APPLICATION: "clusterd",
+            microk8s.APPLICATION: "control",
+            k8s.APPLICATION: "control",
+            hypervisor.APPLICATION: "compute",
+            microceph.APPLICATION: "storage",
+        }
+
+    @abc.abstractmethod
+    def _update_microcluster_status(self, status: dict, microcluster_status: dict):
+        """How to update microcluster status in the status dict."""
+        raise NotImplementedError
+
+    def _get_microcluster_status(self) -> dict:
+        client = self.deployment.get_client()
+        try:
+            cluster_status = client.cluster.get_status()
+        except ClusterServiceUnavailableException:
+            LOG.debug("Failed to query cluster status", exc_info=True)
+            raise SunbeamException("Cluster service is not yet bootstrapped.")
+        status = {}
+        for node, _status in cluster_status.items():
+            status[node] = _status.get("status")
+        return status
+
+    def _get_application_status_per_machine(self, model: str) -> dict:
+        """Return status of every units of applications in a given model.
+
+        <machine_id>:
+            applications:
+                <application>:
+                    name: <unit_name>
+                    status: <status>
+        """
+        machine_status = {}
+        status = run_sync(self.jhelper.get_model_status(model))
+        for app, app_status in status["applications"].items():
+            for unit, unit_status in app_status["units"].items():
+                _machine_pointer = machine_status.setdefault(
+                    unit_status["machine"], {"applications": {}}
+                )
+                _machine_pointer["applications"][app] = {
+                    "name": unit,
+                    "status": unit_status["workload-status"]["status"],
+                }
+        return machine_status
+
+    def _get_machines_status(self, model: str) -> dict:
+        """Return status of every machine in a given model.
+
+        <machine_id>:
+            name: <machine_hostname>
+            status: <status>
+        """
+        machines_status = {}
+        status = run_sync(self.jhelper.get_model_status(model))
+        for machine, machine_status in status["machines"].items():
+            machines_status[machine] = {
+                "name": machine_status["hostname"],
+                "status": machine_status["instance-status"]["status"],
+            }
+        return machines_status
+
+    def _compute_status(self) -> dict:
+        status = {}
+        for model in self.models():
+            _status_model = self._get_machines_status(model)
+            status[model] = merge_dict(
+                _status_model,
+                self._get_application_status_per_machine(model),
+            )
+        self._update_microcluster_status(status, self._get_microcluster_status())
+        return _to_status(status, self.applications_to_columns())
+
+    def run(self, status: Status) -> Result:
+        """Run the step to completion."""
+        self.update_status(status, "Computing cluster status")
+        cluster_status = self._compute_status()
+        return Result(ResultType.COMPLETED, cluster_status)

--- a/sunbeam-python/sunbeam/jobs/juju.py
+++ b/sunbeam-python/sunbeam/jobs/juju.py
@@ -336,11 +336,17 @@ class JujuHelper:
         owner = model_impl.info.owner_tag.removeprefix(OWNER_TAG_PREFIX)
         return f"{owner}/{model_impl.info.name}"
 
-    async def get_model_status_full(self, model: str) -> Dict:
-        """Get juju status for the model."""
+    async def get_model_status(
+        self, model: str, filter: list[str] | None = None
+    ) -> dict:
+        """Get juju filtered status."""
         model_impl = await self.get_model(model)
-        status = await model_impl.get_status()
-        return status
+        status = await model_impl.get_status(filter)
+        return json.loads(status.to_json())
+
+    async def get_model_status_full(self, model: str) -> dict:
+        """Get juju status for the model."""
+        return await self.get_model_status(model)
 
     async def get_application_names(self, model: str) -> List[str]:
         """Get Application names in the model.

--- a/sunbeam-python/tests/unit/sunbeam/jobs/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/jobs/test_juju.py
@@ -237,6 +237,7 @@ async def test_jhelper_get_model_unknown_error(
 
 @pytest.mark.asyncio
 async def test_jhelper_get_model_status_full(jhelper: juju.JujuHelper, model):
+    model.get_status.return_value = Mock(to_json=Mock(return_value="{}"))
     await jhelper.get_model_status_full("control-plane")
     jhelper.controller.get_model.assert_called_with("control-plane")
     model.get_status.assert_called_once()


### PR DESCRIPTION
Original cluster was just fetching members from the cluster, displaying the corresponding role, and whether or not the microcluster was active. It only worked in local mode.

In a MAAS deployment, very few nodes have a clusterd. It does not make sense to tie the cluster list to the microcluster members.

Now, displays the machines in controller and openstack-machines (MAAS only) models, with the status of each unit corresponding to its role.

Example in local mode:
![image](https://github.com/canonical/snap-openstack/assets/4944914/42d7e3d8-5f43-473c-8736-edd2b83e9d92)
![image](https://github.com/canonical/snap-openstack/assets/4944914/a5de49a3-1ccb-4349-b877-2b30d9ccf153)

Example in MAAS mode:
![image](https://github.com/canonical/snap-openstack/assets/4944914/aa16337a-a45f-4ce0-b837-dade1f404c01)
![image](https://github.com/canonical/snap-openstack/assets/4944914/fbc4330e-8404-482f-bc66-b5c20df24be1)

