### PR TITLE
Increase microceph app timeout

### DIFF
--- a/sunbeam-python/sunbeam/steps/microceph.py
+++ b/sunbeam-python/sunbeam/steps/microceph.py
@@ -44,9 +44,11 @@ LOG = logging.getLogger(__name__)
 CONFIG_KEY = "TerraformVarsMicrocephPlan"
 CONFIG_DISKS_KEY = "TerraformVarsMicroceph"
 APPLICATION = "microceph"
-MICROCEPH_APP_TIMEOUT = 540  # 9 minutes, updating rgw configs can take some time
+# Timeout set to 20 minutes instead of 9 minutes due to bug
+# https://github.com/canonical/charm-microceph/issues/113
+MICROCEPH_APP_TIMEOUT = 1200  # updating rgw configs can take some time
 MICROCEPH_UNIT_TIMEOUT = (
-    1200  # 15 minutes, adding / removing units can take a long time
+    1200  # 20 minutes, adding / removing units can take a long time
 )
 
 


### PR DESCRIPTION
Increase microceph app timeout to 20 minutes.
This is due to bug [1] where sometimes miroceph
bootstrap for an event might take 10 minutes.

[1] https://github.com/canonical/charm-microceph/issues/113