### PR TITLE
Add offer urls as variables for hypervisor terraform plan

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -85,7 +85,6 @@ jobs:
           # sg snap_daemon "openstack.sunbeam validation run smoke"
           # sg snap_daemon "openstack.sunbeam validation run --output tempest_validation.log"
           # sg snap_daemon "openstack.sunbeam disable caas"
-          sg snap_daemon "openstack.sunbeam disable resource-optimization"
           sg snap_daemon "openstack.sunbeam disable secrets"
           sg snap_daemon "openstack.sunbeam disable vault"
           # Commented disabling observability due to LP#1998282
@@ -94,11 +93,12 @@ jobs:
           sg snap_daemon "openstack.sunbeam disable dns"
           sg snap_daemon "openstack.sunbeam disable loadbalancer"
           sg snap_daemon "openstack.sunbeam disable orchestration"
+          sg snap_daemon "openstack.sunbeam disable resource-optimization"
           # sg snap_daemon "openstack.sunbeam disable validation"
 
           sg snap_daemon "openstack.sunbeam enable consul"
           sg snap_daemon "openstack.sunbeam enable instance-recovery"
-          # sg snap_daemon "openstack.sunbeam disable instance-recovery"
+          sg snap_daemon "openstack.sunbeam disable instance-recovery"
           # Disable consul as the pods are stuck in getting terminated
           # sg snap_daemon "openstack.sunbeam disable consul"
 

--- a/cloud/etc/deploy-openstack-hypervisor/main.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/main.tf
@@ -26,11 +26,6 @@ terraform {
 
 provider "juju" {}
 
-data "terraform_remote_state" "openstack" {
-  backend = var.openstack-state-backend
-  config  = var.openstack-state-config
-}
-
 resource "juju_application" "openstack-hypervisor" {
   name  = "openstack-hypervisor"
   trust = false
@@ -60,7 +55,7 @@ resource "juju_integration" "hypervisor-amqp" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.rabbitmq-offer-url
+    offer_url = var.rabbitmq-offer-url
   }
 }
 
@@ -73,11 +68,12 @@ resource "juju_integration" "hypervisor-identity" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.keystone-offer-url
+    offer_url = var.keystone-offer-url
   }
 }
 
 resource "juju_integration" "hypervisor-cert-distributor" {
+  count = (var.cert-distributor-offer-url != null) ? 1 : 0
   model = var.machine_model
 
   application {
@@ -86,11 +82,12 @@ resource "juju_integration" "hypervisor-cert-distributor" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.cert-distributor-offer-url
+    offer_url = var.cert-distributor-offer-url
   }
 }
 
 resource "juju_integration" "hypervisor-certs" {
+  count = (var.ca-offer-url != null) ? 1 : 0
   model = var.machine_model
 
   application {
@@ -99,7 +96,7 @@ resource "juju_integration" "hypervisor-certs" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.ca-offer-url
+    offer_url = var.ca-offer-url
   }
 }
 
@@ -112,12 +109,12 @@ resource "juju_integration" "hypervisor-ovn" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.ovn-relay-offer-url
+    offer_url = var.ovn-relay-offer-url
   }
 }
 
 resource "juju_integration" "hypervisor-ceilometer" {
-  count = try(data.terraform_remote_state.openstack.outputs.ceilometer-offer-url, null) != null ? 1 : 0
+  count = (var.ceilometer-offer-url != null) ? 1 : 0
   model = var.machine_model
 
   application {
@@ -126,11 +123,12 @@ resource "juju_integration" "hypervisor-ceilometer" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.ceilometer-offer-url
+    offer_url = var.ceilometer-offer-url
   }
 }
 
 resource "juju_integration" "hypervisor-cinder-ceph" {
+  count = (var.cinder-ceph-offer-url != null) ? 1 : 0
   model = var.machine_model
 
   application {
@@ -139,7 +137,7 @@ resource "juju_integration" "hypervisor-cinder-ceph" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.cinder-ceph-offer-url
+    offer_url = var.cinder-ceph-offer-url
   }
 }
 
