### PR TITLE
Use new manifest in test-snap workflow

### DIFF
--- a/.github/assets/testing/manifest.yml
+++ b/.github/assets/testing/manifest.yml
@@ -1,66 +1,68 @@
-software:
-  charms:
-    aodh-k8s:
-      channel: OS_CHARM
-    barbican-k8s:
-      channel: OS_CHARM
-    ceilometer-k8s:
-      channel: OS_CHARM
-    cinder-ceph-k8s:
-      channel: OS_CHARM
-    cinder-k8s:
-      channel: OS_CHARM
-    designate-bind-k8s:
-    # Is that interesting to switch ?
-      channel: 9/edge
-    designate-k8s:
-      channel: OS_CHARM
-    glance-k8s:
-      channel: OS_CHARM
-    gnocchi-k8s:
-      channel: OS_CHARM
-    heat-k8s:
-      channel: OS_CHARM
-    horizon-k8s:
-      channel: OS_CHARM
-    keystone-k8s:
-      channel: OS_CHARM
-    keystone-ldap-k8s:
-      channel: OS_CHARM
-    magnum-k8s:
-      channel: OS_CHARM
-    neutron-k8s:
-      channel: OS_CHARM
-    nova-k8s:
-      channel: OS_CHARM
-    octavia-k8s:
-      channel: OS_CHARM
-    openstack-exporter-k8s:
-      channel: OS_CHARM
-    openstack-hypervisor:
-      channel: OS_CHARM
-    # removed as not present in 2023.2
-    # openstack-images-sync-k8s:
-    #   channel: OS_CHARM
-    ovn-central-k8s:
-      channel: OVN_CHARM
-    ovn-relay-k8s:
-      channel: OVN_CHARM
-    placement-k8s:
-      channel: OS_CHARM
-    sunbeam-clusterd:
-      channel: OS_CHARM
-    sunbeam-machine:
-      channel: OS_CHARM
-    tempest-k8s:
-      channel: OS_CHARM
-    microceph:
-      channel: MICROCEPH_CHARM
-      config:
-        snap-channel: MICROCEPH_SNAP
-    rabbitmq-k8s:
-      channel: RABBITMQ_CHARM
-    mysql-k8s:
-      channel: MYSQL_CHARM
-    mysql-router-k8s:
-      channel: MYSQL_ROUTER_CHARM
+core:
+  software:
+    charms:
+      aodh-k8s:
+        channel: OS_CHARM
+      barbican-k8s:
+        channel: OS_CHARM
+      ceilometer-k8s:
+        channel: OS_CHARM
+      cinder-ceph-k8s:
+        channel: OS_CHARM
+      cinder-k8s:
+        channel: OS_CHARM
+      designate-bind-k8s:
+      # Is that interesting to switch ?
+        channel: 9/edge
+      designate-k8s:
+        channel: OS_CHARM
+      glance-k8s:
+        channel: OS_CHARM
+      gnocchi-k8s:
+        channel: OS_CHARM
+      heat-k8s:
+        channel: OS_CHARM
+      horizon-k8s:
+        channel: OS_CHARM
+      keystone-k8s:
+        channel: OS_CHARM
+      keystone-ldap-k8s:
+        channel: OS_CHARM
+      magnum-k8s:
+        channel: OS_CHARM
+      neutron-k8s:
+        channel: OS_CHARM
+      nova-k8s:
+        channel: OS_CHARM
+      octavia-k8s:
+        channel: OS_CHARM
+      openstack-exporter-k8s:
+        channel: OS_CHARM
+      openstack-hypervisor:
+        channel: OS_CHARM
+      openstack-images-sync-k8s:
+        channel: OS_CHARM
+      watcher-k8s:
+        channel: OS_CHARM
+      ovn-central-k8s:
+        channel: OVN_CHARM
+      ovn-relay-k8s:
+        channel: OVN_CHARM
+      placement-k8s:
+        channel: OS_CHARM
+      sunbeam-clusterd:
+        channel: OS_CHARM
+      sunbeam-machine:
+        channel: OS_CHARM
+      tempest-k8s:
+        channel: OS_CHARM
+      microceph:
+        channel: MICROCEPH_CHARM
+        config:
+          snap-channel: MICROCEPH_SNAP
+      rabbitmq-k8s:
+        channel: RABBITMQ_CHARM
+      mysql-k8s:
+        channel: MYSQL_CHARM
+      mysql-router-k8s:
+        channel: MYSQL_ROUTER_CHARM

