### PR TITLE
Extend observability to connect to external cos

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -74,7 +74,7 @@ jobs:
           sg snap_daemon "openstack.sunbeam enable loadbalancer"
           sg snap_daemon "openstack.sunbeam enable dns --nameservers=testing.github."
           sg snap_daemon "openstack.sunbeam enable telemetry"
-          sg snap_daemon "openstack.sunbeam enable observability"
+          sg snap_daemon "openstack.sunbeam enable observability embedded"
           sg snap_daemon "openstack.sunbeam enable vault"
           sg snap_daemon "openstack.sunbeam enable secrets"
           # Disable caas temporarily while MySQL memory gets adjusted
@@ -87,7 +87,7 @@ jobs:
           sg snap_daemon "openstack.sunbeam disable secrets"
           sg snap_daemon "openstack.sunbeam disable vault"
           # Commented disabling observability due to LP#1998282
-          # sg snap_daemon "openstack.sunbeam disable observability"
+          # sg snap_daemon "openstack.sunbeam disable observability embedded"
           # sg snap_daemon "openstack.sunbeam disable telemetry"
           sg snap_daemon "openstack.sunbeam disable dns"
           sg snap_daemon "openstack.sunbeam disable loadbalancer"

--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -248,6 +248,47 @@ class JujuStepHelper:
                 f"Command finished. stdout={process.stdout}, stderr={process.stderr}"
             )
 
+    def integrate(
+        self,
+        model: str,
+        provider: str,
+        requirer: str,
+        ignore_error_if_exists: bool = True,
+    ):
+        """Juju integrate applications."""
+        cmd = [
+            self._get_juju_binary(),
+            "integrate",
+            "-m",
+            model,
+            provider,
+            requirer,
+        ]
+        try:
+            LOG.debug(f'Running command {" ".join(cmd)}')
+            process = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            LOG.debug(
+                f"Command finished. stdout={process.stdout}, stderr={process.stderr}"
+            )
+        except subprocess.CalledProcessError as e:
+            LOG.debug(e.stderr)
+            if ignore_error_if_exists and "already exists" not in e.stderr:
+                raise e
+
+    def remove_relation(self, model: str, provider: str, requirer: str):
+        """Juju remove relation."""
+        cmd = [
+            self._get_juju_binary(),
+            "remove-relation",
+            "-m",
+            model,
+            provider,
+            requirer,
+        ]
+        LOG.debug(f'Running command {" ".join(cmd)}')
+        process = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        LOG.debug(f"Command finished. stdout={process.stdout}, stderr={process.stderr}")
+
     def revision_update_needed(
         self, application_name: str, model: str, status: dict | None = None
     ) -> bool:

--- a/sunbeam-python/sunbeam/features/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/openstack.py
@@ -412,6 +412,7 @@ class EnableOpenStackApplicationStep(BaseStep, JujuStepHelper):
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
         feature: OpenStackControlPlaneFeature,
