### PR TITLE
Make cloud names unique instead of constants

### DIFF
--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -36,7 +36,8 @@ from sunbeam.jobs.juju import (
     run_sync,
 )
 from sunbeam.jobs.k8s import (
-    MICROK8S_CLOUD,
+    CREDENTIAL_SUFFIX,
+    K8S_CLOUD_SUFFIX,
     MICROK8S_KUBECONFIG_KEY,
     validate_cidr_or_ip_range,
 )
@@ -51,7 +52,6 @@ LOG = logging.getLogger(__name__)
 APPLICATION = "microk8s"
 MICROK8S_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
 MICROK8S_UNIT_TIMEOUT = 1200  # 20 minutes, adding / removing units can take a long time
-CREDENTIAL_SUFFIX = "-creds"
 MICROK8S_CONFIG_KEY = "TerraformVarsMicrok8s"
 MICROK8S_ADDONS_CONFIG_KEY = "TerraformVarsMicrok8sAddons"
 
@@ -205,14 +205,14 @@ class RemoveMicrok8sUnitStep(RemoveMachineUnitStep):
 class AddMicrok8sCloudStep(BaseStep, JujuStepHelper):
     _CONFIG = MICROK8S_KUBECONFIG_KEY
 
-    def __init__(self, client: Client, jhelper: JujuHelper):
+    def __init__(self, deployment: Deployment, jhelper: JujuHelper):
         super().__init__(
             "Add MicroK8S cloud", "Adding MicroK8S cloud to Juju controller"
         )
-        self.client = client
+        self.client = deployment.get_client()
         self.jhelper = jhelper
