### PR TITLE
Add curl install to prepare_node.py to cater for Ubuntu Desktop

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -45,15 +45,13 @@ sudo grep -r $USER /etc/{{sudoers,sudoers.d}} | grep NOPASSWD:ALL &> /dev/null |
     rm -f /tmp/90-$USER-sudo-access
 }}
 
-# Ensure OpenSSH server is installed
-dpkg -s openssh-server &> /dev/null || {{
-    sudo apt install -y openssh-server
-}}
-
-# Ensure Curl is installed
-dpkg -s curl &> /dev/null || {{
-    sudo apt install -y curl
-}}
+# Ensure pre-reqs - e.g. OpenSSH server are installed
+PREREQ_DPKGS=("curl" "openssh-server")
+for pkg in ${PREREQ_DPKS[@]}; do
+  dpkg -s $pkg &> /dev/null || {
+    sudo apt install -y $pkg
+  }
+done
 
 # Add $USER to the snap_daemon group supporting interaction
 # with the sunbeam clustering daemon for cluster operations.

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -50,6 +50,11 @@ dpkg -s openssh-server &> /dev/null || {{
     sudo apt install -y openssh-server
 }}
 
+# Ensure Curl is installed
+dpkg -s curl &> /dev/null || {{
+    sudo apt install -y curl
+}}
+
 # Add $USER to the snap_daemon group supporting interaction
 # with the sunbeam clustering daemon for cluster operations.
 sudo usermod --append --groups snap_daemon $USER

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -45,13 +45,15 @@ sudo grep -r $USER /etc/{{sudoers,sudoers.d}} | grep NOPASSWD:ALL &> /dev/null |
     rm -f /tmp/90-$USER-sudo-access
 }}
 
-# Ensure pre-reqs - e.g. OpenSSH server are installed
-PREREQ_DPKGS=("curl" "openssh-server")
-for pkg in ${PREREQ_DPKS[@]}; do
-  dpkg -s $pkg &> /dev/null || {
-    sudo apt install -y $pkg
-  }
-done
+# Ensure OpenSSH server is installed
+dpkg -s openssh-server &> /dev/null || {{
+    sudo apt install -y openssh-server
+}}
+
+# Ensure Curl is installed
+dpkg -s curl &> /dev/null || {{
+    sudo apt install -y curl
+}}
 
 # Add $USER to the snap_daemon group supporting interaction
 # with the sunbeam clustering daemon for cluster operations.

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -47,7 +47,7 @@ sudo grep -r $USER /etc/{{sudoers,sudoers.d}} | grep NOPASSWD:ALL &> /dev/null |
 
 # Ensure pre-reqs - e.g. OpenSSH server are installed
 PREREQ_DPKGS=("curl" "openssh-server")
-for pkg in ${PREREQ_DPKS[@]}; do
+for pkg in ${PREREQ_DPKGS[@]}; do
   dpkg -s $pkg &> /dev/null || {
     sudo apt install -y $pkg
   }

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -47,7 +47,7 @@ sudo grep -r $USER /etc/{{sudoers,sudoers.d}} | grep NOPASSWD:ALL &> /dev/null |
 
 # Ensure pre-reqs - e.g. OpenSSH server are installed
 PREREQ_DPKGS=("curl" "openssh-server")
-for pkg in ${PREREQ_DPKGS[@]}; do
+for pkg in ${PREREQ_DPKS[@]}; do
   dpkg -s $pkg &> /dev/null || {
     sudo apt install -y $pkg
   }


### PR DESCRIPTION
2078939 - curl doesn't get installed on a desktop install.