### PR TITLE
Segregate juju_controller and clusterd

### DIFF
--- a/sunbeam-python/sunbeam/commands/certificates.py
+++ b/sunbeam-python/sunbeam/commands/certificates.py
@@ -49,14 +49,6 @@ class DeployCertificatesProviderApplicationStep(BaseStep):
         self.model = model
         self.app = APPLICATION
 
-    def _get_controller_machines(self) -> list[str]:
-        """Get controller machines."""
-        controller = run_sync(self.jhelper.get_application("controller", self.model))
-        machines = []
-        for unit in controller.units:
-            machines.append(str(unit.machine.id))
-        return sorted(machines)
-
     def is_skip(self, status: Status | None = None) -> Result:
         """Check whether or not to deploy tls operator."""
         try:
@@ -66,12 +58,13 @@ class DeployCertificatesProviderApplicationStep(BaseStep):
         return Result(ResultType.SKIPPED)
 
     def run(self, status: Status | None = None) -> Result:
-        """Deploy sunbeam clusterd to controller machines."""
-        self.update_status(status, "fetching controller application")
-        machines = self._get_controller_machines()
+        """Deploy sunbeam clusterd to infra machines."""
+        self.update_status(status, "fetching infra machines")
+        clusterd_machines = run_sync(self.jhelper.get_machines(self.model))
+        machines = list(clusterd_machines.keys())
 
         if len(machines) == 0:
-            return Result(ResultType.FAILED, "No controller machines found")
+            return Result(ResultType.FAILED, f"No machines found in {self.model} model")
 
         # Deploy on first controller machine
         machines = machines[:1]

