### PR TITLE
Make required options arguments

### DIFF
--- a/sunbeam-python/sunbeam/commands/inspect.py
+++ b/sunbeam-python/sunbeam/commands/inspect.py
@@ -36,6 +36,7 @@ from sunbeam.jobs.common import (
 )
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import JujuHelper
+from sunbeam.utils import argument_with_deprecated_option
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -122,11 +123,8 @@ def plans(ctx: click.Context, format: str):
 
 
 @inspect.command()
-@click.option(
-    "--plan",
-    type=str,
-    prompt=True,
-    help="Name of the terraform plan to unlock.",
+@argument_with_deprecated_option(
+    "plan", type=str, help="Name of the terraform plan to unlock."
 )
 @click.option("--force", is_flag=True, default=False, help="Force unlock the plan.")
 @click.pass_context

--- a/sunbeam-python/sunbeam/commands/manifest.py
+++ b/sunbeam-python/sunbeam/commands/manifest.py
@@ -30,6 +30,7 @@ from sunbeam.clusterd.service import (
 from sunbeam.jobs.common import FORMAT_TABLE, FORMAT_YAML
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.manifest import Manifest
+from sunbeam.utils import argument_with_deprecated_option
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -104,12 +105,12 @@ def list(ctx: click.Context, format: str) -> None:
 
 
 @click.command()
-@click.option("--id", type=str, prompt=True, help="Manifest ID")
+@argument_with_deprecated_option("id", type=str, help="Manifest ID")
 @click.pass_context
 def show(ctx: click.Context, id: str) -> None:
     """Show Manifest data.
 
-    Use '--id=latest' to get the last committed manifest.
+    Use ID 'latest' to get the last committed manifest.
     """
     deployment: Deployment = ctx.obj
     client = deployment.get_client()

--- a/sunbeam-python/sunbeam/features/dns/feature.py
+++ b/sunbeam-python/sunbeam/features/dns/feature.py
@@ -33,6 +33,7 @@ from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import JujuHelper, run_sync
 from sunbeam.jobs.manifest import AddManifestStep, CharmManifest, SoftwareConfig
 from sunbeam.jobs.steps import PatchLoadBalancerServicesStep
+from sunbeam.utils import argument_with_deprecated_option
 from sunbeam.versions import BIND_CHANNEL, OPENSTACK_CHANNEL
 
 LOG = logging.getLogger(__name__)
@@ -136,17 +137,22 @@ class DnsFeature(OpenStackControlPlaneFeature):
         return {}
 
     @click.command()
-    @click.option(
-        "--nameservers",
-        required=True,
-        help="""
+    @argument_with_deprecated_option(
+        "nameservers",
+        type=str,
+        help="""\
         Space delimited list of nameservers. These are the nameservers that
         have been provided to the domain registrar in order to delegate
         the domain to DNS service. e.g. "ns1.example.com. ns2.example.com."
         """,
     )
     def enable_feature(self, nameservers: str) -> None:
-        """Enable dns service."""
+        """Enable dns service.
+
+        NAMESERVERS: Space delimited list of nameservers. These are the nameservers that
+        have been provided to the domain registrar in order to delegate
+        the domain to DNS service. e.g. "ns1.example.com. ns2.example.com."
+        """
         nameservers_split = nameservers.split()
         for nameserver in nameservers_split:
             if nameserver[-1] != ".":

--- a/sunbeam-python/sunbeam/features/pro/feature.py
+++ b/sunbeam-python/sunbeam/features/pro/feature.py
@@ -36,6 +36,7 @@ from sunbeam.jobs.common import BaseStep, Result, ResultType, run_plan
 from sunbeam.jobs.deployment import Deployment
 from sunbeam.jobs.juju import JujuHelper, TimeoutException, run_sync
 from sunbeam.jobs.manifest import Manifest, SoftwareConfig, TerraformManifest
+from sunbeam.utils import argument_with_deprecated_option
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -239,11 +240,8 @@ class ProFeature(EnableDisableFeature):
         click.echo("Ubuntu Pro disabled.")
 
     @click.command()
-    @click.option(
-        "-t",
-        "--token",
-        help="Ubuntu Pro token to use for subscription attachment",
-        prompt=True,
+    @argument_with_deprecated_option(
+        "token", type=str, short_form="t", help="Ubuntu Pro token"
     )
     def enable_feature(self, token: str) -> None:
         """Enable Ubuntu Pro across deployment.

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -153,7 +153,7 @@ from sunbeam.provider.local.steps import (
     LocalClusterStatusStep,
     LocalSetHypervisorUnitsOptionsStep,
 )
-from sunbeam.utils import CatchGroup
+from sunbeam.utils import CatchGroup, argument_with_deprecated_option
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -702,18 +702,7 @@ def _write_to_file(token: str, output: Path):
 
 
 @click.command()
-@click.argument(
-    # TODO(gboutry): remove required=False when option is fully removed
-    "name",
-    required=False,
-    type=str,
-)
-@click.option(
-    "--name",
-    "name_param",
-    type=str,
-    help="Fully qualified node name. Deprecated, use argument.",
-)
+@argument_with_deprecated_option("name", type=str, help="Fully qualified node name.")
 @click.option(
     "-f",
     "--format",
@@ -736,8 +725,7 @@ def _write_to_file(token: str, output: Path):
 @click.pass_context
 def add(
     ctx: click.Context,
-    name: str | None,
-    name_param: str | None,
+    name: str,
     format: str,
     output: Path | None,
 ) -> None:
@@ -745,17 +733,6 @@ def add(
 
     NAME must be a fully qualified domain name.
     """
-    if name and name_param:
-        raise click.ClickException("Name cannot be passed as argument and option")
-    elif not name:
-        if name_param is None:
-            raise click.ClickException("Name is required")
-        LOG.debug(
-            "Using name from option. This behavior is deprecated."
-            " Please use argument."
-        )
-        name = name_param
-
     preflight_checks = [DaemonGroupCheck(), VerifyFQDNCheck(name)]
     run_preflight_checks(preflight_checks, console)
     name = remove_trailing_dot(name)
@@ -798,15 +775,7 @@ def add(
 
 
 @click.command()
-@click.argument(
-    # TODO(gboutry): remove required=False when option is fully removed
-    "token",
-    required=False,
-    type=str,
-)
-@click.option(
-    "--token", "token_param", type=str, help="Join token. Deprecated, use argument."
-)
+@argument_with_deprecated_option("token", type=str, help="Join token.")
 @click.option("-a", "--accept-defaults", help="Accept all defaults.", is_flag=True)
 @click.option(
     "--role",
@@ -823,8 +792,7 @@ def add(
 @click.pass_context
 def join(
     ctx: click.Context,
-    token: str | None,
-    token_param: str | None,
+    token: str,
     roles: list[Role],
     accept_defaults: bool = False,
 ) -> None:
@@ -833,17 +801,6 @@ def join(
     Join the node to the cluster.
     Use `-` as token to read from stdin.
     """
-    if token and token_param:
-        raise click.ClickException("Token cannot be passed as argument and option")
-    elif not token:
-        if token_param is None:
-            raise click.ClickException("Token is required")
-        LOG.debug(
-            "Using token from option. This behavior is deprecated."
-            " Please use argument."
-        )
-        token = token_param
-
     if token == "-":
         token = click.get_text_stream("stdin").readline().strip()
     is_control_node = any(role.is_control_node() for role in roles)
@@ -1031,7 +988,7 @@ def list_nodes(
     help=("Skip safety checks and ignore cleanup errors for some tasks"),
     is_flag=True,
 )
-@click.option("--name", type=str, prompt=True, help="Fully qualified node name")
+@argument_with_deprecated_option("name", type=str, help="Fully qualified node name.")
 @click.pass_context
 def remove(ctx: click.Context, name: str, force: bool) -> None:
     """Remove a node from the cluster."""

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -158,7 +158,7 @@ from sunbeam.provider.maas.steps import (
     MachineStorageCheck,
     NetworkMappingCompleteCheck,
 )
-from sunbeam.utils import CatchGroup
+from sunbeam.utils import CatchGroup, argument_with_deprecated_option
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -860,9 +860,9 @@ def list_nodes(ctx: click.Context, format: str) -> None:
 
 
 @click.command("maas")
-@click.option("-n", "--name", type=str, prompt=True, help="Name of the deployment")
-@click.option("-t", "--token", type=str, prompt=True, help="API token")
-@click.option("-u", "--url", type=str, prompt=True, help="API URL")
+@argument_with_deprecated_option("name", type=str, help="Name of the deployment")
+@argument_with_deprecated_option("token", type=str, help="API token")
+@argument_with_deprecated_option("url", type=str, help="API URL")
 def add_maas(name: str, token: str, url: str) -> None:
     """Add MAAS-backed deployment to registered deployments."""
     preflight_checks = [


### PR DESCRIPTION
Required options are actually arguments, make them arguments, keep a backward compatible option for each.

sunbeam manifest show:
```
$ sunbeam manifest show -h
Usage: sunbeam manifest show [OPTIONS] [ID]

  Show Manifest data.

  Use ID 'latest' to get the last committed manifest.

Options:
  --id TEXT   Manifest ID. Deprecated, use argument instead
  -h, --help  Show this message and exit.
```

sunbeam enable dns:
```
$ sunbeam enable dns -h
Usage: sunbeam enable dns [OPTIONS] [NAMESERVERS]

  Enable dns service.

  NAMESERVERS: Space delimited list of nameservers. These are the nameservers
  that have been provided to the domain registrar in order to delegate the
  domain to DNS service. e.g. "ns1.example.com. ns2.example.com."

Options:
  --nameservers TEXT  Space delimited list of nameservers. These are the
                      nameservers that have been provided to the domain
                      registrar in order to delegate the domain to DNS
                      service. e.g. "ns1.example.com. ns2.example.com." .
                      Deprecated, use argument instead
  -h, --help          Show this message and exit.
```

add deployment type maas:

```
$ sunbeam deployment add maas -h
Usage: sunbeam deployment add maas [OPTIONS] [NAME] [TOKEN] [URL]

  Add MAAS-backed deployment to registered deployments.

Options:
  --name TEXT   Name of the deployment. Deprecated, use argument instead
  --token TEXT  API token. Deprecated, use argument instead
  --url TEXT    API URL. Deprecated, use argument instead
  -h, --help    Show this message and exit.
```

sunbeam cluster remove:
```
$ sunbeam cluster remove -h
Usage: sunbeam cluster remove [OPTIONS] [NAME]

  Remove a node from the cluster.

Options:
  --force      Skip safety checks and ignore cleanup errors for some tasks
  --name TEXT  Fully qualified node name.. Deprecated, use argument instead
  -h, --help   Show this message and exit.
```