### PR TITLE
Dump model by alias

### DIFF
--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -418,7 +418,7 @@ class UserQuestions(BaseStep):
                 self.variables[section] = {}
         preseed = {}
         if self.manifest and (user := self.manifest.core.config.user):
-            preseed = user.model_dump()
+            preseed = user.model_dump(by_alias=True)
 
         user_bank = sunbeam.core.questions.QuestionBank(
             questions=user_questions(),
@@ -435,7 +435,7 @@ class UserQuestions(BaseStep):
         if self.manifest and (
             ext_network := self.manifest.core.config.external_network
         ):
-            preseed = ext_network.model_dump()
+            preseed = ext_network.model_dump(by_alias=True)
         if self.variables["user"]["remote_access_location"] == utils.LOCAL_ACCESS:
             ext_net_bank = sunbeam.core.questions.QuestionBank(
                 questions=ext_net_questions_local_only(),

--- a/sunbeam-python/sunbeam/commands/manifest.py
+++ b/sunbeam-python/sunbeam/commands/manifest.py
@@ -48,7 +48,7 @@ def generate_software_manifest(
     comment = "# "
 
     try:
-        software_dict = software_config.model_dump()
+        software_dict = software_config.model_dump(by_alias=True)
         LOG.debug(f"Manifest software dict with extra fields: {software_dict}")
 
         # Remove terraform default sources

--- a/sunbeam-python/sunbeam/commands/proxy.py
+++ b/sunbeam-python/sunbeam/commands/proxy.py
@@ -280,7 +280,7 @@ class PromptForProxyStep(BaseStep):
 
         preseed = {}
         if self.manifest and (proxy := self.manifest.core.config.proxy):
-            preseed = proxy.model_dump()
+            preseed = proxy.model_dump(by_alias=True)
 
         proxy_bank = QuestionBank(
             questions=proxy_questions(),

--- a/sunbeam-python/sunbeam/core/deployments.py
+++ b/sunbeam-python/sunbeam/core/deployments.py
@@ -69,10 +69,10 @@ class DeploymentsConfig(pydantic.BaseModel):
         Writing to temporary file first in case there's an error during write.
         Not to lose the original file.
         """
-        self_dict = self.model_dump()
+        self_dict = self.model_dump(by_alias=True)
         # self_dict has deployments with Deployment dict but not of provider
         # so workaround to add each deployment based on provider
-        deployments = [d.model_dump() for d in self.deployments]
+        deployments = [d.model_dump(by_alias=True) for d in self.deployments]
         self_dict["deployments"] = deployments
         LOG.debug(f"Writing deployment configuration to {str(self.path)!r}")
         yaml.SafeDumper.add_representer(str, str_presenter)
@@ -158,7 +158,7 @@ class DeploymentsConfig(pydantic.BaseModel):
 
     def get_minimal_info(self) -> dict:
         """Get deployments config with minimal information."""
-        self_dict = self.model_dump()
+        self_dict = self.model_dump(by_alias=True)
         # self_dict has deployments with Deployment dict but not of provider
         # so workaround to add each deployment based on provider
         deployments = [d.model_dump(include={"name", "type"}) for d in self.deployments]

--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -178,7 +178,7 @@ class JujuAccount(pydantic.BaseModel):
 
     def to_dict(self):
         """Return self as dict."""
-        return self.model_dump()
+        return self.model_dump(by_alias=True)
 
     @classmethod
     def load(
@@ -213,7 +213,7 @@ class JujuController(pydantic.BaseModel):
 
     def to_dict(self):
         """Return self as dict."""
-        return self.model_dump()
+        return self.model_dump(by_alias=True)
 
     @classmethod
     def load(cls, client: Client) -> "JujuController":

--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -125,8 +125,11 @@ class SoftwareConfig(pydantic.BaseModel):
 
     def merge(self, other: "SoftwareConfig") -> "SoftwareConfig":
         """Return a merged version of the software config."""
-        juju = JujuManifest(
-            **utils.merge_dict(self.juju.model_dump(), other.juju.model_dump())
+        juju = JujuManifest.model_validate(
+            utils.merge_dict(
+                self.juju.model_dump(by_alias=True),
+                other.juju.model_dump(by_alias=True),
+            )
         )
         charms: dict[str, CharmManifest] = utils.merge_dict(
             copy.deepcopy(self.charms), copy.deepcopy(other.charms)
@@ -177,7 +180,7 @@ class CoreConfig(pydantic.BaseModel):
         metallb: str | None = None
 
     class _K8sAddons(pydantic.BaseModel):
-        loadbalancers: str | None = None
+        loadbalancer: str | None = None
 
     class _User(pydantic.BaseModel):
         run_demo_setup: bool | None = None
@@ -223,8 +226,11 @@ class CoreManifest(pydantic.BaseModel):
 
     def merge(self, other: "CoreManifest") -> "CoreManifest":
         """Merge the core manifest with the provided manifest."""
-        config = CoreConfig(
-            **utils.merge_dict(self.config.model_dump(), other.config.model_dump())
+        config = CoreConfig.model_validate(
+            utils.merge_dict(
+                self.config.model_dump(by_alias=True),
+                other.config.model_dump(by_alias=True),
+            )
         )
         software = self.software.merge(other.software)
         return type(self)(config=config, software=software)
@@ -239,8 +245,11 @@ class FeatureManifest(pydantic.BaseModel):
         if self.config and other.config:
             if type(self.config) is not type(other.config):
                 raise ValueError("Feature config types do not match")
-            config = type(self.config)(
-                **utils.merge_dict(self.config.model_dump(), other.config.model_dump())
+            config = type(self.config).model_validate(
+                utils.merge_dict(
+                    self.config.model_dump(by_alias=True),
+                    other.config.model_dump(by_alias=True),
+                )
             )
         elif other.config:
             config = other.config

--- a/sunbeam-python/sunbeam/core/terraform.py
+++ b/sunbeam-python/sunbeam/core/terraform.py
@@ -438,7 +438,7 @@ class TerraformHelper:
                     if charm_manifest:
                         break
             if charm_manifest:
-                manifest_charm = charm_manifest.model_dump()
+                manifest_charm = charm_manifest.model_dump(by_alias=True)
                 for charm_attribute_name, tfvar_name in per_charm_tfvar_map.items():
                     charm_attribute_value = manifest_charm.get(charm_attribute_name)
                     if charm_attribute_value:

--- a/sunbeam-python/sunbeam/features/caas/feature.py
+++ b/sunbeam-python/sunbeam/features/caas/feature.py
@@ -98,7 +98,9 @@ class CaasConfigureStep(BaseStep):
                 manifest_caas_config = feature_manifest.config
                 if not manifest_caas_config:
                     raise ValueError("No caas configuration found in manifest")
-                manifest_caas_config_dict = manifest_caas_config.model_dump()
+                manifest_caas_config_dict = manifest_caas_config.model_dump(
+                    by_alias=True
+                )
                 for caas_config_attribute, tfvar_name in self.tfhelper.tfvar_map.get(
                     "caas_config", {}
                 ).items():

--- a/sunbeam-python/sunbeam/features/tls/ca.py
+++ b/sunbeam-python/sunbeam/features/tls/ca.py
@@ -470,7 +470,7 @@ class CaTlsFeature(TlsFeature):
                 jhelper,
                 ca,
                 ca_chain,
-                deployment_preseed=preseed.model_dump() if preseed else {},
+                deployment_preseed=preseed.model_dump(by_alias=True) if preseed else {},
             ),
             # On ingress change, the keystone takes time to update the service
             # endpoint, update the identity-service relation data on every

--- a/sunbeam-python/sunbeam/provider/local/steps.py
+++ b/sunbeam-python/sunbeam/provider/local/steps.py
@@ -188,7 +188,7 @@ class LocalSetHypervisorUnitsOptionsStep(SetHypervisorUnitsOptionsStep):
         if self.manifest and (
             ext_network := self.manifest.core.config.external_network
         ):
-            preseed = ext_network.model_dump()
+            preseed = ext_network.model_dump(by_alias=True)
 
         if self.join_mode or remote_access_location == utils.REMOTE_ACCESS:
             # If nic is in the preseed assume the user knows what they are doing and

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -2102,7 +2102,7 @@ class MaasUserQuestions(BaseStep):
                 self.variables[section] = {}
         preseed = {}
         if self.manifest and (user := self.manifest.core.config.user):
-            preseed = user.model_dump()
+            preseed = user.model_dump(by_alias=True)
         user_bank = sunbeam.core.questions.QuestionBank(
             questions=maas_deployment.maas_user_questions(self.maas_client),
             console=console,
@@ -2116,7 +2116,7 @@ class MaasUserQuestions(BaseStep):
         if self.manifest and (
             ext_network := self.manifest.core.config.external_network
         ):
-            preseed = ext_network.model_dump()
+            preseed = ext_network.model_dump(by_alias=True)
         ext_net_bank = sunbeam.core.questions.QuestionBank(
             questions=ext_net_questions(),
             console=console,

--- a/sunbeam-python/sunbeam/steps/clusterd.py
+++ b/sunbeam-python/sunbeam/steps/clusterd.py
@@ -161,7 +161,7 @@ class AskManagementCidrStep(BaseStep):
         self.variables.setdefault("bootstrap", {})
         preseed = {}
         if self.manifest and (bootstrap := self.manifest.core.config.bootstrap):
-            preseed = bootstrap.model_dump()
+            preseed = bootstrap.model_dump(by_alias=True)
 
         bootstrap_bank = questions.QuestionBank(
             questions=bootstrap_questions(),

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -131,7 +131,7 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
 
         preseed = {}
         if k8s_addons := self.manifest.core.config.k8s_addons:
-            preseed = k8s_addons.model_dump()
+            preseed = k8s_addons.model_dump(by_alias=True)
 
         k8s_addons_bank = QuestionBank(
             questions=k8s_addons_questions(),

--- a/sunbeam-python/sunbeam/steps/microceph.py
+++ b/sunbeam-python/sunbeam/steps/microceph.py
@@ -319,7 +319,7 @@ class ConfigureMicrocephOSDStep(BaseStep):
 
         # Set defaults
         if self.manifest and self.manifest.core.config.microceph_config:
-            microceph_config = self.manifest.core.config.model_dump()[
+            microceph_config = self.manifest.core.config.model_dump(by_alias=True)[
                 "microceph_config"
             ]
         else:

--- a/sunbeam-python/sunbeam/steps/microk8s.py
+++ b/sunbeam-python/sunbeam/steps/microk8s.py
@@ -116,7 +116,7 @@ class DeployMicrok8sApplicationStep(DeployMachineApplicationStep):
 
         preseed = {}
         if addons := self.manifest.core.config.addons:
-            preseed = addons.model_dump()
+            preseed = addons.model_dump(by_alias=True)
 
         microk8s_addons_bank = questions.QuestionBank(
             questions=microk8s_addons_questions(),


### PR DESCRIPTION
The manifest has one alias'd field that was not working correctly: `k8s-addons`, it wouldn't be parsed after a dump.

- always dump model by alias
- use model_validate for dicts instead of **unpacking
- fix `loadbalancer` typo