### PR TITLE
Support for external juju controller

### DIFF
--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -454,7 +454,7 @@ class ClusterAddJujuUserStep(BaseStep):
 class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
     """Save Juju controller in cluster database."""
 
-    def __init__(self, client: Client, controller: str):
+    def __init__(self, client: Client, controller: str, is_external: bool = False):
         super().__init__(
             "Add Juju controller to cluster DB",
             "Adding Juju controller to cluster database",
@@ -462,6 +462,7 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
 
         self.client = client
         self.controller = controller
+        self.is_external = is_external
 
     def _extract_ip(self, ip) -> Union[ipaddress.IPv4Address, ipaddress.IPv6Address]:
         """Extract ip from ipv4 or ipv6 ip:port."""
@@ -533,6 +534,7 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
             name=self.controller,
             api_endpoints=self.filter_ips(controller["api-endpoints"], self.networks),
             ca_cert=controller["ca-cert"],
+            is_external=self.is_external,
         )
         try:
             juju_controller.write(self.client)

--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -530,6 +530,7 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
         controller = self.get_controller(self.controller)["details"]
 
         juju_controller = JujuController(
+            name=self.controller,
             api_endpoints=self.filter_ips(controller["api-endpoints"], self.networks),
             ca_cert=controller["ca-cert"],
         )

