### PR TITLE
Add minimum role check for infra node

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -851,6 +851,13 @@ class DeploymentTopologyCheck(DiagnosticsCheck):
         )
         checks.append(
             DeploymentRolesCheck(
+                self.machines,
+                "juju controllers",
+                maas_deployment.RoleTags.INFRA.value,
+            )
+        )
+        checks.append(
+            DeploymentRolesCheck(
                 self.machines, "control nodes", maas_deployment.RoleTags.CONTROL.value
             )
         )


### PR DESCRIPTION
Add minimum role check for infra node so
that validate command shows a diagnostics failure
message when no infra nodes are present.