### PR TITLE
Lower openstack deploy timeout to 60 minutes

### DIFF
--- a/sunbeam-python/sunbeam/steps/openstack.py
+++ b/sunbeam-python/sunbeam/steps/openstack.py
@@ -55,7 +55,7 @@ from sunbeam.core.steps import PatchLoadBalancerServicesStep
 from sunbeam.core.terraform import TerraformException, TerraformHelper
 
 LOG = logging.getLogger(__name__)
-OPENSTACK_DEPLOY_TIMEOUT = 5400  # 90 minutes
+OPENSTACK_DEPLOY_TIMEOUT = 3600  # 60 minutes
 
 CONFIG_KEY = "TerraformVarsOpenstack"
 TOPOLOGY_KEY = "Topology"


### PR DESCRIPTION
The timeout was upped to 90 minutes because of performance issue, which most have been resolved since then.