### PR TITLE
Put instance recovery behind edge risk gate

### DIFF
--- a/sunbeam-python/sunbeam/features/instance_recovery/feature.py
+++ b/sunbeam-python/sunbeam/features/instance_recovery/feature.py
@@ -17,7 +17,7 @@ import click
 from packaging.version import Version
 from rich.console import Console
 
-from sunbeam.core.common import BaseStep, run_plan
+from sunbeam.core.common import BaseStep, RiskLevel, run_plan
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import JujuHelper
 from sunbeam.core.manifest import (
@@ -49,6 +49,8 @@ class InstanceRecoveryFeature(OpenStackControlPlaneFeature):
     requires = {FeatureRequirement("consul")}
     name = "instance-recovery"
     tf_plan_location = TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO
+
+    risk_availability: RiskLevel = RiskLevel.EDGE
 
     def default_software_overrides(self) -> SoftwareConfig:
         """Feature software configuration."""


### PR DESCRIPTION
Current implementation of masakari does not capture all necessary features to be useful in MAAS installations.