### PR TITLE
Pin aiohappyeyeballs to 2.4.0

### DIFF
--- a/sunbeam-python/upper-constraints.txt
+++ b/sunbeam-python/upper-constraints.txt
@@ -618,3 +618,8 @@ sphinxcontrib-applehelp===1.0.4;python_version=='3.8'
 sphinxcontrib-applehelp===1.0.8;python_version>='3.9'
 scikit-learn===1.3.2;python_version=='3.8'
 scikit-learn===1.4.0;python_version>='3.9'
+
+# Packages not part of 2024.1 upper-constraints.txt
+
+# aiohappyeyeballs 2.4.2 breaks the snap build, pin to 2.4.0
+aiohappyeyeballs===2.4.0


### PR DESCRIPTION
Pin aiohappyeyeballs to 2.4.0 in upper-constraints.txt 2.4.2 breaks the snap build.