### PR TITLE
Apply hypervisor charm configs using terraform plan

### DIFF
--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -36,6 +36,7 @@ from sunbeam.core.common import SunbeamException
 LOG = logging.getLogger(__name__)
 LOCAL_ACCESS = "local"
 REMOTE_ACCESS = "remote"
+IPVANYNETWORK_UNSET = "0.0.0.0/0"
 
 
 def get_hypervisor_hostname() -> str:


### PR DESCRIPTION
Currently openstack-hypervisor charm configs like
external network settings are applied using juju
library. Instead apply them using hypervisor
terraform plan.

Remove the existing step SetHypervisorCharmConfigStep and update ReapplyHypervsiorTerraformPlan to get
external network configs and apply them.
ReapplyHypervsiorTerraformPlan is reused instead of updating the existing step because whenever the step ReapplyHypervsiorTerraformPlan is called, it requires external network configs as extra tfvars. Otherwise the charm configs will be overrided by what is specified in manifest or defaults.

Fixes: LP#2084903