### PR TITLE
hypervisor: map data endpoint to data network

### DIFF
--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -96,6 +96,10 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
                     "space": self.deployment.get_space(Networks.DATA),
                 },
                 {
+                    "endpoint": "data",
+                    "space": self.deployment.get_space(Networks.DATA),
+                },
+                {
                     "endpoint": "amqp",
                     "space": self.deployment.get_space(Networks.INTERNAL),
                 },


### PR DESCRIPTION
Hypervisor charm added support for the extra-binding `data`. This binding will determine which network supports project communication (vm-to-vm through hypervisors traffic).