### PR TITLE
MAAS: rename compute nic tag to neutron:physnet1

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -82,7 +82,7 @@ class StorageTags(enum.Enum):
 
 
 class NicTags(enum.Enum):
-    COMPUTE = "compute"
+    COMPUTE = "neutron:physnet1"
 
     @classmethod
     def values(cls) -> list[str]:

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -394,7 +394,7 @@ class MachineComputeNicCheck(DiagnosticsCheck):
                 machine=self.machine["hostname"],
             )
         compute_tag = maas_deployment.NicTags.COMPUTE.value
-        if compute_tag not in assigned_roles:
+        if maas_deployment.RoleTags.COMPUTE.value not in assigned_roles:
             self.message = "not a compute node."
             return DiagnosticsResult.success(
                 self.name,
@@ -406,7 +406,7 @@ class MachineComputeNicCheck(DiagnosticsCheck):
             if compute_tag in nic["tags"]:
                 return DiagnosticsResult.success(
                     self.name,
-                    "compute nic found",
+                    compute_tag + " nic found",
                     machine=self.machine["hostname"],
                 )
 


### PR DESCRIPTION
Prepare for the future of multiple provider networks and make the tag more meaningful by renaming it `neutron:physnet1`