@@ -152,12 +150,12 @@ resource "juju_integration" "hypervisor-nova-controller" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.nova-offer-url
+    offer_url = var.nova-offer-url
   }
 }
 
 resource "juju_integration" "hypervisor-masakari" {
-  count = try(data.terraform_remote_state.openstack.outputs.masakari-offer-url, null) != null ? 1 : 0
+  count = (var.masakari-offer-url != null) ? 1 : 0
   model = var.machine_model
 
   application {
@@ -166,6 +164,6 @@ resource "juju_integration" "hypervisor-masakari" {
   }
 
   application {
-    offer_url = data.terraform_remote_state.openstack.outputs.masakari-offer-url
+    offer_url = var.masakari-offer-url
   }
 }

--- a/cloud/etc/deploy-openstack-hypervisor/variables.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/variables.tf
@@ -53,18 +53,62 @@ variable "machine_model" {
   type        = string
 }
 
-variable "openstack-state-backend" {
-  description = "backend type used for openstack state"
-  type        = string
-  default     = "local"
-}
-
-variable "openstack-state-config" {
-  type = map(any)
-}
-
 variable "endpoint_bindings" {
   description = "Endpoint bindings for openstack-hypervisor"
   type        = set(map(string))
+  default     = null
+}
+
+# Mandatory relation, no defaults
+variable "rabbitmq-offer-url" {
+  description = "Offer URL for openstack rabbitmq"
+  type        = string
+}
+
+# Mandatory relation, no defaults
+variable "keystone-offer-url" {
+  description = "Offer URL for openstack keystone identity-credentials relation"
+  type        = string
+}
+
+variable "cert-distributor-offer-url" {
+  description = "Offer URL for openstack keystone certificate-transfer relation"
+  type        = string
+  default     = null
+}
+
+variable "ca-offer-url" {
+  description = "Offer URL for Certificates"
+  type        = string
+  default     = null
+}
+
+# Mandatory relation, no defaults
+variable "ovn-relay-offer-url" {
+  description = "Offer URL for ovn relay service"
+  type        = string
+}
+
+variable "ceilometer-offer-url" {
+  description = "Offer URL for openstack ceilometer"
+  type        = string
+  default     = null
+}
+
+variable "cinder-ceph-offer-url" {
+  description = "Offer URL for openstack cinder-ceph"
+  type        = string
+  default     = null
+}
+
+# Mandatory relation, no defaults
+variable "nova-offer-url" {
+  description = "Offer URL for openstack nova"
+  type        = string
+}
+
+variable "masakari-offer-url" {
+  description = "Offer URL for openstack masakari"
+  type        = string
   default     = null
 }

--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -279,16 +279,21 @@ def get_external_network_configs(client: Client) -> dict:
     variables = sunbeam.core.questions.load_answers(client, CLOUD_CONFIG_SECTION)
     ext_network = variables.get("external_network", {})
     charm_config["external-bridge"] = "br-ex"
-    if variables["user"]["remote_access_location"] == utils.LOCAL_ACCESS:
+    if (
+        variables.get("user", {}).get("remote_access_location", "")
+        == utils.LOCAL_ACCESS
+    ):
         external_network = ipaddress.ip_network(
-            variables["external_network"].get("cidr")
+            variables.get("external_network", {}).get("cidr")
         )
         bridge_interface = f"{ext_network.get('gateway')}/{external_network.prefixlen}"
         charm_config["external-bridge-address"] = bridge_interface
     else:
         charm_config["external-bridge-address"] = utils.IPVANYNETWORK_UNSET
 
-    charm_config["physnet-name"] = variables["external_network"].get("physical_network")
+    charm_config["physnet-name"] = variables.get("external_network", {}).get(
+        "physical_network"
+    )
 
     return charm_config
 

--- a/sunbeam-python/sunbeam/features/instance_recovery/feature.py
+++ b/sunbeam-python/sunbeam/features/instance_recovery/feature.py
@@ -26,6 +26,7 @@ from sunbeam.core.manifest import (
     FeatureConfig,
     SoftwareConfig,
 )
+from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.terraform import TerraformInitStep
 from sunbeam.features.interface.v1.base import FeatureRequirement
 from sunbeam.features.interface.v1.openstack import (
@@ -35,6 +36,7 @@ from sunbeam.features.interface.v1.openstack import (
     TerraformPlanLocation,
 )
 from sunbeam.steps.hypervisor import ReapplyHypervisorTerraformPlanStep
+from sunbeam.steps.juju import RemoveSaasApplicationsStep
 from sunbeam.utils import click_option_show_hints, pass_method_obj
 from sunbeam.versions import OPENSTACK_CHANNEL
 
@@ -82,30 +84,41 @@ class InstanceRecoveryFeature(OpenStackControlPlaneFeature):
     ) -> None:
         """Run plans to enable feature."""
         tfhelper = deployment.get_tfhelper(self.tfplan)
+        tfhelper_openstack = deployment.get_tfhelper("openstack-plan")
         tfhelper_hypervisor = deployment.get_tfhelper("hypervisor-plan")
         jhelper = JujuHelper(deployment.get_connected_controller())
-        plan: list[BaseStep] = []
+        plan1: list[BaseStep] = []
         if self.user_manifest:
-            plan.append(AddManifestStep(deployment.get_client(), self.user_manifest))
-        plan.extend(
+            plan1.append(AddManifestStep(deployment.get_client(), self.user_manifest))
+        plan1.extend(
             [
                 TerraformInitStep(tfhelper),
                 EnableOpenStackApplicationStep(
                     deployment, config, tfhelper, jhelper, self
                 ),
+            ]
+        )
+        run_plan(plan1, console, show_hints)
+
+        openstack_tf_output = tfhelper_openstack.output()
+        extra_tfvars = {
+            "masakari-offer-url": openstack_tf_output.get("masakari-offer-url")
+        }
+        plan2: list[BaseStep] = []
+        plan2.extend(
+            [
                 TerraformInitStep(tfhelper_hypervisor),
-                # No need to pass any extra terraform vars for this feature
                 ReapplyHypervisorTerraformPlanStep(
                     deployment.get_client(),
                     tfhelper_hypervisor,
                     jhelper,
                     self.manifest,
                     deployment.openstack_machines_model,
+                    extra_tfvars=extra_tfvars,
                 ),
             ]
         )
-
-        run_plan(plan, console, show_hints)
+        run_plan(plan2, console, show_hints)
         click.echo(f"OpenStack {self.display_name} application enabled.")
 
     def run_disable_plans(self, deployment: Deployment, show_hints: bool) -> None:
@@ -113,9 +126,8 @@ class InstanceRecoveryFeature(OpenStackControlPlaneFeature):
         tfhelper = deployment.get_tfhelper(self.tfplan)
         tfhelper_hypervisor = deployment.get_tfhelper("hypervisor-plan")
         jhelper = JujuHelper(deployment.get_connected_controller())
+        extra_tfvars = {"masakari-offer-url": None}
         plan = [
-            TerraformInitStep(tfhelper),
-            DisableOpenStackApplicationStep(deployment, tfhelper, jhelper, self),
             TerraformInitStep(tfhelper_hypervisor),
             ReapplyHypervisorTerraformPlanStep(
                 deployment.get_client(),
@@ -123,7 +135,16 @@ class InstanceRecoveryFeature(OpenStackControlPlaneFeature):
                 jhelper,
                 self.manifest,
                 deployment.openstack_machines_model,
+                extra_tfvars=extra_tfvars,
             ),
+            RemoveSaasApplicationsStep(
+                jhelper,
+                deployment.openstack_machines_model,
+                OPENSTACK_MODEL,
+                saas_apps_to_delete=["masakari"],
+            ),
+            TerraformInitStep(tfhelper),
+            DisableOpenStackApplicationStep(deployment, tfhelper, jhelper, self),
         ]
 
         run_plan(plan, console, show_hints)

--- a/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
@@ -254,64 +254,6 @@ class TestRemoveGrafanaAgentStep:
         assert result.message == "timed out"
 
 
-class TestRemoveSaasApplicationsStep:
-    def test_is_skip(self, jhelper):
-        jhelper.get_model_status.return_value = {
-            "remote-applications": {
-                "test-1": {"offer-url": "admin/offering_model.test-1"},
-                "test-2": {"endpoints": [{"interface": "grafana_dashboard"}]},
-                "test-3": {"endpoints": [{"interface": "identity_credentials"}]},
-            }
-        }
-        step = observability_feature.RemoveSaasApplicationsStep(
-            jhelper,
-            "test",
-            "offering_model",
-            observability_feature.OBSERVABILITY_OFFER_INTERFACES,
-        )
-        result = step.is_skip()
-        assert step._remote_app_to_delete == ["test-1", "test-2"]
-        assert result.result_type == ResultType.COMPLETED
-
-    def test_is_skip_no_remote_app(self, jhelper):
-        jhelper.get_model_status.return_value = {}
-        step = observability_feature.RemoveSaasApplicationsStep(
-            jhelper,
-            "test",
-            "offering_model",
-            observability_feature.OBSERVABILITY_OFFER_INTERFACES,
-        )
-        result = step.is_skip()
-        assert result.result_type == ResultType.SKIPPED
-
-    def test_is_skip_no_saas_app(self, jhelper):
-        jhelper.get_model_status.return_value = {
-            "remote-applications": {
-                "test-1": {"offer-url": "admin/offering_model.test-1"},
-                "test-3": {"endpoints": [{"interface": "identity_credentials"}]},
-            }
-        }
-        step = observability_feature.RemoveSaasApplicationsStep(
-            jhelper,
-            "test",
-            "offering_model-no-apps",
-            observability_feature.OBSERVABILITY_OFFER_INTERFACES,
-        )
-        result = step.is_skip()
-        assert result.result_type == ResultType.SKIPPED
-
-    def test_run(self, jhelper):
-        step = observability_feature.RemoveSaasApplicationsStep(
-            jhelper,
-            "test",
-            "offering_model",
-            observability_feature.OBSERVABILITY_OFFER_INTERFACES,
-        )
-        step._remote_app_to_delete = ["test-1"]
-        result = step.run()
-        assert result.result_type == ResultType.COMPLETED
-
-
 class TestIntegrateRemoteCosOffersStep:
     def test_run(self, deployment, jhelper, observabilityfeature, snap, run):
         observabilityfeature.grafana_offer_url = "remotecos:admin/grafana"


### PR DESCRIPTION
* For openstack-hypervisor terraform plans, add variables for offer urls to be consumed. This is to avoid occurence of bug https://bugs.launchpad.net/juju/+bug/2085310 if the remote offer is removed by force
* Remove openstack terraform plan backend config from openstack hypervisor terraform variables
* Update DeployOpenStackControlPlaneStep to update all offer urls in terraform tfvars
* Update Telemetry and InstanceRecovery features to pass necessary offer ruls during enable/disable for step ReapplyOpenStackHypervisorTerraformStep
* Update Telemetry and InstanceRecovery feature to add step to remove RemoteSAAS as a wordaround for
https://github.com/juju/terraform-provider-juju/issues/473
* Move RemoveSaasApplicationsStep to sunbeam/steps/juju.py from observability feature to make it reusable
* Add saas_apps_to_delete parameter to RemoveSaasApplicationsStep to filter the saas applications that need to be removed