### PR TITLE
Make PatchLoadBalancerServicesStep an abstract class

### DIFF
--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ipaddress
 import logging
 from typing import Optional
 
@@ -36,6 +35,11 @@ from sunbeam.jobs.juju import (
     UnsupportedKubeconfigException,
     run_sync,
 )
+from sunbeam.jobs.k8s import (
+    MICROK8S_CLOUD,
+    MICROK8S_KUBECONFIG_KEY,
+    validate_cidr_or_ip_range,
+)
 from sunbeam.jobs.manifest import Manifest
 from sunbeam.jobs.steps import (
     AddMachineUnitsStep,
@@ -44,34 +48,12 @@ from sunbeam.jobs.steps import (
 )
 
 LOG = logging.getLogger(__name__)
-MICROK8S_CLOUD = "sunbeam-microk8s"
 APPLICATION = "microk8s"
 MICROK8S_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
 MICROK8S_UNIT_TIMEOUT = 1200  # 20 minutes, adding / removing units can take a long time
 CREDENTIAL_SUFFIX = "-creds"
-MICROK8S_DEFAULT_STORAGECLASS = "microk8s-hostpath"
-MICROK8S_KUBECONFIG_KEY = "Microk8sConfig"
 MICROK8S_CONFIG_KEY = "TerraformVarsMicrok8s"
 MICROK8S_ADDONS_CONFIG_KEY = "TerraformVarsMicrok8sAddons"
-METALLB_ANNOTATION = "metallb.universe.tf/loadBalancerIPs"
-
-
-def validate_cidr_or_ip_range(ip_ranges: str):
-    for ip_range in ip_ranges.split(","):
-        ips = ip_range.split("-")
-        if len(ips) == 1:
-            if "/" not in ips[0]:
-                raise ValueError(
-                    "Invalid CIDR definition, must be in the form 'ip/mask'"
-                )
-            ipaddress.ip_network(ips[0])
-        elif len(ips) == 2:
-            ipaddress.ip_address(ips[0])
-            ipaddress.ip_address(ips[1])
-        else:
-            raise ValueError(
-                "Invalid IP range, must be in the form of 'ip-ip' or 'cidr'"
-            )
 
 
 def microk8s_addons_questions():

--- a/sunbeam-python/sunbeam/features/dns/feature.py
+++ b/sunbeam-python/sunbeam/features/dns/feature.py
@@ -21,7 +21,7 @@ from packaging.version import Version
 from rich.console import Console
 
 from sunbeam.clusterd.service import ClusterServiceUnavailableException
-from sunbeam.commands.openstack import OPENSTACK_MODEL, PatchLoadBalancerServicesStep
+from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.commands.terraform import TerraformInitStep
 from sunbeam.features.interface.v1.openstack import (
     ApplicationChannelData,
@@ -33,6 +33,7 @@ from sunbeam.jobs.common import run_plan
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import JujuHelper, run_sync
 from sunbeam.jobs.manifest import AddManifestStep, CharmManifest, SoftwareConfig
+from sunbeam.jobs.steps import PatchLoadBalancerServicesStep
 from sunbeam.versions import BIND_CHANNEL, OPENSTACK_CHANNEL
 
 LOG = logging.getLogger(__name__)
@@ -40,7 +41,13 @@ console = Console()
 
 
 class PatchBindLoadBalancerStep(PatchLoadBalancerServicesStep):
-    SERVICES = ["bind"]
+    def services(self) -> list[str]:
+        """List of services to patch."""
+        return ["bind"]
+
+    def model(self) -> str:
+        """Name of the model to use."""
+        return OPENSTACK_MODEL
 
 
 class DnsFeature(OpenStackControlPlaneFeature):

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -30,8 +30,8 @@ from rich.status import Status
 
 from sunbeam.clusterd.service import ClusterServiceUnavailableException
 from sunbeam.commands.juju import JujuStepHelper
-from sunbeam.commands.k8s import CREDENTIAL_SUFFIX, K8SHelper
-from sunbeam.commands.openstack import OPENSTACK_MODEL, PatchLoadBalancerServicesStep
+from sunbeam.commands.k8s import CREDENTIAL_SUFFIX
+from sunbeam.commands.openstack import OPENSTACK_MODEL
 from sunbeam.commands.terraform import (
     TerraformException,
     TerraformHelper,
@@ -54,6 +54,7 @@ from sunbeam.jobs.common import (
 )
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import JujuHelper, JujuWaitException, TimeoutException, run_sync
+from sunbeam.jobs.k8s import K8SHelper
 from sunbeam.jobs.manifest import (
     AddManifestStep,
     CharmManifest,
@@ -61,6 +62,7 @@ from sunbeam.jobs.manifest import (
     SoftwareConfig,
     TerraformManifest,
 )
+from sunbeam.jobs.steps import PatchLoadBalancerServicesStep
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -388,8 +390,13 @@ class RemoveGrafanaAgentStep(BaseStep, JujuStepHelper):
 
 
 class PatchCosLoadBalancerStep(PatchLoadBalancerServicesStep):
-    SERVICES = ["traefik"]
-    MODEL = OBSERVABILITY_MODEL
+    def services(self) -> list[str]:
+        """List of services to patch."""
+        return ["traefik"]
+
+    def model(self) -> str:
+        """Name of the model to use."""
+        return OBSERVABILITY_MODEL
 
 
 class ObservabilityFeature(OpenStackControlPlaneFeature):

--- a/sunbeam-python/sunbeam/jobs/k8s.py
+++ b/sunbeam-python/sunbeam/jobs/k8s.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import ipaddress
+import logging
+
+from snaphelpers import Snap
+
+from sunbeam.jobs.common import SunbeamException
+
+LOG = logging.getLogger(__name__)
+
+# --- Microk8s specific
+MICROK8S_CLOUD = "sunbeam-microk8s"
+MICROK8S_KUBECONFIG_KEY = "Microk8sConfig"
+MICROK8S_DEFAULT_STORAGECLASS = "microk8s-hostpath"
+METALLB_ANNOTATION = "metallb.universe.tf/loadBalancerIPs"
+
+# --- K8s specific
+K8S_CLOUD = "sunbeam-k8s"
+K8S_DEFAULT_STORAGECLASS = "csi-rawfile-default"
+K8S_KUBECONFIG_KEY = "K8SKubeConfig"
+SERVICE_LB_ANNOTATION = "io.cilium/lb-ipam-ips"
+
+SUPPORTED_K8S_PROVIDERS = ["k8s", "microk8s"]
+
+
+def validate_cidr_or_ip_range(ip_ranges: str):
+    for ip_range in ip_ranges.split(","):
+        ips = ip_range.split("-")
+        if len(ips) == 1:
+            if "/" not in ips[0]:
+                raise ValueError(
+                    "Invalid CIDR definition, must be in the form 'ip/mask'"
+                )
+            ipaddress.ip_network(ips[0])
+        elif len(ips) == 2:
+            ipaddress.ip_address(ips[0])
+            ipaddress.ip_address(ips[1])
+        else:
+            raise ValueError(
+                "Invalid IP range, must be in the form of 'ip-ip' or 'cidr'"
+            )
+
+
+class K8SHelper:
+    """K8S Helper that provides cloud constants."""
+
+    @classmethod
+    def get_provider(cls) -> str:
+        """Return k8s provider from snap settings."""
+        provider = Snap().config.get("k8s.provider")
+        if provider not in SUPPORTED_K8S_PROVIDERS:
+            raise SunbeamException(
+                f"k8s provider should be one of {SUPPORTED_K8S_PROVIDERS}"
+            )
+
+        return provider
+
+    @classmethod
+    def get_cloud(cls) -> str:
+        """Return cloud name matching provider."""
+        match cls.get_provider():
+            case "k8s":
+                return K8S_CLOUD
+            case _:
+                return MICROK8S_CLOUD
+
+    @classmethod
+    def get_default_storageclass(cls) -> str:
+        """Return storageclass matching provider."""
+        match cls.get_provider():
+            case "k8s":
+                return K8S_DEFAULT_STORAGECLASS
+            case _:
+                return MICROK8S_DEFAULT_STORAGECLASS
+
+    @classmethod
+    def get_kubeconfig_key(cls) -> str:
+        """Return kubeconfig key matching provider."""
+        match cls.get_provider():
+            case "k8s":
+                return K8S_KUBECONFIG_KEY
+            case _:
+                return MICROK8S_KUBECONFIG_KEY
+
+    @classmethod
+    def get_loadbalancer_annotation(cls) -> str:
+        """Return loadbalancer annotation matching provider."""
+        match cls.get_provider():
+            case "k8s":
+                return SERVICE_LB_ANNOTATION
+            case _:
+                return METALLB_ANNOTATION

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -91,7 +91,7 @@ from sunbeam.commands.mysql import ConfigureMySQLStep
 from sunbeam.commands.openstack import (
     OPENSTACK_MODEL,
     DeployControlPlaneStep,
-    PatchLoadBalancerServicesStep,
+    OpenStackPatchLoadBalancerServicesStep,
     PromptRegionStep,
 )
 from sunbeam.commands.proxy import PromptForProxyStep
@@ -508,7 +508,7 @@ def bootstrap(
 
     if is_control_node:
         plan5.append(ConfigureMySQLStep(jhelper))
-        plan5.append(PatchLoadBalancerServicesStep(client))
+        plan5.append(OpenStackPatchLoadBalancerServicesStep(client))
 
     # NOTE(jamespage):
     # As with MicroCeph, always deploy the openstack-hypervisor charm

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -73,7 +73,7 @@ from sunbeam.commands.mysql import ConfigureMySQLStep
 from sunbeam.commands.openstack import (
     OPENSTACK_MODEL,
     DeployControlPlaneStep,
-    PatchLoadBalancerServicesStep,
+    OpenStackPatchLoadBalancerServicesStep,
     PromptRegionStep,
 )
 from sunbeam.commands.proxy import PromptForProxyStep
@@ -669,7 +669,7 @@ def deploy(
         )
     )
     plan2.append(ConfigureMySQLStep(jhelper))
-    plan2.append(PatchLoadBalancerServicesStep(client))
+    plan2.append(OpenStackPatchLoadBalancerServicesStep(client))
     plan2.append(TerraformInitStep(tfhelper_hypervisor_deploy))
     plan2.append(
         DeployHypervisorApplicationStep(

--- a/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/plugins/test_observability.py
@@ -56,7 +56,7 @@ def observabilityfeature():
 
 @pytest.fixture()
 def ssnap():
-    with patch("sunbeam.commands.k8s.Snap") as p:
+    with patch("sunbeam.jobs.k8s.Snap") as p:
         yield p
 
 


### PR DESCRIPTION
Make PatchLoadBalancerServicesStep an abstract class to allow easy overridable of services / models. This is needed because traefik-rgw is conditional.

sunbeam.jobs should never import anything from commands, both a as design choice and to prevent import loops. Extract k8s helper to the jobs package.