--- a/.github/assets/testing/manifest_2023.x.yml
+++ b/.github/assets/testing/manifest_2023.x.yml
@@ -1,0 +1,66 @@
+software:
+  charms:
+    aodh-k8s:
+      channel: OS_CHARM
+    barbican-k8s:
+      channel: OS_CHARM
+    ceilometer-k8s:
+      channel: OS_CHARM
+    cinder-ceph-k8s:
+      channel: OS_CHARM
+    cinder-k8s:
+      channel: OS_CHARM
+    designate-bind-k8s:
+    # Is that interesting to switch ?
+      channel: 9/edge
+    designate-k8s:
+      channel: OS_CHARM
+    glance-k8s:
+      channel: OS_CHARM
+    gnocchi-k8s:
+      channel: OS_CHARM
+    heat-k8s:
+      channel: OS_CHARM
+    horizon-k8s:
+      channel: OS_CHARM
+    keystone-k8s:
+      channel: OS_CHARM
+    keystone-ldap-k8s:
+      channel: OS_CHARM
+    magnum-k8s:
+      channel: OS_CHARM
+    neutron-k8s:
+      channel: OS_CHARM
+    nova-k8s:
+      channel: OS_CHARM
+    octavia-k8s:
+      channel: OS_CHARM
+    openstack-exporter-k8s:
+      channel: OS_CHARM
+    openstack-hypervisor:
+      channel: OS_CHARM
+    # removed as not present in 2023.2
+    # openstack-images-sync-k8s:
+    #   channel: OS_CHARM
+    ovn-central-k8s:
+      channel: OVN_CHARM
+    ovn-relay-k8s:
+      channel: OVN_CHARM
+    placement-k8s:
+      channel: OS_CHARM
+    sunbeam-clusterd:
+      channel: OS_CHARM
+    sunbeam-machine:
+      channel: OS_CHARM
+    tempest-k8s:
+      channel: OS_CHARM
+    microceph:
+      channel: MICROCEPH_CHARM
+      config:
+        snap-channel: MICROCEPH_SNAP
+    rabbitmq-k8s:
+      channel: RABBITMQ_CHARM
+    mysql-k8s:
+      channel: MYSQL_CHARM
+    mysql-router-k8s:
+      channel: MYSQL_ROUTER_CHARM

--- a/.github/workflows/test-snap.yml
+++ b/.github/workflows/test-snap.yml
@@ -71,9 +71,20 @@ jobs:
         run: |
           export COLUMNS=256
           set +x
+          # 2023.x, 2024.1/beta does not support k8s provider
+          if [ ! ${{ inputs.snap-channel }} =~ "2024.1/edge" && ${{ inputs.k8s-provider }} == "k8s" ]; then echo "k8s provider not supported"; exit 1; fi
+
           sudo snap install openstack --channel ${{ inputs.snap-channel }}
           sudo snap set openstack k8s.provider=${{ inputs.k8s-provider }}
-          cp .github/assets/testing/manifest.yml .
+
+          # New manifest is applicable from 2024.1/edge
+          # Change this condition once 2024.1/edge is released to beta
+          if [ ${{ inputs.snap-channel }} =~ "2024.1/edge" ];
+          then
+              cp .github/assets/testing/manifest.yml manifest.yml
+          else
+              cp .github/assets/testing/manifest_2023.x.yml manifest.yml
+          fi
           sed -i 's|OS_CHARM|${{ inputs.os-charm-channel }}|' manifest.yml
           sed -i 's|OVN_CHARM|${{ inputs.ovn-charm-channel }}|' manifest.yml
           sed -i 's|MICROCEPH_CHARM|${{ inputs.microceph-charm-channel }}|' manifest.yml


### PR DESCRIPTION
Use new manifest for 2024.1/edge test-snap tests
Error out if k8s provider is selected in
test-snap workflow with 2023.x or 2024.1/beta