### PR TITLE
Remove show hints option from list_machines_cmd

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -909,7 +909,6 @@ def add_maas(name: str, token: str, url: str, show_hints: bool) -> None:
     default=FORMAT_TABLE,
     help="Output format",
 )
-@click_option_show_hints
 @click.pass_context
 def list_machines_cmd(ctx: click.Context, format: str) -> None:
     """List machines in active deployment."""


### PR DESCRIPTION
This command does not make use of show_hints and fail at run time.