-        self.cloud_name = MICROK8S_CLOUD
-        self.credential_name = f"{MICROK8S_CLOUD}{CREDENTIAL_SUFFIX}"
+        self.cloud_name = f"{deployment.name}{K8S_CLOUD_SUFFIX}"
+        self.credential_name = f"{self.cloud_name}{CREDENTIAL_SUFFIX}"
 
     def is_skip(self, status: Optional[Status] = None) -> Result:
         """Determines if the step should be skipped or not.

--- a/sunbeam-python/sunbeam/commands/openstack.py
+++ b/sunbeam-python/sunbeam/commands/openstack.py
@@ -24,7 +24,6 @@ import sunbeam.commands.microceph as microceph
 from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.commands.juju import JujuStepHelper
-from sunbeam.commands.k8s import CREDENTIAL_SUFFIX
 from sunbeam.commands.terraform import TerraformException, TerraformHelper
 from sunbeam.jobs.common import (
     RAM_32_GB_IN_KB,
@@ -37,8 +36,9 @@ from sunbeam.jobs.common import (
     update_config,
     update_status_background,
 )
+from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import JujuHelper, JujuWaitException, TimeoutException, run_sync
-from sunbeam.jobs.k8s import K8SHelper
+from sunbeam.jobs.k8s import CREDENTIAL_SUFFIX, K8SHelper
 from sunbeam.jobs.manifest import Manifest
 from sunbeam.jobs.questions import (
     PromptQuestion,
@@ -107,7 +107,7 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
 
     def __init__(
         self,
-        client: Client,
+        deployment: Deployment,
         tfhelper: TerraformHelper,
         jhelper: JujuHelper,
         manifest: Manifest,
@@ -121,7 +121,7 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
             "Deploying OpenStack Control Plane",
             "Deploying OpenStack Control Plane to Kubernetes (this may take a while)",
         )
-        self.client = client
+        self.client = deployment.get_client()
         self.tfhelper = tfhelper
         self.jhelper = jhelper
         self.manifest = manifest
@@ -131,7 +131,7 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         self.proxy_settings = proxy_settings or {}
         self.force = force
         self.model = OPENSTACK_MODEL
-        self.cloud = K8SHelper.get_cloud()
+        self.cloud = K8SHelper.get_cloud(deployment.name)
 
     def get_storage_tfvars(self, storage_nodes: list[dict]) -> dict:
         """Create terraform variables related to storage."""

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -97,7 +97,7 @@ class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
         self.manifest = self.feature.manifest
         self.client = self.feature.deployment.get_client()
         self.model = OBSERVABILITY_MODEL
-        self.cloud = K8SHelper.get_cloud()
+        self.cloud = K8SHelper.get_cloud(self.feature.deployment.name)
 
     def run(self, status: Optional[Status] = None) -> Result:
         """Execute configuration using terraform."""
@@ -165,7 +165,7 @@ class UpdateObservabilityModelConfigStep(BaseStep, JujuStepHelper):
         self.manifest = self.feature.manifest
         self.client = self.feature.deployment.get_client()
         self.model = OBSERVABILITY_MODEL
-        self.cloud = K8SHelper.get_cloud()
+        self.cloud = K8SHelper.get_cloud(self.feature.deployment.name)
 
     def run(self, status: Optional[Status] = None) -> Result:
         """Execute configuration using terraform."""
@@ -325,7 +325,7 @@ class RemoveObservabilityStackStep(BaseStep, JujuStepHelper):
         self.manifest = self.feature.manifest
         self.jhelper = jhelper
         self.model = OBSERVABILITY_MODEL
-        self.cloud = K8SHelper.get_cloud()
+        self.cloud = K8SHelper.get_cloud(self.feature.deployment.name)
 
     def run(self, status: Optional[Status] = None) -> Result:
         """Execute configuration using terraform."""

--- a/sunbeam-python/sunbeam/hooks.py
+++ b/sunbeam-python/sunbeam/hooks.py
@@ -22,8 +22,6 @@ from sunbeam.log import setup_logging
 
 LOG = logging.getLogger(__name__)
 DEFAULT_CONFIG = {
-    "juju.cloud.type": "manual",
-    "juju.cloud.name": "sunbeam",
     "daemon.group": "snap_daemon",
     "daemon.debug": False,
     "k8s.provider": "microk8s",

--- a/sunbeam-python/sunbeam/jobs/deployments.py
+++ b/sunbeam-python/sunbeam/jobs/deployments.py
@@ -145,6 +145,15 @@ class DeploymentsConfig(pydantic.BaseModel):
         self.active = name
         self.write()
 
+    def get_minimal_info(self) -> dict:
+        """Get deployments config with minimal information."""
+        self_dict = self.model_dump()
+        # self_dict has deployments with Deployment dict but not of provider
+        # so workaround to add each deployment based on provider
+        deployments = [d.model_dump(include={"name", "type"}) for d in self.deployments]
+        self_dict["deployments"] = deployments
+        return self_dict
+
 
 def deployment_path(snap: Snap) -> Path:
     """Path to deployments configuration."""

--- a/sunbeam-python/sunbeam/jobs/k8s.py
+++ b/sunbeam-python/sunbeam/jobs/k8s.py
@@ -22,18 +22,18 @@ from sunbeam.jobs.common import SunbeamException
 LOG = logging.getLogger(__name__)
 
 # --- Microk8s specific
-MICROK8S_CLOUD = "sunbeam-microk8s"
 MICROK8S_KUBECONFIG_KEY = "Microk8sConfig"
 MICROK8S_DEFAULT_STORAGECLASS = "microk8s-hostpath"
 METALLB_ANNOTATION = "metallb.universe.tf/loadBalancerIPs"
 
 # --- K8s specific
-K8S_CLOUD = "sunbeam-k8s"
 K8S_DEFAULT_STORAGECLASS = "csi-rawfile-default"
 K8S_KUBECONFIG_KEY = "K8SKubeConfig"
 SERVICE_LB_ANNOTATION = "io.cilium/lb-ipam-ips"
 
 SUPPORTED_K8S_PROVIDERS = ["k8s", "microk8s"]
+CREDENTIAL_SUFFIX = "-creds"
+K8S_CLOUD_SUFFIX = "-k8s"
 
 
 def validate_cidr_or_ip_range(ip_ranges: str):
@@ -69,13 +69,9 @@ class K8SHelper:
         return provider
 
     @classmethod
-    def get_cloud(cls) -> str:
+    def get_cloud(cls, deployment_name: str) -> str:
         """Return cloud name matching provider."""
-        match cls.get_provider():
-            case "k8s":
-                return K8S_CLOUD
-            case _:
-                return MICROK8S_CLOUD
+        return f"{deployment_name}{K8S_CLOUD_SUFFIX}"
 
     @classmethod
     def get_default_storageclass(cls) -> str:

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -15,6 +15,7 @@
 
 import logging
 
+import petname
 import pydantic
 import snaphelpers
 from rich.console import Console
@@ -61,7 +62,7 @@ LOCAL_TYPE = "local"
 
 
 class LocalDeployment(Deployment):
-    name: str = "local"
+    name: str = petname.Generate()
     url: str = "local"
     type: str = LOCAL_TYPE
     _client: Client | None = pydantic.PrivateAttr(default=None)

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -631,7 +631,7 @@ def deploy(
         plan2.append(
             StoreK8SKubeConfigStep(client, jhelper, deployment.openstack_machines_model)
         )
-        plan2.append(AddK8SCloudStep(client, jhelper))
+        plan2.append(AddK8SCloudStep(deployment, jhelper))
     else:
         plan2.append(
             MaasDeployMicrok8sApplicationStep(
@@ -656,7 +656,7 @@ def deploy(
                 client, jhelper, deployment.openstack_machines_model
             )
         )
-        plan2.append(AddMicrok8sCloudStep(client, jhelper))
+        plan2.append(AddMicrok8sCloudStep(deployment, jhelper))
 
     plan2.append(TerraformInitStep(tfhelper_microceph))
     plan2.append(
@@ -686,7 +686,7 @@ def deploy(
     plan2.append(TerraformInitStep(tfhelper_openstack_deploy))
     plan2.append(
         DeployControlPlaneStep(
-            client,
+            deployment,
             tfhelper_openstack_deploy,
             jhelper,
             manifest,

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -1127,16 +1127,15 @@ class MaasSaveControllerStep(SaveControllerStep):
 
     def __init__(
         self,
-        controller: str,
+        controller: str | None,
         deployment_name: str,
         deployments_config: DeploymentsConfig,
         data_location: Path,
         is_external: bool = False,
     ):
-        self.deployment_name = deployment_name
-        self.deployments_config = deployments_config
-        deployment = self.deployments_config.get_deployment(self.deployment_name)
-        super().__init__(deployment, controller, data_location, is_external)
+        super().__init__(
+            controller, deployment_name, deployments_config, data_location, is_external
+        )
 
     def is_skip(self, status: Status | None = None) -> Result:
         """Determines if the step should be skipped or not."""
@@ -1144,12 +1143,6 @@ class MaasSaveControllerStep(SaveControllerStep):
             return Result(ResultType.SKIPPED)
 
         return super().is_skip(status)
-
-    def run(self, status: Status | None) -> Result:
-        """Save controller to deployment information."""
-        super().run(status)
-        self.deployments_config.write()
-        return Result(ResultType.COMPLETED)
 
 
 class MaasSaveClusterdCredentialsStep(BaseStep):

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_k8s.py
@@ -21,7 +21,7 @@ import pytest
 from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.commands.k8s import (
     CREDENTIAL_SUFFIX,
-    K8S_CLOUD,
+    K8S_CLOUD_SUFFIX,
     AddK8SCloudStep,
     StoreK8SKubeConfigStep,
 )
@@ -53,35 +53,37 @@ class TestAddK8SCloudStep(unittest.TestCase):
         super().__init__(methodName)
 
     def setUp(self):
-        self.client = Mock(cluster=Mock(get_config=Mock(return_value="{}")))
+        self.deployment = Mock()
+        self.cloud_name = f"{self.deployment.name}{K8S_CLOUD_SUFFIX}"
+        self.deployment.get_client().cluster.get_config.return_value = "{}"
         self.jhelper = AsyncMock()
 
     def test_is_skip(self):
         clouds = {}
         self.jhelper.get_clouds.return_value = clouds
 
-        step = AddK8SCloudStep(self.client, self.jhelper)
+        step = AddK8SCloudStep(self.deployment, self.jhelper)
         result = step.is_skip()
 
         assert result.result_type == ResultType.COMPLETED
 
     def test_is_skip_cloud_already_deployed(self):
-        clouds = {"cloud-sunbeam-k8s": {"endpoint": "10.0.10.1"}}
+        clouds = {f"cloud-{self.cloud_name}": {"endpoint": "10.0.10.1"}}
         self.jhelper.get_clouds.return_value = clouds
 
-        step = AddK8SCloudStep(self.client, self.jhelper)
+        step = AddK8SCloudStep(self.deployment, self.jhelper)
         result = step.is_skip()
 
         assert result.result_type == ResultType.SKIPPED
 
     def test_run(self):
         with patch("sunbeam.commands.k8s.read_config", Mock(return_value={})):
-            step = AddK8SCloudStep(self.client, self.jhelper)
+            step = AddK8SCloudStep(self.deployment, self.jhelper)
             result = step.run()
 
         self.jhelper.add_k8s_cloud.assert_called_with(
-            K8S_CLOUD,
-            f"{K8S_CLOUD}{CREDENTIAL_SUFFIX}",
+            self.cloud_name,
+            f"{self.cloud_name}{CREDENTIAL_SUFFIX}",
             {},
         )
         assert result.result_type == ResultType.COMPLETED

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_openstack.py
@@ -67,8 +67,8 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         self.jhelper.run_action.return_value = {}
         self.tfhelper = Mock()
         self.manifest = Mock()
-        self.client = Mock()
-        self.client.cluster.list_nodes_by_role.side_effect = [
+        self.deployment = Mock()
+        self.deployment.get_client().cluster.list_nodes_by_role.side_effect = [
             [{"name": f"control-{i}"} for i in range(4)],
             [{"name": f"storage-{i}"} for i in range(4)],
         ]
@@ -84,7 +84,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         )
 
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,
@@ -108,7 +108,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         )
 
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,
@@ -131,7 +131,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         self.jhelper.wait_until_active.side_effect = TimeoutException("timed out")
 
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,
@@ -156,7 +156,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         )
 
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,
@@ -177,7 +177,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
     def test_is_skip_pristine(self):
         self.snap_mock().config.get.return_value = "k8s"
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,
@@ -196,7 +196,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
     def test_is_skip_subsequent_run(self):
         self.snap_mock().config.get.return_value = "k8s"
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,
@@ -215,7 +215,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
     def test_is_skip_database_changed(self):
         self.snap_mock().config.get.return_value = "k8s"
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,
@@ -234,7 +234,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
     def test_is_skip_incompatible_topology(self):
         self.snap_mock().config.get.return_value = "k8s"
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,
@@ -256,7 +256,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
     def test_is_skip_force_incompatible_topology(self):
         self.snap_mock().config.get.return_value = "k8s"
         step = DeployControlPlaneStep(
-            self.client,
+            self.deployment,
             self.tfhelper,
             self.jhelper,
             self.manifest,


### PR DESCRIPTION
* Add petname as deployment name to LocalDeployment
* Add the deployment as active in bootstrap command
* Use deployment name as cloud name for manual cloud
* Use deployment name as cloud name prefix for k8s cloud and k8s credentials
* Remove snap params juju.cloud.type, juju.cloud.name
* Save juju information in deployments.yaml for local mode