### PR TITLE
local: gather compute nics from the hypervisor

### DIFF
--- a/sunbeam-python/sunbeam/core/questions.py
+++ b/sunbeam-python/sunbeam/core/questions.py
@@ -152,7 +152,11 @@ class Question(typing.Generic[T]):
             default = self.default_value
         return default
 
-    def ask(self, new_default: T | None = None) -> T | None:
+    def ask(
+        self,
+        new_default: T | None = None,
+        new_choices: list[T] | None = None,
+    ) -> T | None:
         """Ask a question if needed.
 
         If a preseed has been supplied for this question then do not ask the
@@ -162,6 +166,7 @@ class Question(typing.Generic[T]):
                             that previous answers may impact the value of a
                             sensible default so the original default can be
                             overriden at the point of prompting the user.
+        :param new_choices: The new choices for the question.
         """
         if self.preseed is not None:
             self.answer = self.preseed
@@ -174,7 +179,7 @@ class Question(typing.Generic[T]):
                     self.question,
                     default=default,
                     console=self.console,
-                    choices=self.choices,
+                    choices=new_choices or self.choices,
                     password=self.password,
                     stream=STREAM,
                 )
@@ -186,7 +191,7 @@ class Question(typing.Generic[T]):
                 if self.preseed is not None:
                     LOG.error(message)
                     raise
-                LOG.warn(message)
+                LOG.warning(message)
                 self.ask(new_default=new_default)
 
         return self.answer

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_configure.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_configure.py
@@ -73,13 +73,6 @@ def tfhelper():
     yield Mock(path=Path())
 
 
-@pytest.fixture()
-def get_nic_macs():
-    with patch.object(sunbeam.utils, "get_nic_macs") as p:
-        p.return_value = ["00:16:3e:01:6e:75"]
-        yield p
-
-
 class SetHypervisorCharmConfigStep:
     def test_is_skip(self, cclient, jhelper):
         step = configure.SetHypervisorCharmConfigStep(
@@ -172,7 +165,7 @@ class TestUserQuestions:
         return user_bank_mock, net_bank_mock
 
     def test_prompt_remote_demo_setup(
-        self, cclient, load_answers, question_bank, jhelper, write_answers, get_nic_macs
+        self, cclient, load_answers, question_bank, jhelper, write_answers
     ):
         load_answers.return_value = {}
         user_bank_mock, net_bank_mock = self.configure_mocks(question_bank)
@@ -184,7 +177,7 @@ class TestUserQuestions:
         self.check_remote_questions(net_bank_mock)
 
     def test_prompt_remote_no_demo_setup(
-        self, cclient, load_answers, question_bank, jhelper, write_answers, get_nic_macs
+        self, cclient, load_answers, question_bank, jhelper, write_answers
     ):
         load_answers.return_value = {}
         user_bank_mock, net_bank_mock = self.configure_mocks(question_bank)


### PR DESCRIPTION
Call upon the `list-nics` action on the hypervisor to list the host nics, get details about their state and list which one are candidate to become the compute nic.

Depends-on:
- https://github.com/canonical/snap-openstack-hypervisor/pull/43