### PR TITLE
caas: Update tfhelper env with admin credentials

### DIFF
--- a/sunbeam-python/sunbeam/features/caas/feature.py
+++ b/sunbeam-python/sunbeam/features/caas/feature.py
@@ -223,7 +223,7 @@ class CaasFeature(OpenStackControlPlaneFeature):
         admin_credentials = retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)
 
         tfhelper = self.deployment.get_tfhelper(self.configure_plan)
-        tfhelper.env = admin_credentials
+        tfhelper.env = (tfhelper.env or {}) | admin_credentials
         plan = [
             TerraformInitStep(tfhelper),
             CaasConfigureStep(

--- a/sunbeam-python/sunbeam/jobs/common.py
+++ b/sunbeam-python/sunbeam/jobs/common.py
@@ -361,7 +361,7 @@ async def update_status_background(
     """
     if status is None:
         return asyncio.create_task(asyncio.sleep(0))
-    apps = {app: False for app in applications}
+    apps = dict.fromkeys(applications, False)
     nb_apps = len(applications)
     message = (
         step.status + "waiting for services to come online ({nb_active_apps}/{nb_apps})"

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -168,7 +168,7 @@ class TestMachineNetworkCheck:
         snap = Mock()
         mocker.patch(
             "sunbeam.provider.maas.client.get_network_mapping",
-            return_value={network: "alpha" for network in Networks.values()},
+            return_value=dict.fromkeys(Networks.values(), "alpha"),
         )
         machine = {"hostname": "test_machine", "roles": [], "spaces": []}
         check = MachineNetworkCheck(snap, machine)


### PR DESCRIPTION
Update tfhelper.env instead of replacing the environment. The environment can contain the credentials to access the state backend.