### PR TITLE
Allow a feature to specify at which risk it is available

### DIFF
--- a/sunbeam-python/sunbeam/core/common.py
+++ b/sunbeam-python/sunbeam/core/common.py
@@ -439,6 +439,35 @@ class RiskLevel(str, enum.Enum):
     BETA = "beta"
     EDGE = "edge"
 
+    __ordering__ = (STABLE, CANDIDATE, BETA, EDGE)
+
+    def __str__(self) -> str:
+        """Return the string representation of the risk level."""
+        return self.value
+
+    def __lt__(self, other: str) -> bool:
+        """Implement less than comparison."""
+        if self == other:
+            return False
+        str_self = str(self)
+        str_other = str(other)
+        for elem in self.__ordering__:
+            if str_self == elem:
+                return True
+            elif str_other == elem:
+                return False
+        return False
+
+    def __gt__(self, other: str) -> bool:
+        """Implement greater than comparison."""
+        return not (self < other)
+
+    def __ge__(self, other: str) -> bool:
+        """Implement greater than or equal comparison."""
+        if self == other:
+            return True
+        return not (self < other)
+
 
 def infer_risk(snap: Snap) -> RiskLevel:
     """Compute risk level from environment."""

--- a/sunbeam-python/sunbeam/features/caas/feature.py
+++ b/sunbeam-python/sunbeam/features/caas/feature.py
@@ -25,7 +25,7 @@ from rich.status import Status
 
 from sunbeam.clusterd.client import Client
 from sunbeam.commands.configure import retrieve_admin_credentials
-from sunbeam.core.common import BaseStep, Result, ResultType, run_plan
+from sunbeam.core.common import BaseStep, Result, ResultType, RiskLevel, run_plan
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import JujuHelper
 from sunbeam.core.manifest import (
@@ -129,6 +129,8 @@ class CaasFeature(OpenStackControlPlaneFeature):
     }
 
     name = "caas"
+    risk_availability = RiskLevel.BETA
+
     tf_plan_location = TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO
     configure_plan = "caas-setup"
 

--- a/sunbeam-python/sunbeam/features/interface/v1/base.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/base.py
@@ -26,7 +26,7 @@ from snaphelpers import Snap
 
 from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import ConfigItemNotFoundException
-from sunbeam.core.common import SunbeamException, read_config, update_config
+from sunbeam.core.common import RiskLevel, SunbeamException, read_config, update_config
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.manifest import FeatureConfig, Manifest, SoftwareConfig
 
@@ -301,6 +301,9 @@ class BaseFeature(BaseRegisterable, Generic[ConfigType]):
     # Name of feature
     name: str
     group: type[BaseFeatureGroup] | None = None
+
+    # Risk level of the feature
+    risk_availability: RiskLevel = RiskLevel.STABLE
 
     def __init_subclass__(cls, **kwargs):
         """Register inherited features classes."""


### PR DESCRIPTION
This feature allows features to specify from which risk and higher they are available. Disable CAAS for risk lower than BETA.