--- a/sunbeam-python/sunbeam/commands/cluster_status.py
+++ b/sunbeam-python/sunbeam/commands/cluster_status.py
@@ -80,7 +80,7 @@ def format_status(
 ) -> list[rich.console.RenderableType]:
     """Return a list renderables for the status.
 
-    Mandatory columns are always displayed on the infrastructure model, even if no
+    Mandatory columns are always displayed on the openstack machines model, even if no
     member of the cluster has that role.
 
     Status format is:
@@ -101,7 +101,7 @@ def format_status(
             column_set: set[str] = set()
             for status_name in model_status.values():
                 column_set.update(status_name.get("status", {}).keys())
-            if model == deployment.infrastructure_model:
+            if model == deployment.openstack_machines_model:
                 column_set.update(mandatory_columns)
             columns: list[str] = sorted(column_set, key=functools.cmp_to_key(_cmp))
             for column in columns:

--- a/sunbeam-python/sunbeam/commands/clusterd.py
+++ b/sunbeam-python/sunbeam/commands/clusterd.py
@@ -560,14 +560,6 @@ class DeploySunbeamClusterdApplicationStep(BaseStep):
         self.model = model
         self.app = APPLICATION
 
-    def _get_controller_machines(self) -> list[str]:
-        """Get controller machines."""
-        controller = run_sync(self.jhelper.get_application("controller", self.model))
-        machines = []
-        for unit in controller.units:
-            machines.append(str(unit.machine.id))
-        return sorted(machines)
-
     def is_skip(self, status: Status | None = None) -> Result:
         """Check wheter or not to deploy sunbeam-clusterd."""
         try:
@@ -577,14 +569,15 @@ class DeploySunbeamClusterdApplicationStep(BaseStep):
         return Result(ResultType.SKIPPED)
 
     def run(self, status: Status | None = None) -> Result:
-        """Deploy sunbeam clusterd to controller machines."""
-        self.update_status(status, "fetching controller application")
-        machines = self._get_controller_machines()
+        """Deploy sunbeam clusterd to infra machines."""
+        self.update_status(status, "fetching infra machines")
+        infra_machines = run_sync(self.jhelper.get_machines(self.model))
+        machines = list(infra_machines.keys())
 
         self.update_status(status, "computing number of units for sunbeam-clusterd")
         num_machines = len(machines)
         if num_machines == 0:
-            return Result(ResultType.FAILED, "No controller machines found")
+            return Result(ResultType.FAILED, f"No machines found in {self.model} model")
 
         num_units = num_machines
         self.update_status(status, "deploying application")

--- a/sunbeam-python/sunbeam/commands/inspect.py
+++ b/sunbeam-python/sunbeam/commands/inspect.py
@@ -63,7 +63,7 @@ def inspect(ctx: click.Context) -> None:
 
     plan = []
     with tempfile.TemporaryDirectory() as tmpdirname:
-        for model in [deployment.infrastructure_model, OPENSTACK_MODEL]:
+        for model in [deployment.openstack_machines_model, OPENSTACK_MODEL]:
             status_file = Path(tmpdirname) / f"juju_status_{model}.out"
             debug_file = Path(tmpdirname) / f"debug_log_{model}.out"
             plan.extend(

--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -1487,13 +1487,13 @@ class JujuLoginStep(BaseStep, JujuStepHelper):
         return Result(ResultType.COMPLETED)
 
 
-class AddInfrastructureModelStep(BaseStep):
-    """Add infrastructure model."""
+class AddJujuModelStep(BaseStep):
+    """Add model with configs."""
 
     def __init__(
         self, jhelper: JujuHelper, model: str, proxy_settings: dict | None = None
     ):
-        super().__init__("Add infrastructure model", "Adding infrastructure model")
+        super().__init__(f"Add model {model}", f"Adding model {model}")
         self.jhelper = jhelper
         self.model = model
         self.proxy_settings = proxy_settings or {}
@@ -1508,7 +1508,7 @@ class AddInfrastructureModelStep(BaseStep):
         return Result(ResultType.COMPLETED)
 
     def run(self, status: Optional["Status"] = None) -> Result:
-        """Add infrastructure model."""
+        """Add model with configs."""
         try:
             model_config = convert_proxy_to_model_configs(self.proxy_settings)
             run_sync(self.jhelper.add_model(self.model, config=model_config))

--- a/sunbeam-python/sunbeam/commands/proxy.py
+++ b/sunbeam-python/sunbeam/commands/proxy.py
@@ -95,7 +95,7 @@ def _update_proxy(proxy: dict, deployment: Deployment):
             deployment.get_tfhelper("sunbeam-machine-plan"),
             jhelper,
             manifest,
-            deployment.infrastructure_model,
+            deployment.openstack_machines_model,
             refresh=True,
             proxy_settings=proxy_settings,
         )
@@ -108,7 +108,7 @@ def _update_proxy(proxy: dict, deployment: Deployment):
     if deployment.type == MAAS_TYPE:
         plan.append(
             UpdateJujuModelConfigStep(
-                jhelper, deployment.infrastructure_model, model_config
+                jhelper, deployment.openstack_machines_model, model_config
             )
         )
     else:

--- a/sunbeam-python/sunbeam/commands/resize.py
+++ b/sunbeam-python/sunbeam/commands/resize.py
@@ -62,13 +62,13 @@ def resize(ctx: click.Context, topology: str, force: bool = False) -> None:
                     microceph_tfhelper,
                     jhelper,
                     manifest,
-                    deployment.infrastructure_model,
+                    deployment.openstack_machines_model,
                     refresh=True,
                 ),
                 SetCephMgrPoolSizeStep(
                     client,
                     jhelper,
-                    deployment.infrastructure_model,
+                    deployment.openstack_machines_model,
                 ),
             ]
         )
@@ -83,7 +83,7 @@ def resize(ctx: click.Context, topology: str, force: bool = False) -> None:
                 manifest,
                 topology,
                 "auto",
-                deployment.infrastructure_model,
+                deployment.openstack_machines_model,
                 force=force,
             ),
         ]

--- a/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/commands/upgrades/intra_channel.py
@@ -139,7 +139,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                 self.deployment.get_tfhelper("sunbeam-machine-plan"),
                 self.jhelper,
                 self.manifest,
-                self.deployment.infrastructure_model,
+                self.deployment.openstack_machines_model,
                 refresh=True,
             ),
         ]
@@ -154,7 +154,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                         self.deployment.get_tfhelper("k8s-plan"),
                         self.jhelper,
                         self.manifest,
-                        self.deployment.infrastructure_model,
+                        self.deployment.openstack_machines_model,
                         refresh=True,
                     ),
                 ]
@@ -169,7 +169,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                         self.deployment.get_tfhelper("microk8s-plan"),
                         self.jhelper,
                         self.manifest,
-                        self.deployment.infrastructure_model,
+                        self.deployment.openstack_machines_model,
                         refresh=True,
                     ),
                 ]
@@ -184,7 +184,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                     self.deployment.get_tfhelper("microceph-plan"),
                     self.jhelper,
                     self.manifest,
-                    self.deployment.infrastructure_model,
+                    self.deployment.openstack_machines_model,
                     refresh=True,
                 ),
                 TerraformInitStep(self.deployment.get_tfhelper("hypervisor-plan")),
@@ -193,7 +193,7 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                     self.deployment.get_tfhelper("hypervisor-plan"),
                     self.jhelper,
                     self.manifest,
-                    self.deployment.infrastructure_model,
+                    self.deployment.openstack_machines_model,
                 ),
                 UpgradeFeatures(self.deployment, upgrade_release=False),
             ]

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -265,7 +265,7 @@ class DeployGrafanaAgentStep(BaseStep, JujuStepHelper):
         self.jhelper = jhelper
         self.manifest = self.feature.manifest
         self.client = self.feature.deployment.get_client()
-        self.model = self.feature.deployment.infrastructure_model
+        self.model = self.feature.deployment.openstack_machines_model
 
     def run(self, status: Optional[Status] = None) -> Result:
         """Execute configuration using terraform."""
@@ -361,7 +361,7 @@ class RemoveGrafanaAgentStep(BaseStep, JujuStepHelper):
         self.tfhelper = tfhelper
         self.jhelper = jhelper
         self.manifest = self.feature.manifest
-        self.model = self.feature.deployment.infrastructure_model
+        self.model = self.feature.deployment.openstack_machines_model
 
     def run(self, status: Optional[Status] = None) -> Result:
         """Execute configuration using terraform."""
@@ -602,7 +602,7 @@ class ObservabilityFeature(OpenStackControlPlaneFeature):
             TerraformInitStep(tfhelper_grafana_agent),
             RemoveGrafanaAgentStep(self, tfhelper_grafana_agent, jhelper),
             RemoveSaasApplicationsStep(
-                jhelper, self.deployment.infrastructure_model, OBSERVABILITY_MODEL
+                jhelper, self.deployment.openstack_machines_model, OBSERVABILITY_MODEL
             ),
         ]
 

--- a/sunbeam-python/sunbeam/features/pro/feature.py
+++ b/sunbeam-python/sunbeam/features/pro/feature.py
@@ -210,7 +210,7 @@ class ProFeature(EnableDisableFeature):
                 jhelper,
                 self.manifest,
                 self.token,
-                self.deployment.infrastructure_model,
+                self.deployment.openstack_machines_model,
             ),
         ]
 

--- a/sunbeam-python/sunbeam/features/telemetry/feature.py
+++ b/sunbeam-python/sunbeam/features/telemetry/feature.py
@@ -107,7 +107,7 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                     tfhelper_hypervisor,
                     jhelper,
                     self.manifest,
-                    self.deployment.infrastructure_model,
+                    self.deployment.openstack_machines_model,
                 ),
             ]
         )
@@ -128,7 +128,7 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                 tfhelper_hypervisor,
                 jhelper,
                 self.manifest,
-                self.deployment.infrastructure_model,
+                self.deployment.openstack_machines_model,
             ),
         ]
 

--- a/sunbeam-python/sunbeam/jobs/deployment.py
+++ b/sunbeam-python/sunbeam/jobs/deployment.py
@@ -97,8 +97,8 @@ class Deployment(pydantic.BaseModel):
     _tfhelpers: dict[str, TerraformHelper] = pydantic.PrivateAttr(default={})
 
     @property
-    def infrastructure_model(self) -> str:
-        """Return the infrastructure model name."""
+    def openstack_machines_model(self) -> str:
+        """Return the openstack machines model name."""
         return NotImplemented
 
     @property

--- a/sunbeam-python/sunbeam/jobs/juju.py
+++ b/sunbeam-python/sunbeam/jobs/juju.py
@@ -54,6 +54,7 @@ from sunbeam.versions import JUJU_BASE
 
 LOG = logging.getLogger(__name__)
 CONTROLLER_MODEL = "admin/controller"
+CONTROLLER_APPLICATION = "controller"
 CONTROLLER = "sunbeam-controller"
 JUJU_CONTROLLER_KEY = "JujuController"
 ACCOUNT_FILE = "account.yaml"

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -341,7 +341,7 @@ def bootstrap(
     plan4.append(
         AddJujuSpaceStep(
             jhelper,
-            deployment.infrastructure_model,
+            deployment.openstack_machines_model,
             deployment.get_space(Networks.MANAGEMENT),
             [management_cidr],
         )
@@ -349,7 +349,7 @@ def bootstrap(
     plan4.append(
         UpdateJujuModelConfigStep(
             jhelper,
-            deployment.infrastructure_model,
+            deployment.openstack_machines_model,
             {
                 "default-space": deployment.get_space(Networks.MANAGEMENT),
             },
@@ -362,7 +362,7 @@ def bootstrap(
         # Binding controller's endpoints to the management space
         BindJujuApplicationStep(
             jhelper,
-            deployment.infrastructure_model,
+            deployment.openstack_machines_model,
             "controller",
             deployment.get_space(Networks.MANAGEMENT),
         )
@@ -378,14 +378,14 @@ def bootstrap(
             sunbeam_machine_tfhelper,
             jhelper,
             manifest,
-            deployment.infrastructure_model,
+            deployment.openstack_machines_model,
             refresh=True,
             proxy_settings=proxy_settings,
         )
     )
     plan4.append(
         AddSunbeamMachineUnitsStep(
-            client, fqdn, jhelper, deployment.infrastructure_model
+            client, fqdn, jhelper, deployment.openstack_machines_model
         )
     )
 
@@ -399,19 +399,19 @@ def bootstrap(
                 k8s_tfhelper,
                 jhelper,
                 manifest,
-                deployment.infrastructure_model,
+                deployment.openstack_machines_model,
                 accept_defaults=accept_defaults,
                 deployment_preseed=preseed,
             )
         )
         plan4.append(
-            AddK8SUnitsStep(client, fqdn, jhelper, deployment.infrastructure_model)
+            AddK8SUnitsStep(client, fqdn, jhelper, deployment.openstack_machines_model)
         )
         plan4.append(
-            EnableK8SFeatures(client, jhelper, deployment.infrastructure_model)
+            EnableK8SFeatures(client, jhelper, deployment.openstack_machines_model)
         )
         plan4.append(
-            StoreK8SKubeConfigStep(client, jhelper, deployment.infrastructure_model)
+            StoreK8SKubeConfigStep(client, jhelper, deployment.openstack_machines_model)
         )
         plan4.append(AddK8SCloudStep(client, jhelper))
     else:
@@ -424,16 +424,20 @@ def bootstrap(
                 k8s_tfhelper,
                 jhelper,
                 manifest,
-                deployment.infrastructure_model,
+                deployment.openstack_machines_model,
                 accept_defaults=accept_defaults,
                 deployment_preseed=preseed,
             )
         )
         plan4.append(
-            AddMicrok8sUnitsStep(client, fqdn, jhelper, deployment.infrastructure_model)
+            AddMicrok8sUnitsStep(
+                client, fqdn, jhelper, deployment.openstack_machines_model
+            )
         )
         plan4.append(
-            StoreMicrok8sConfigStep(client, jhelper, deployment.infrastructure_model)
+            StoreMicrok8sConfigStep(
+                client, jhelper, deployment.openstack_machines_model
+            )
         )
         plan4.append(AddMicrok8sCloudStep(client, jhelper))
 
@@ -447,14 +451,14 @@ def bootstrap(
             microceph_tfhelper,
             jhelper,
             manifest,
-            deployment.infrastructure_model,
+            deployment.openstack_machines_model,
         )
     )
 
     if is_storage_node:
         plan4.append(
             AddMicrocephUnitsStep(
-                client, fqdn, jhelper, deployment.infrastructure_model
+                client, fqdn, jhelper, deployment.openstack_machines_model
             )
         )
         plan4.append(
@@ -462,7 +466,7 @@ def bootstrap(
                 client,
                 fqdn,
                 jhelper,
-                deployment.infrastructure_model,
+                deployment.openstack_machines_model,
                 accept_defaults=accept_defaults,
                 deployment_preseed=preseed,
             )
@@ -479,7 +483,7 @@ def bootstrap(
                 manifest,
                 topology,
                 database,
-                deployment.infrastructure_model,
+                deployment.openstack_machines_model,
                 proxy_settings=proxy_settings,
             )
         )
@@ -493,7 +497,7 @@ def bootstrap(
                 microceph_tfhelper,
                 jhelper,
                 manifest,
-                deployment.infrastructure_model,
+                deployment.openstack_machines_model,
                 refresh=True,
             )
         )
@@ -519,13 +523,13 @@ def bootstrap(
             openstack_tfhelper,
             jhelper,
             manifest,
-            deployment.infrastructure_model,
+            deployment.openstack_machines_model,
         )
     )
     if is_compute_node:
         plan5.append(
             AddHypervisorUnitsStep(
-                client, fqdn, jhelper, deployment.infrastructure_model
+                client, fqdn, jhelper, deployment.openstack_machines_model
             )
         )
 
@@ -684,26 +688,28 @@ def join(
     plan2.append(ClusterUpdateNodeStep(client, name, machine_id=machine_id))
     plan2.append(
         AddSunbeamMachineUnitsStep(
-            client, name, jhelper, deployment.infrastructure_model
+            client, name, jhelper, deployment.openstack_machines_model
         ),
     )
 
     if is_control_node:
         if k8s_provider == "k8s":
             plan2.append(
-                AddK8SUnitsStep(client, name, jhelper, deployment.infrastructure_model)
+                AddK8SUnitsStep(
+                    client, name, jhelper, deployment.openstack_machines_model
+                )
             )
         else:
             plan2.append(
                 AddMicrok8sUnitsStep(
-                    client, name, jhelper, deployment.infrastructure_model
+                    client, name, jhelper, deployment.openstack_machines_model
                 )
             )
 
     if is_storage_node:
         plan2.append(
             AddMicrocephUnitsStep(
-                client, name, jhelper, deployment.infrastructure_model
+                client, name, jhelper, deployment.openstack_machines_model
             )
         )
         plan2.append(
@@ -711,7 +717,7 @@ def join(
                 client,
                 name,
                 jhelper,
-                deployment.infrastructure_model,
+                deployment.openstack_machines_model,
                 accept_defaults=accept_defaults,
                 deployment_preseed=preseed,
             )
@@ -721,13 +727,13 @@ def join(
         plan2.extend(
             [
                 AddHypervisorUnitsStep(
-                    client, name, jhelper, deployment.infrastructure_model
+                    client, name, jhelper, deployment.openstack_machines_model
                 ),
                 LocalSetHypervisorUnitsOptionsStep(
                     client,
                     name,
                     jhelper,
-                    deployment.infrastructure_model,
+                    deployment.openstack_machines_model,
                     join_mode=True,
                     deployment_preseed=preseed,
                 ),
@@ -788,28 +794,30 @@ def remove(ctx: click.Context, name: str, force: bool) -> None:
     plan = [
         JujuLoginStep(deployment.juju_account),
         RemoveSunbeamMachineStep(
-            client, name, jhelper, deployment.infrastructure_model
+            client, name, jhelper, deployment.openstack_machines_model
         ),
     ]
 
     if k8s_provider == "k8s":
         plan.append(
-            RemoveK8SUnitStep(client, name, jhelper, deployment.infrastructure_model)
+            RemoveK8SUnitStep(
+                client, name, jhelper, deployment.openstack_machines_model
+            )
         )
     else:
         plan.append(
             RemoveMicrok8sUnitStep(
-                client, name, jhelper, deployment.infrastructure_model
+                client, name, jhelper, deployment.openstack_machines_model
             )
         )
 
     plan.extend(
         [
             RemoveMicrocephUnitStep(
-                client, name, jhelper, deployment.infrastructure_model
+                client, name, jhelper, deployment.openstack_machines_model
             ),
             RemoveHypervisorUnitStep(
-                client, name, jhelper, deployment.infrastructure_model, force
+                client, name, jhelper, deployment.openstack_machines_model, force
             ),
             RemoveJujuMachineStep(client, name),
             # Cannot remove user as the same user name cannot be resued,
@@ -908,7 +916,7 @@ def configure_cmd(
             client,
             jhelper,
             ext_network=answer_file,
-            model=deployment.infrastructure_model,
+            model=deployment.openstack_machines_model,
         ),
     ]
     node = client.cluster.get_node_info(name)
@@ -919,7 +927,7 @@ def configure_cmd(
                 client,
                 name,
                 jhelper,
-                deployment.infrastructure_model,
+                deployment.openstack_machines_model,
                 # Accept preseed file but do not allow 'accept_defaults' as nic
                 # selection may vary from machine to machine and is potentially
                 # destructive if it takes over an unintended nic.

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -115,8 +115,8 @@ class LocalDeployment(Deployment):
         self.clusterd_certpair = self._load_cert_pair()
 
     @property
-    def infrastructure_model(self) -> str:
-        """Return the infrastructure model name."""
+    def openstack_machines_model(self) -> str:
+        """Return the openstack machines model name."""
         return "controller"
 
     @property

--- a/sunbeam-python/sunbeam/provider/local/steps.py
+++ b/sunbeam-python/sunbeam/provider/local/steps.py
@@ -193,7 +193,7 @@ class LocalSetHypervisorUnitsOptionsStep(SetHypervisorUnitsOptionsStep):
 class LocalClusterStatusStep(ClusterStatusStep):
     def models(self) -> list[str]:
         """List of models to query status from."""
-        return [self.deployment.infrastructure_model]
+        return [self.deployment.openstack_machines_model]
 
     @cache
     def _has_storage(self) -> bool:
@@ -215,7 +215,9 @@ class LocalClusterStatusStep(ClusterStatusStep):
     def _update_microcluster_status(self, status: dict, microcluster_status: dict):
         """How to update microcluster status in the status dict."""
         for member, member_status in microcluster_status.items():
-            for node_status in status[self.deployment.infrastructure_model].values():
+            for node_status in status[
+                self.deployment.openstack_machines_model
+            ].values():
                 if node_status.get("name") != member:
                     continue
                 node_status["clusterd-status"] = member_status

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -39,6 +39,7 @@ class RoleTags(enum.Enum):
     COMPUTE = "compute"
     STORAGE = "storage"
     JUJU_CONTROLLER = "juju-controller"
+    INFRA = "infra"
 
     @classmethod
     def values(cls) -> list[str]:
@@ -67,6 +68,9 @@ ROLE_NETWORK_MAPPING = {
         Networks.STORAGE_CLUSTER,
     ],
     RoleTags.JUJU_CONTROLLER: [
+        Networks.MANAGEMENT,
+    ],
+    RoleTags.INFRA: [
         Networks.MANAGEMENT,
     ],
 }
@@ -138,9 +142,14 @@ class MaasDeployment(Deployment):
         return AddMaasDeployment
 
     @property
-    def infrastructure_model(self) -> str:
-        """Return the infrastructure model name."""
+    def openstack_machines_model(self) -> str:
+        """Return the openstack machines model name."""
         return "openstack-machines"
+
+    @property
+    def infra_model(self) -> str:
+        """Return the openstack infra model name."""
+        return "openstack-infra"
 
     def get_client(self) -> Client:
         """Return a client for the deployment."""

--- a/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
@@ -633,21 +633,21 @@ class TestDeploySunbeamClusterdApplicationStep:
         result = step.is_skip()
         assert result.result_type == ResultType.SKIPPED
 
-    def test_run_when_no_controller_machines_found(self, manifest, model):
+    def test_run_when_no_machines_found(self, manifest, model):
         jhelper = AsyncMock()
         jhelper.get_application.return_value = AsyncMock()
+        jhelper.get_machines.return_value = {}
         step = DeploySunbeamClusterdApplicationStep(jhelper, manifest, model)
-        step._get_controller_machines = MagicMock(return_value=[])
         result = step.run()
         assert result.result_type == ResultType.FAILED
-        assert result.message == "No controller machines found"
+        assert result.message == f"No machines found in {model} model"
 
-    def test_run_when_controller_machines_found(self, manifest, model):
+    def test_run_when_machines_found(self, manifest, model):
         jhelper = AsyncMock()
         jhelper.get_application.return_value = AsyncMock()
+        jhelper.get_machines.return_value = {"1": "m1", "2": "m2", "3": "m3"}
         manifest.software.charms = {"sunbeam-clusterd": Mock(config={})}
         step = DeploySunbeamClusterdApplicationStep(jhelper, manifest, model)
-        step._get_controller_machines = MagicMock(return_value=["1", "2", "3"])
         result = step.run()
         assert result.result_type == ResultType.COMPLETED
 


### PR DESCRIPTION
Currently clusterd, tls apps are running on juju_controller nodes.
Deploy clusterd, tls apps on different nodes.

Create new role/tag 'infra'
Create new model openstack-infra to deploy nodes with tag infra
Deploy Clusterd and tls-operator application on infra model machines