### PR TITLE
Perform full string matching on roles when querying nodes

### DIFF
--- a/sunbeam-microcluster/database/node.go
+++ b/sunbeam-microcluster/database/node.go
@@ -68,7 +68,8 @@ func GetNodesFromRoles(ctx context.Context, tx *sql.Tx, roles []string) ([]Node,
 				queryParts[0] += " AND"
 			}
 			queryParts[0] += " instr(nodes.role, ?) > 0"
-			args = append(args, role)
+			// Role is a json list, quote it to cheaply do full string match
+			args = append(args, "\""+role+"\"")
 		}
 	}
 


### PR DESCRIPTION
Since the introduction of the role `juju-controller` in registered nodes, queries searching for the role `control` will return nodes belonging to the role `control` and `juju-controller`.

The role field is a json list stringified, adding double quotes around the role query will actually perform a full string matching cheaply.