### PR TITLE
Add possibility to map unit status in cluster list

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -757,7 +757,7 @@ def list(
     run_preflight_checks(preflight_checks, console)
     deployment: LocalDeployment = ctx.obj
     jhelper = JujuHelper(deployment.get_connected_controller())
-    step = LocalClusterStatusStep(deployment, jhelper, console, format)
+    step = LocalClusterStatusStep(deployment, jhelper)
     results = run_plan([step], console)
     msg = get_step_message(results, LocalClusterStatusStep)
     renderables = cluster_status.format_status(deployment, msg, format)

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -788,7 +788,7 @@ def list_nodes(ctx: click.Context, format: str) -> None:
     """List nodes in the custer."""
     deployment: MaasDeployment = ctx.obj
     jhelper = JujuHelper(deployment.get_connected_controller())
-    step = MaasClusterStatusStep(deployment, jhelper, console, format)
+    step = MaasClusterStatusStep(deployment, jhelper)
     results = run_plan([step], console)
     msg = get_step_message(results, MaasClusterStatusStep)
     renderables = cluster_status.format_status(deployment, msg, format)


### PR DESCRIPTION
A local sunbeam deployment can be deployed without storage, in this case, the openstack-hypervisor units will sit in status `waiting`, waiting for the ceph-access relation to complete. This is expected, and should be considered as active.

Remove unnecessary parameters from the cluster list step.