--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -789,7 +789,7 @@ class RegisterJujuUserStep(BaseStep, JujuStepHelper):
 
     def __init__(
         self,
-        client: Client,
+        client: Client | None,
         name: str,
         controller: str,
         data_location: Path,
@@ -938,7 +938,6 @@ class RegisterRemoteJujuUserStep(RegisterJujuUserStep):
 
     def __init__(
         self,
-        client: Client,
         token: str,
         controller: str,
         data_location: Path,
@@ -946,7 +945,7 @@ class RegisterRemoteJujuUserStep(RegisterJujuUserStep):
     ):
         # User name not required to register a user. Pass empty string to
         # base class as user name
-        super().__init__(client, "", controller, data_location, replace)
+        super().__init__(None, "", controller, data_location, replace)
         self.registration_token = token
         self.account_file = f"{self.controller}.yaml"
 

--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -331,6 +331,17 @@ class JujuStepHelper:
         else:
             return False
 
+    def get_model_name_with_owner(self, model: str) -> str:
+        """Return model name with owner name.
+
+        :param model: Model name
+
+        Raises ModelNotFoundException if model does not exist.
+        """
+        model_with_owner = run_sync(self.jhelper.get_model_name_with_owner(model))
+
+        return model_with_owner
+
 
 class AddCloudJujuStep(BaseStep, JujuStepHelper):
     """Add cloud definition to juju client."""
@@ -700,9 +711,7 @@ class JujuGrantModelAccessStep(BaseStep, JujuStepHelper):
         :return:
         """
         try:
-            model_with_owner = run_sync(
-                self.jhelper.get_model_name_with_owner(self.model)
-            )
+            model_with_owner = self.get_model_name_with_owner(self.model)
             # Grant write access to the model
             # Without this step, the user is not able to view the model created
             # by other users.
@@ -1083,10 +1092,8 @@ class AddJujuMachineStep(BaseStep, JujuStepHelper):
                  ResultType.COMPLETED or ResultType.FAILED otherwise
         """
         try:
-            self.model_with_owner = run_sync(
-                self.jhelper.get_model_name_with_owner(self.model)
-            )
-        except Exception as e:
+            self.model_with_owner = self.get_model_name_with_owner(self.model)
+        except ModelNotFoundException as e:
             LOG.debug(str(e))
             return Result(ResultType.FAILED, "Model not found")
 

--- a/sunbeam-python/sunbeam/commands/juju_utils.py
+++ b/sunbeam-python/sunbeam/commands/juju_utils.py
@@ -19,6 +19,7 @@ import click
 from rich.console import Console
 from snaphelpers import Snap
 
+from sunbeam.clusterd.client import Client
 from sunbeam.commands.juju import RegisterRemoteJujuUserStep, UnregisterJujuController
 from sunbeam.jobs.common import run_plan
 from sunbeam.jobs.deployment import Deployment
@@ -40,7 +41,10 @@ console = Console()
 def register_controller(ctx: click.Context, name: str, token: str, force: bool) -> None:
     """Register existing Juju controller."""
     deployment: Deployment = ctx.obj
-    client = deployment.get_client()
+    try:
+        client = deployment.get_client()
+    except ValueError:
+        client = Client.from_socket()
     data_location = Snap().paths.user_data
 
     plan = [

--- a/sunbeam-python/sunbeam/commands/juju_utils.py
+++ b/sunbeam-python/sunbeam/commands/juju_utils.py
@@ -19,10 +19,8 @@ import click
 from rich.console import Console
 from snaphelpers import Snap
 
-from sunbeam.clusterd.client import Client
 from sunbeam.commands.juju import RegisterRemoteJujuUserStep, UnregisterJujuController
 from sunbeam.jobs.common import run_plan
-from sunbeam.jobs.deployment import Deployment
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -40,17 +38,8 @@ console = Console()
 @click.pass_context
 def register_controller(ctx: click.Context, name: str, token: str, force: bool) -> None:
     """Register existing Juju controller."""
-    deployment: Deployment = ctx.obj
-    try:
-        client = deployment.get_client()
-    except ValueError:
-        client = Client.from_socket()
     data_location = Snap().paths.user_data
-
-    plan = [
-        RegisterRemoteJujuUserStep(client, token, name, data_location, replace=force)
-    ]
-
+    plan = [RegisterRemoteJujuUserStep(token, name, data_location, replace=force)]
     run_plan(plan, console)
     console.print(f"Controller {name} registered")
 
@@ -61,8 +50,6 @@ def register_controller(ctx: click.Context, name: str, token: str, force: bool) 
 def unregister_controller(ctx: click.Context, name: str) -> None:
     """Unregister external Juju controller."""
     data_location = Snap().paths.user_data
-
     plan = [UnregisterJujuController(name, data_location)]
-
     run_plan(plan, console)
     console.print(f"Controller {name} unregistered")

--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -211,7 +211,7 @@ class AddMicrok8sCloudStep(BaseStep, JujuStepHelper):
         )
         self.client = client
         self.jhelper = jhelper
-        self.name = MICROK8S_CLOUD
+        self.cloud_name = MICROK8S_CLOUD
         self.credential_name = f"{MICROK8S_CLOUD}{CREDENTIAL_SUFFIX}"
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
@@ -223,7 +223,7 @@ class AddMicrok8sCloudStep(BaseStep, JujuStepHelper):
         clouds = run_sync(self.jhelper.get_clouds())
         LOG.debug(f"Clouds registered in the controller: {clouds}")
         # TODO(hemanth): Need to check if cloud credentials are also created?
-        if f"cloud-{self.name}" in clouds.keys():
+        if f"cloud-{self.cloud_name}" in clouds.keys():
             return Result(ResultType.SKIPPED)
 
         return Result(ResultType.COMPLETED)
@@ -233,7 +233,9 @@ class AddMicrok8sCloudStep(BaseStep, JujuStepHelper):
         try:
             kubeconfig = read_config(self.client, self._CONFIG)
             run_sync(
-                self.jhelper.add_k8s_cloud(self.name, self.credential_name, kubeconfig)
+                self.jhelper.add_k8s_cloud(
+                    self.cloud_name, self.credential_name, kubeconfig
+                )
             )
         except (ConfigItemNotFoundException, UnsupportedKubeconfigException) as e:
             LOG.debug("Failed to add k8s cloud to Juju controller", exc_info=True)

--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -137,10 +137,9 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         """Create terraform variables related to storage."""
         tfvars = {}
         if storage_nodes:
+            model_with_owner = self.get_model_name_with_owner(self.machine_model)
             tfvars["enable-ceph"] = True
-            tfvars["ceph-offer-url"] = (
-                f"admin/{self.machine_model}.{microceph.APPLICATION}"
-            )
+            tfvars["ceph-offer-url"] = f"{model_with_owner}.{microceph.APPLICATION}"
             tfvars["ceph-osd-replication-count"] = microceph.ceph_replica_scale(
                 len(storage_nodes)
             )

--- a/sunbeam-python/sunbeam/commands/utils.py
+++ b/sunbeam-python/sunbeam/commands/utils.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 import logging
-import secrets
-import string
 
 import click
 from rich.console import Console
@@ -44,9 +42,3 @@ def juju_login(ctx: click.Context) -> None:
     run_plan(plan, console)
 
     console.print("Juju re-login complete.")
-
-
-def random_string(length: int) -> str:
-    """Utility function to generate secure random string."""
-    alphabet = string.ascii_letters + string.digits
-    return "".join(secrets.choice(alphabet) for i in range(length))

--- a/sunbeam-python/sunbeam/jobs/checks.py
+++ b/sunbeam-python/sunbeam/jobs/checks.py
@@ -505,3 +505,28 @@ class TokenCheck(Check):
             return False
 
         return True
+
+
+class JujuControllerRegistrationCheck(Check):
+    """Check if juju controller is registered or not."""
+
+    def __init__(self, controller: str, data_location: Path):
+        super().__init__(
+            "Check Juju Controller registration",
+            "Checking if juju controller is registered",
+        )
+        self.controller = controller
+        self.data_location = data_location
+
+    def run(self) -> bool:
+        """Validate registration of juju controller.
+
+        Checks:
+            - Existence of accounts file for juju controller
+        """
+        account_file = self.data_location / f"{self.controller}.yaml"
+        if account_file.exists():
+            return True
+        else:
+            self.message = f"Juju controller {self.controller} is not registered."
+            return False

--- a/sunbeam-python/sunbeam/jobs/juju.py
+++ b/sunbeam-python/sunbeam/jobs/juju.py
@@ -202,6 +202,7 @@ class JujuAccount(pydantic.BaseModel):
 
 
 class JujuController(pydantic.BaseModel):
+    name: str
     api_endpoints: List[str]
     ca_cert: str
 
@@ -261,17 +262,22 @@ class JujuHelper:
                 raise ModelNotFoundException(f"Model {model!r} not found")
             raise e
 
-    async def add_model(self, model: str, config: dict | None = None) -> Model:
+    async def add_model(
+        self, model: str, cloud: str | None = None, config: dict | None = None
+    ) -> Model:
         """Add a model.
 
         :model: Name of the model
+        :cloud: Name of the cloud
         :config: model configuration
         """
         # TODO(gboutry): workaround until we manage public ssh keys properly
         old_home = os.environ["HOME"]
         os.environ["HOME"] = os.environ["SNAP_REAL_HOME"]
         try:
-            return await self.controller.add_model(model, config=config)
+            return await self.controller.add_model(
+                model, cloud_name=cloud, config=config
+            )
         finally:
             os.environ["HOME"] = old_home
 
@@ -1132,6 +1138,7 @@ class JujuHelper:
         cloud_yaml["clouds"][cloud_name] = {
             "type": "manual",
             "endpoint": ip_address,
+            "auth-types": ["empty"],
         }
         return cloud_yaml
 

--- a/sunbeam-python/sunbeam/jobs/juju.py
+++ b/sunbeam-python/sunbeam/jobs/juju.py
@@ -264,12 +264,17 @@ class JujuHelper:
             raise e
 
     async def add_model(
-        self, model: str, cloud: str | None = None, config: dict | None = None
+        self,
+        model: str,
+        cloud: str | None = None,
+        credential: str | None = None,
+        config: dict | None = None,
     ) -> Model:
         """Add a model.
 
         :model: Name of the model
         :cloud: Name of the cloud
+        :credential: Name of the credential
         :config: model configuration
         """
         # TODO(gboutry): workaround until we manage public ssh keys properly
@@ -277,7 +282,7 @@ class JujuHelper:
         os.environ["HOME"] = os.environ["SNAP_REAL_HOME"]
         try:
             return await self.controller.add_model(
-                model, cloud_name=cloud, config=config
+                model, cloud_name=cloud, credential_name=credential, config=config
             )
         finally:
             os.environ["HOME"] = old_home

--- a/sunbeam-python/sunbeam/jobs/steps.py
+++ b/sunbeam-python/sunbeam/jobs/steps.py
@@ -280,7 +280,7 @@ class RemoveMachineUnitStep(BaseStep):
     ):
         super().__init__(banner, description)
         self.client = client
