### PR TITLE
Allow passing a list of comma separated roles

### DIFF
--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -284,12 +284,19 @@ def get_step_message(plan_results: dict, step: Type[BaseStep]) -> Any:
 
 
 def validate_roles(
-    ctx: click.core.Context, param: click.core.Option, value: tuple
+    ctx: click.core.Context, param: click.core.Option, value: Sequence[str]
 ) -> list[Role]:
+    """Validate roles."""
+    roles: set[str] = set()
+    for val in value:
+        roles.update(val.split(","))
     try:
-        return [Role[role.upper()] for role in value]
+        return [Role[role.upper()] for role in roles]
     except KeyError as e:
-        raise click.BadParameter(str(e))
+        raise click.BadParameter(
+            f"{str(e)}. Valid choices are "
+            + ", ".join(role.lower() for role in Role.__members__)
+        ) from e
 
 
 def get_host_total_ram() -> int:

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -215,10 +215,10 @@ class LocalProvider(ProviderBase):
     "roles",
     multiple=True,
     default=["control", "compute"],
-    type=click.Choice(["control", "compute", "storage"], case_sensitive=False),
     callback=validate_roles,
     help="Specify additional roles, compute or storage, for the "
-    "bootstrap node. Defaults to the compute role.",
+    "bootstrap node. Defaults to the compute role."
+    " Can be repeated and comma separated.",
 )
 @click_option_topology
 @click.option(
@@ -748,9 +748,12 @@ def add(ctx: click.Context, name: str, format: str) -> None:
     "roles",
     multiple=True,
     default=["control", "compute"],
-    type=click.Choice(["control", "compute", "storage"], case_sensitive=False),
     callback=validate_roles,
-    help="Specify which roles the node will be assigned in the cluster.",
+    help=(
+        f"Specify which roles ({', '.join(role.lower() for role in Role.__members__)})"
+        " the node will be assigned in the cluster."
+        " Can be repeated and comma separated."
+    ),
 )
 @click.pass_context
 def join(


### PR DESCRIPTION
Now, roles can be assigned by either repeating or passing a comma separated list or both.

![image](https://github.com/user-attachments/assets/9afd0f0e-013d-4737-9149-179c5131c0a5)
![image](https://github.com/user-attachments/assets/0747e6c5-275f-42fd-88c3-0d0e1cb2ab0b)
