### PR TITLE
Add credential to controller for non primary node users

### DIFF
--- a/sunbeam-python/sunbeam/commands/microk8s.py
+++ b/sunbeam-python/sunbeam/commands/microk8s.py
@@ -23,6 +23,7 @@ from rich.status import Status
 from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.commands.juju import JujuStepHelper
+from sunbeam.commands.k8s import AddK8SCredentialStep
 from sunbeam.commands.terraform import TerraformHelper
 from sunbeam.jobs import questions
 from sunbeam.jobs.common import BaseStep, Result, ResultType, read_config, update_config
@@ -242,6 +243,10 @@ class AddMicrok8sCloudStep(BaseStep, JujuStepHelper):
             return Result(ResultType.FAILED, str(e))
 
         return Result(ResultType.COMPLETED)
+
+
+class AddMicrok8sCredentialStep(AddK8SCredentialStep):
+    _KUBECONFIG = MICROK8S_KUBECONFIG_KEY
 
 
 class StoreMicrok8sConfigStep(BaseStep, JujuStepHelper):

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -76,6 +76,7 @@ from sunbeam.commands.juju import (
 )
 from sunbeam.commands.k8s import (
     AddK8SCloudStep,
+    AddK8SCredentialStep,
     AddK8SUnitsStep,
     DeployK8SApplicationStep,
     EnableK8SFeatures,
@@ -90,6 +91,7 @@ from sunbeam.commands.microceph import (
 )
 from sunbeam.commands.microk8s import (
     AddMicrok8sCloudStep,
+    AddMicrok8sCredentialStep,
     AddMicrok8sUnitsStep,
     DeployMicrok8sApplicationStep,
     RemoveMicrok8sUnitStep,
@@ -857,12 +859,14 @@ def join(
                     client, name, jhelper, deployment.openstack_machines_model
                 )
             )
+            plan4.append(AddK8SCredentialStep(deployment, jhelper))
         else:
             plan4.append(
                 AddMicrok8sUnitsStep(
                     client, name, jhelper, deployment.openstack_machines_model
                 )
             )
+            plan4.append(AddMicrok8sCredentialStep(deployment, jhelper))
 
     if is_storage_node:
         plan4.append(


### PR DESCRIPTION
Sunbeam creates juju user per node. Add k8s credential to juju controller as part of join command. This will allow the user to be able to create a model on k8s.