-        self.name = name
+        self.node_name = name
         self.jhelper = jhelper
         self.config = config
         self.application = application
@@ -299,10 +299,10 @@ class RemoveMachineUnitStep(BaseStep):
                 ResultType.COMPLETED or ResultType.FAILED otherwise
         """
         try:
-            node = self.client.cluster.get_node_info(self.name)
+            node = self.client.cluster.get_node_info(self.node_name)
             self.machine_id = str(node.get("machineid"))
         except NodeNotExistInClusterException:
-            LOG.debug(f"Machine {self.name} does not exist, skipping.")
+            LOG.debug(f"Machine {self.node_name} does not exist, skipping.")
             return Result(ResultType.SKIPPED)
 
         try:

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -668,7 +668,7 @@ def join(
         ClusterJoinNodeStep(client, token, ip, name, roles_str),
         SaveJujuUserLocallyStep(name, data_location),
         RegisterJujuUserStep(client, name, deployment.controller, data_location),
-        AddJujuMachineStep(ip),
+        AddJujuMachineStep(ip, deployment.infrastructure_model),
     ]
     plan1_results = run_plan(plan1, console)
 
@@ -819,7 +819,7 @@ def remove(ctx: click.Context, name: str, force: bool) -> None:
             RemoveHypervisorUnitStep(
                 client, name, jhelper, deployment.openstack_machines_model, force
             ),
-            RemoveJujuMachineStep(client, name),
+            RemoveJujuMachineStep(client, name, deployment.infrastructure_model),
             # Cannot remove user as the same user name cannot be resued,
             # so commenting the RemoveJujuUserStep
             # RemoveJujuUserStep(name),

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -122,6 +122,10 @@ class LocalDeployment(Deployment):
     @property
     def controller(self) -> str:
         """Return the controller name."""
+        if self.juju_controller:
+            return self.juju_controller.name
+
+        # Juju controller not yet set, return defaults
         return CONTROLLER
 
     def get_client(self) -> Client:

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -117,12 +117,15 @@ class LocalDeployment(Deployment):
     @property
     def openstack_machines_model(self) -> str:
         """Return the openstack machines model name."""
+        if self.juju_controller and self.juju_controller.is_external:
+            return "openstack-machines"
+
         return "controller"
 
     @property
     def controller(self) -> str:
         """Return the controller name."""
-        if self.juju_controller:
+        if self.juju_controller and self.juju_controller.is_external:
             return self.juju_controller.name
 
         # Juju controller not yet set, return defaults

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -239,6 +239,18 @@ def list_machines_by_zone(client: MaasClient) -> dict[str, list[dict]]:
     return _group_machines_by_zone(machines_raw)
 
 
+def list_machines_by_matching_roles(client: MaasClient, roles: list[str]) -> list:
+    """List machines with given roles."""
+    filtered_machines = []
+    machines = list_machines(client)
+    for machine in machines:
+        machine_roles = set(machine["roles"]).intersection(RoleTags.values())
+        if machine_roles.intersection(roles):
+            filtered_machines.append(machine)
+
+    return filtered_machines
+
+
 def list_spaces(client: MaasClient) -> list[dict]:
     """List spaces in deployment, return consumable list of dicts."""
     spaces_raw = client.list_spaces()

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -239,18 +239,6 @@ def list_machines_by_zone(client: MaasClient) -> dict[str, list[dict]]:
     return _group_machines_by_zone(machines_raw)
 
 
-def list_machines_by_matching_roles(client: MaasClient, roles: list[str]) -> list:
-    """List machines with given roles."""
-    filtered_machines = []
-    machines = list_machines(client)
-    for machine in machines:
-        machine_roles = set(machine["roles"]).intersection(RoleTags.values())
-        if machine_roles.intersection(roles):
-            filtered_machines.append(machine)
-
-    return filtered_machines
-
-
 def list_spaces(client: MaasClient) -> list[dict]:
     """List spaces in deployment, return consumable list of dicts."""
     spaces_raw = client.list_spaces()

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -503,7 +503,12 @@ def deploy(
     plan = []
     plan.append(AddManifestStep(client, manifest_path))
     plan.append(
-        AddJujuModelStep(jhelper, deployment.openstack_machines_model, , deployment.name, proxy_settings)
+        AddJujuModelStep(
+            jhelper,
+            deployment.openstack_machines_model,
+            deployment.name,
+            proxy_settings,
+        )
     )
     plan.append(MaasAddMachinesToClusterdStep(client, maas_client))
     plan.append(

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -503,7 +503,7 @@ def deploy(
     plan = []
     plan.append(AddManifestStep(client, manifest_path))
     plan.append(
-        AddJujuModelStep(jhelper, deployment.openstack_machines_model, proxy_settings)
+        AddJujuModelStep(jhelper, deployment.openstack_machines_model, , deployment.name, proxy_settings)
     )
     plan.append(MaasAddMachinesToClusterdStep(client, maas_client))
     plan.append(

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -106,6 +106,10 @@ class MaasDeployment(Deployment):
     @property
     def controller(self) -> str:
         """Return controller name."""
+        if self.juju_controller:
+            return self.juju_controller.name
+
+        # Juju controller not yet set, return defaults
         return self.name + "-controller"
 
     @property

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -1104,6 +1104,7 @@ class MaasSaveControllerStep(BaseStep, JujuStepHelper):
             LOG.debug(str(e))
             return None
         return JujuController(
+            name=name,
             api_endpoints=controller["api-endpoints"],
             ca_cert=controller["ca-cert"],
         )

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -65,7 +65,6 @@ from sunbeam.jobs.common import (
 from sunbeam.jobs.deployment import CertPair, Networks
 from sunbeam.jobs.deployments import DeploymentsConfig
 from sunbeam.jobs.juju import (
-    CONTROLLER_MODEL,
     ActionFailedException,
     JujuHelper,
     JujuSecretNotFound,
@@ -2139,23 +2138,12 @@ class MaasUserQuestions(BaseStep):
 
 
 class MaasClusterStatusStep(ClusterStatusStep):
-    def _controller_model(self) -> str:
-        return CONTROLLER_MODEL.split("/")[1]
-
     def models(self) -> list[str]:
         """List of models to query status from."""
-        models = [
-            self._controller_model(),
+        return [
             self.deployment.infra_model,
             self.deployment.openstack_machines_model,
         ]
-        if (
-            self.deployment.juju_controller
-            and self.deployment.juju_controller.is_external
-        ):
-            models.remove(self._controller_model())
-
-        return models
 
     def _update_microcluster_status(self, status: dict, microcluster_status: dict):
         """How to update microcluster status in the status dict.

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -20,7 +20,9 @@ import ipaddress
 import json
 import logging
 import re
