### PR TITLE
tests: fix test warnings

### DIFF
--- a/sunbeam-python/tests/unit/sunbeam/commands/test_microceph.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_microceph.py
@@ -109,6 +109,7 @@ class TestSetCephMgrPoolSizeStep:
         assert result.result_type == ResultType.COMPLETED
 
     def test_run(self, cclient, jhelper):
+        jhelper.run_action.return_value = Mock()
         step = SetCephMgrPoolSizeStep(cclient, jhelper, "test-model")
         result = step.run()
 

--- a/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
@@ -54,10 +54,8 @@ class TestClusterdSteps:
         init_step = ClusterInitStep(cclient, [role], 0, "10.0.0.0/16")
         init_step.client = MagicMock()
         init_step.fqdn = "node1"
-        with mocker.patch(
-            "sunbeam.utils.get_local_ip_by_cidr", return_value="10.0.0.2"
-        ):
-            result = init_step.run()
+        mocker.patch("sunbeam.utils.get_local_ip_by_cidr", return_value="10.0.0.2")
+        result = init_step.run()
         assert result.result_type == ResultType.COMPLETED
         init_step.client.cluster.bootstrap.assert_called_once()
 


### PR DESCRIPTION
Fix 2 warnings in tests because of improper usage of test mocks.