### PR TITLE
MAAS: use tags instead of pools to delimit resource group

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -801,8 +801,7 @@ def list_nodes(ctx: click.Context, format: str) -> None:
 @click.option("-n", "--name", type=str, prompt=True, help="Name of the deployment")
 @click.option("-t", "--token", type=str, prompt=True, help="API token")
 @click.option("-u", "--url", type=str, prompt=True, help="API URL")
-@click.option("-r", "--resource-pool", type=str, prompt=True, help="Resource pool")
-def add_maas(name: str, token: str, url: str, resource_pool: str) -> None:
+def add_maas(name: str, token: str, url: str) -> None:
     """Add MAAS-backed deployment to registered deployments."""
     preflight_checks = [
         LocalShareCheck(),
@@ -814,12 +813,15 @@ def add_maas(name: str, token: str, url: str, resource_pool: str) -> None:
     path = deployment_path(snap)
     deployments = DeploymentsConfig.load(path)
     plan = []
+    try:
+        deployment = MaasDeployment(name=name, token=token, url=url)
+    except Exception as e:
+        console.print("Error: " + str(e))
+        sys.exit(1)
     plan.append(
         AddMaasDeployment(
             deployments,
-            MaasDeployment(
-                name=name, token=token, url=url, resource_pool=resource_pool
-            ),
+            deployment,
         )
     )
     run_plan(plan, console)

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -91,9 +91,9 @@ class NicTags(enum.Enum):
 
 
 class MaasDeployment(Deployment):
+    name: str = pydantic.Field(pattern=r"^[a-zA-Z0-9-_]+$", max_length=246)
     type: str = MAAS_TYPE
     token: str
-    resource_pool: str
     network_mapping: dict[str, str | None] = {}
     clusterd_address: str | None = None
     clusterd_certificate_authority: str | None = None
@@ -105,14 +105,19 @@ class MaasDeployment(Deployment):
         return self.name + "-controller"
 
     @property
+    def resource_tag(self) -> str:
+        """Return resource tag."""
+        return "openstack-" + self.name
+
+    @property
     def public_api_label(self) -> str:
         """Return public API label."""
-        return self.resource_pool + "-public-api"
+        return self.name + "-public-api"
 
     @property
     def internal_api_label(self) -> str:
         """Return internal API label."""
-        return self.resource_pool + "-internal-api"
+        return self.name + "-internal-api"
 
     @pydantic.validator("type")
     def type_validator(cls, v: str, values: dict) -> str:  # noqa N805

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -63,7 +63,6 @@ class TestAddMaasDeployment:
                 name="test_deployment",
                 token="test_token",
                 url="test_url",
-                resource_pool="test_resource_pool",
             ),
         )
 
@@ -74,23 +73,6 @@ class TestAddMaasDeployment:
                 MaasDeployment(
                     name="test_deployment",
                     url="test_url2",
-                    resource_pool="test_resource_pool3",
-                    token="test_token",
-                )
-            ],
-        )
-        add_maas_deployment.deployments_config = deployments_config
-        result = add_maas_deployment.is_skip()
-        assert result.result_type == ResultType.FAILED
-
-    def test_is_skip_with_existing_url_and_resource_pool(self, add_maas_deployment):
-        deployments_config = DeploymentsConfig(
-            active="test_deployment",
-            deployments=[
-                MaasDeployment(
-                    name="different_deployment",
-                    url="test_url",
-                    resource_pool="test_resource_pool",
                     token="test_token",
                 )
             ],
@@ -443,7 +425,7 @@ class TestZonesCheck:
         check = ZonesCheck(zones)
         result = check.run()
         assert result.passed is False
-        assert result.message == "deployment has 2 zones"
+        assert result.message == "deployment has 0 or 2 zones"
 
     def test_run_with_three_zones(self):
         zones = ["zone1", "zone2", "zone3"]


### PR DESCRIPTION
The deployment will now check for a tag `sunbeam-<name>` to consider machines of the deployment.