+import secrets
 import socket
+import string
 import sys
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -354,3 +356,9 @@ def get_local_cidr_matching_token(token: str) -> str:
         except ValueError:
             pass
     raise ValueError("No local networks found matching join token addresses.")
+
+
+def random_string(length: int) -> str:
+    """Utility function to generate secure random string."""
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for i in range(length))

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -362,3 +362,36 @@ def random_string(length: int) -> str:
     """Utility function to generate secure random string."""
     alphabet = string.ascii_letters + string.digits
     return "".join(secrets.choice(alphabet) for i in range(length))
+
+
+def first_connected_server(servers: list) -> str | None:
+    """Return first connected server from this node.
+
+    servers is expected to be of format ["<ip>:<port>", ...]
+    """
+    for server in servers:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        ip_port = server.rsplit(":", 1)
+        if len(ip_port) != 2:
+            LOG.debug(f"Server {server} not in <ip>:<port> format")
+            continue
+
+        ip = ipaddress.ip_address(ip_port[0])
+        port = int(ip_port[1])
+
+        try:
+            if isinstance(ip, ipaddress.IPv4Address):
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            else:
+                s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+
+            s.settimeout(30)  # 30 seconds timeout
+            s.connect((str(ip), port))
+            return server
+        except Exception as e:
+            LOG.debug(str(e))
+            LOG.debug(f"Not able to connect to {ip} {port}")
+        finally:
+            s.close()
+
+    return None

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_juju.py
@@ -293,6 +293,7 @@ class TestAddCloudJujuStep:
         assert result.result_type == ResultType.FAILED
 
     def test_run(self):
