### PR TITLE
Return empty list if there are no controllers

### DIFF
--- a/sunbeam-python/sunbeam/commands/juju.py
+++ b/sunbeam-python/sunbeam/commands/juju.py
@@ -163,7 +163,7 @@ class JujuStepHelper:
         if clouds is None, return all the controllers.
         """
         controllers = self._juju_cmd("controllers")
-        controllers = controllers.get("controllers", {})
+        controllers = controllers.get("controllers", {}) or {}
         if clouds is None:
             return list(controllers.keys())
 


### PR DESCRIPTION
Update get_controller() to return empty list
if there are no controllers.