+        app_desired_status: list[str] = ["active"],
     ) -> None:
         """Constructor for the generic plan.
 
@@ -426,6 +427,7 @@ class EnableOpenStackApplicationStep(BaseStep, JujuStepHelper):
         self.tfhelper = tfhelper
         self.jhelper = jhelper
         self.feature = feature
+        self.app_desired_status = app_desired_status
         self.model = OPENSTACK_MODEL
 
     def run(self, status: Status | None = None) -> Result:
@@ -449,9 +451,10 @@ class EnableOpenStackApplicationStep(BaseStep, JujuStepHelper):
         task = run_sync(update_status_background(self, apps, queue, status))
         try:
             run_sync(
-                self.jhelper.wait_until_active(
+                self.jhelper.wait_until_desired_status(
                     self.model,
                     apps,
+                    status=self.app_desired_status,
                     timeout=self.feature.set_application_timeout_on_enable(),
                     queue=queue,
                 )

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/main.tf
@@ -24,11 +24,6 @@ terraform {
   }
 }
 
-data "terraform_remote_state" "cos" {
-  backend = var.cos-state-backend
-  config  = var.cos-state-config
-}
-
 resource "juju_application" "grafana-agent" {
   name  = "grafana-agent"
   trust = false
@@ -62,6 +57,7 @@ resource "juju_integration" "principal-application-to-grafana-agent" {
 
 # juju integrate grafana-agent cos.prometheus-receive-remote-write
 resource "juju_integration" "grafana-agent-to-cos-prometheus" {
+  count = var.receive-remote-write-offer-url != null ? 1 : 0
   model = var.principal-application-model
 
   application {
@@ -69,12 +65,13 @@ resource "juju_integration" "grafana-agent-to-cos-prometheus" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.cos.outputs.prometheus-receive-remote-write-offer-url
+    offer_url = var.receive-remote-write-offer-url
   }
 }
 
 # juju integrate grafana-agent cos.loki-logging
 resource "juju_integration" "grafana-agent-to-cos-loki" {
+  count = var.logging-offer-url != null ? 1 : 0 
   model = var.principal-application-model
 
   application {
@@ -82,12 +79,13 @@ resource "juju_integration" "grafana-agent-to-cos-loki" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.cos.outputs.loki-logging-offer-url
+    offer_url = var.logging-offer-url
   }
 }
 
 # juju integrate grafana-agent cos.grafana-dashboards
 resource "juju_integration" "grafana-agent-to-cos-grafana" {
+  count = var.grafana-dashboard-offer-url != null ? 1 : 0
   model = var.principal-application-model
 
   application {
@@ -95,6 +93,6 @@ resource "juju_integration" "grafana-agent-to-cos-grafana" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.cos.outputs.grafana-dashboard-offer-url
+    offer_url = var.grafana-dashboard-offer-url
   }
 }

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/variables.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/variables.tf
@@ -44,12 +44,20 @@ variable "grafana-agent-config" {
   default     = {}
 }
 
-variable "cos-state-backend" {
-  description = "Backend type used for cos state"
+variable "receive-remote-write-offer-url" {
+  description = "Offer URL from prometheus-k8s:receive-remote-write application"
   type        = string
-  default     = "http"
+  default     = null
 }
 
-variable "cos-state-config" {
-  type = map(any)
+variable "grafana-dashboard-offer-url" {
+  description = "Offer URL from grafana-k8s:grafana-dashboard application"
+  type        = string
+  default     = null
+}
+
+variable "logging-offer-url" {
+  description = "Offer URL from loki-k8s:logging application"
+  type        = string
+  default     = null
 }

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
@@ -60,6 +60,12 @@ def ssnap():
         yield p
 
 
+@pytest.fixture()
+def update_config():
+    with patch("sunbeam.features.observability.feature.update_config") as p:
+        yield p
+
+
 class TestDeployObservabilityStackStep:
     def test_run(self, tfhelper, jhelper, observabilityfeature, ssnap):
         ssnap().config.get.return_value = "k8s"
@@ -155,9 +161,8 @@ class TestRemoveObservabilityStackStep:
 
 class TestDeployGrafanaAgentStep:
     def test_run(self, tfhelper, jhelper, observabilityfeature):
-        tfhelper_cos = Mock()
         step = observability_feature.DeployGrafanaAgentStep(
-            observabilityfeature, tfhelper, tfhelper_cos, jhelper
+            observabilityfeature, tfhelper, jhelper
         )
         result = step.run()
 
@@ -166,13 +171,12 @@ class TestDeployGrafanaAgentStep:
         assert result.result_type == ResultType.COMPLETED
 
     def test_run_tf_apply_failed(self, tfhelper, jhelper, observabilityfeature):
-        tfhelper_cos = Mock()
         tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
             "apply failed..."
         )
 
         step = observability_feature.DeployGrafanaAgentStep(
-            observabilityfeature, tfhelper, tfhelper_cos, jhelper
+            observabilityfeature, tfhelper, jhelper
         )
         result = step.run()
 
@@ -182,11 +186,10 @@ class TestDeployGrafanaAgentStep:
         assert result.message == "apply failed..."
 
     def test_run_waiting_timed_out(self, tfhelper, jhelper, observabilityfeature):
-        tfhelper_cos = Mock()
         jhelper.wait_application_ready.side_effect = TimeoutException("timed out")
 
         step = observability_feature.DeployGrafanaAgentStep(
-            observabilityfeature, tfhelper, tfhelper_cos, jhelper
+            observabilityfeature, tfhelper, jhelper
         )
         result = step.run()
 
@@ -197,7 +200,7 @@ class TestDeployGrafanaAgentStep:
 
 
 class TestRemoveGrafanaAgentStep:
-    def test_run(self, tfhelper, jhelper, observabilityfeature):
+    def test_run(self, tfhelper, jhelper, observabilityfeature, update_config):
         step = observability_feature.RemoveGrafanaAgentStep(
             observabilityfeature, tfhelper, jhelper
         )
@@ -236,41 +239,154 @@ class TestRemoveGrafanaAgentStep:
 
 class TestRemoveSaasApplicationsStep:
     def test_is_skip(self, jhelper):
-        jhelper.get_model.return_value = AsyncMock(
-            remote_applications={
-                "test-1": Mock(offer_url="admin/offering_model.test-1")
+        jhelper.get_model_status.return_value = {
+            "remote-applications": {
+                "test-1": {"offer-url": "admin/offering_model.test-1"},
+                "test-2": {"endpoints": [{"interface": "grafana_dashboard"}]},
+                "test-3": {"endpoints": [{"interface": "identity_credentials"}]},
             }
-        )
+        }
         step = observability_feature.RemoveSaasApplicationsStep(
-            jhelper, "test", "offering_model"
+            jhelper,
+            "test",
+            "offering_model",
+            observability_feature.OBSERVABILITY_OFFER_INTERFACES,
         )
         result = step.is_skip()
+        assert step._remote_app_to_delete == ["test-1", "test-2"]
         assert result.result_type == ResultType.COMPLETED
 
     def test_is_skip_no_remote_app(self, jhelper):
-        jhelper.get_model.return_value = AsyncMock(remote_applications={})
+        jhelper.get_model_status.return_value = {}
         step = observability_feature.RemoveSaasApplicationsStep(
-            jhelper, "test", "offering_model"
+            jhelper,
+            "test",
+            "offering_model",
+            observability_feature.OBSERVABILITY_OFFER_INTERFACES,
         )
         result = step.is_skip()
         assert result.result_type == ResultType.SKIPPED
 
     def test_is_skip_no_saas_app(self, jhelper):
-        jhelper.get_model.return_value = AsyncMock(
-            remote_applications={
-                "test-1": Mock(offer_url="admin/offering_model.test-1")
+        jhelper.get_model_status.return_value = {
+            "remote-applications": {
+                "test-1": {"offer-url": "admin/offering_model.test-1"},
+                "test-3": {"endpoints": [{"interface": "identity_credentials"}]},
             }
-        )
+        }
         step = observability_feature.RemoveSaasApplicationsStep(
-            jhelper, "test", "offering_model-no-apps"
+            jhelper,
+            "test",
+            "offering_model-no-apps",
+            observability_feature.OBSERVABILITY_OFFER_INTERFACES,
         )
         result = step.is_skip()
         assert result.result_type == ResultType.SKIPPED
 
     def test_run(self, jhelper):
         step = observability_feature.RemoveSaasApplicationsStep(
-            jhelper, "test", "offering_model"
+            jhelper,
+            "test",
+            "offering_model",
+            observability_feature.OBSERVABILITY_OFFER_INTERFACES,
         )
         step._remote_app_to_delete = ["test-1"]
         result = step.run()
         assert result.result_type == ResultType.COMPLETED
+
+
+class TestIntegrateRemoteCosOffersStep:
+    def test_run(self, jhelper, observabilityfeature, snap, run):
+        observabilityfeature.grafana_offer_url = "remotecos:admin/grafana"
+        observabilityfeature.prometheus_offer_url = "remotecos:admin/prometheus"
+        observabilityfeature.loki_offer_url = "remotecos:admin/loki"
+        observabilityfeature.deployment.openstack_machines_model = "test-model"
+        step = observability_feature.IntegrateRemoteCosOffersStep(
+            observabilityfeature, jhelper
+        )
+
+        result = step.run()
+        jhelper.wait_application_ready.assert_called()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_waiting_timedout(self, jhelper, observabilityfeature, snap, run):
+        jhelper.wait_application_ready.side_effect = TimeoutException("timed out")
+
+        observabilityfeature.grafana_offer_url = "remotecos:admin/grafana"
+        observabilityfeature.prometheus_offer_url = "remotecos:admin/prometheus"
+        observabilityfeature.loki_offer_url = "remotecos:admin/loki"
+        observabilityfeature.deployment.openstack_machines_model = "test-model"
+        step = observability_feature.IntegrateRemoteCosOffersStep(
+            observabilityfeature, jhelper
+        )
+
+        result = step.run()
+        jhelper.wait_application_ready.assert_called()
+        assert result.result_type == ResultType.FAILED
+        assert result.message == "timed out"
+
+
+class TestRemoveRemoteCosOffersStep:
+    def test_run(self, jhelper, observabilityfeature, snap, run):
+        observabilityfeature.deployment.openstack_machines_model = "test-model"
+        jhelper.get_model_status.side_effect = [
+            {
+                "relations": [
+                    {"key": "grafana-agent:logging-consumer loki:loki_push_api"}
+                ]
+            },
+            {
+                "relations": [
+                    {
+                        "key": "openstack-hypervisor:identity-service keystone:identity_service"
+                    }
+                ]
+            },
+        ]
+        step = observability_feature.RemoveRemoteCosOffersStep(
+            observabilityfeature, jhelper
+        )
+
+        result = step.run()
+        run.assert_called_once()
+        jhelper.wait_application_ready.assert_called()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_no_remote_offers(self, jhelper, observabilityfeature, snap, run):
+        observabilityfeature.deployment.openstack_machines_model = "test-model"
+        jhelper.get_model_status.side_effect = [{}, {}]
+        step = observability_feature.RemoveRemoteCosOffersStep(
+            observabilityfeature, jhelper
+        )
+
+        result = step.run()
+        run.assert_not_called()
+        jhelper.wait_application_ready.assert_called()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_waiting_timedout(self, jhelper, observabilityfeature, snap, run):
+        observabilityfeature.deployment.openstack_machines_model = "test-model"
+        jhelper.get_model_status.side_effect = [
+            {
+                "relations": [
+                    {"key": "grafana-agent:logging-consumer loki:loki_push_api"}
+                ]
+            },
+            {
+                "relations": [
+                    {
+                        "key": "openstack-hypervisor:identity-service keystone:identity_service"
+                    }
+                ]
+            },
+        ]
+        jhelper.wait_application_ready.side_effect = TimeoutException("timed out")
+        step = observability_feature.RemoveRemoteCosOffersStep(
+            observabilityfeature, jhelper
+        )
+
+        result = step.run()
+        run.assert_called_once()
+        jhelper.wait_application_ready.assert_called()
+        assert result.result_type == ResultType.FAILED
+        assert result.message == "timed out"

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_openstack.py
@@ -68,7 +68,7 @@ class TestEnableOpenStackApplicationStep:
         result = step.run()
 
         tfhelper.update_tfvars_and_apply_tf.assert_called_once()
-        jhelper.wait_until_active.assert_called_once()
+        jhelper.wait_until_desired_status.assert_called_once()
         assert result.result_type == ResultType.COMPLETED
 
     def test_run_tf_apply_failed(self, jhelper, tfhelper, osfeature):
@@ -80,18 +80,18 @@ class TestEnableOpenStackApplicationStep:
         result = step.run()
 
         tfhelper.update_tfvars_and_apply_tf.assert_called_once()
-        jhelper.wait_until_active.assert_not_called()
+        jhelper.wait_until_desired_status.assert_not_called()
         assert result.result_type == ResultType.FAILED
         assert result.message == "apply failed..."
 
     def test_run_waiting_timed_out(self, jhelper, tfhelper, osfeature):
-        jhelper.wait_until_active.side_effect = TimeoutException("timed out")
+        jhelper.wait_until_desired_status.side_effect = TimeoutException("timed out")
 
         step = openstack.EnableOpenStackApplicationStep(tfhelper, jhelper, osfeature)
         result = step.run()
 
         tfhelper.update_tfvars_and_apply_tf.assert_called_once()
-        jhelper.wait_until_active.assert_called_once()
+        jhelper.wait_until_desired_status.assert_called_once()
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
 


### PR DESCRIPTION
New Observability commands:
* Enable Observability with external COS:
`sunbeam enable observability external `

* Disable Observability with external COS:
`sunbeam disable observability external`

* Enable Observability with internal:
`sunbeam enable observability embedded`

* Disable Observability with internal:
`sunbeam disable observability embedded`

Backward compatible commands that are deprecated:
* Enable Observability with internal
`sunbeam enable observability`

* Disable Observability with internal
`sunbeam disable observability`