+        controller_name = "test-controller"
         cloud_name = "my-cloud"
         cloud_definition = {
             "clouds": {
@@ -302,17 +303,20 @@ class TestAddCloudJujuStep:
                 }
             }
         }
-        step = juju.AddCloudJujuStep(cloud_name, cloud_definition)
+        step = juju.AddCloudJujuStep(cloud_name, cloud_definition, controller_name)
 
         with patch.object(step, "add_cloud") as mock_add_cloud:
             mock_add_cloud.return_value = True
 
             result = step.run()
 
-        mock_add_cloud.assert_called_once_with("my-cloud", cloud_definition)
+        mock_add_cloud.assert_called_once_with(
+            "my-cloud", cloud_definition, controller_name
+        )
         assert result.result_type == ResultType.COMPLETED
 
     def test_run_when_exception_raised(self):
+        controller_name = "test-controller"
         cloud_name = "my-cloud"
         cloud_definition = {
             "clouds": {
@@ -322,7 +326,7 @@ class TestAddCloudJujuStep:
                 }
             }
         }
-        step = juju.AddCloudJujuStep(cloud_name, cloud_definition)
+        step = juju.AddCloudJujuStep(cloud_name, cloud_definition, controller_name)
 
         with patch.object(step, "add_cloud") as mock_add_cloud:
             mock_add_cloud.side_effect = subprocess.CalledProcessError(
@@ -331,7 +335,9 @@ class TestAddCloudJujuStep:
 
             result = step.run()
 
-        mock_add_cloud.assert_called_once_with("my-cloud", cloud_definition)
+        mock_add_cloud.assert_called_once_with(
+            "my-cloud", cloud_definition, controller_name
+        )
         assert result.result_type == ResultType.FAILED
 
 


### PR DESCRIPTION
Support external juju controllers in local and maas mode.

Bootstrap command will have new option --controller:
`sunbeam cluster bootstrap --role <> --manifest <> --accept-defaults --controller <controller name>`

Other significant changes:
* Role validation for juju controller nodes is removed from deployment validate command and added as part of preflight check for bootstrap command.