### PR TITLE
Change juju controller strategy to k8s

### DIFF
--- a/.github/assets/testing/edge.yml
+++ b/.github/assets/testing/edge.yml
@@ -1,5 +1,9 @@
 core:
   software:
+    juju:
+      bootstrap_args:
+        - --bootstrap-constraints
+        - root-disk=5G
     charms:
       cinder-ceph-k8s:
         channel: 2024.1/edge

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -48,6 +48,23 @@ jobs:
           sudo apt remove --purge docker.io containerd runc -y
           sudo rm -rf /run/containerd
 
+          sudo lxd init --auto
+          sudo lxc network create br0
+          sudo lxc profile device remove default eth0
+          sudo lxc profile device add default eth0 nic network=br0 name=eth0
+          sudo lxc network delete lxdbr0
+
+          sudo snap install juju --channel 3.6/stable
+          juju bootstrap localhost lxdcloud
+
+          # Allow lxd controller to reach to k8s controller on loadbalancer ip
+          # sudo nft insert rule ip filter FORWARD tcp dport 17070 accept
+          # sudo nft insert rule ip filter FORWARD tcp sport 17070 accept
+          # With above rules, got the following error:
+          # api.charmhub.io on 10.152.183.182:53: server misbehaving
+          # Accept all packets filtered for forward
+          sudo nft chain ip filter FORWARD '{policy accept;}'
+
           sudo snap install  ${{ needs.build.outputs.snap }} --dangerous
           openstack.sunbeam prepare-node-script | bash -x
           sudo snap connect openstack:juju-bin juju:juju-bin

--- a/.github/workflows/test-snap.yml
+++ b/.github/workflows/test-snap.yml
@@ -66,6 +66,15 @@ jobs:
           # 2023.x, 2024.1/beta does not support k8s provider
           if [[ ! ${{ inputs.snap-channel }} =~ "2024.1/edge" && ${{ inputs.k8s-provider }} == "k8s" ]]; then echo "k8s provider not supported"; exit 1; fi
 
+          sudo lxd init --auto
+          sudo lxc network create br0
+          sudo lxc profile device remove default eth0
+          sudo lxc profile device add default eth0 nic network=br0 name=eth0
+          sudo lxc network delete lxdbr0
+
+          sudo snap install juju --channel 3.6/stable
+          juju bootstrap localhost lxdcloud
+
           sudo snap install openstack --channel ${{ inputs.snap-channel }}
           sudo snap set openstack k8s.provider=${{ inputs.k8s-provider }}
 

--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -253,6 +253,10 @@ class ClusterService(MicroClusterService, ExtendedAPIService):
     # sucessfully run. Note: this is distinct from microcluster bootstrap.
     SUNBEAM_BOOTSTRAP_KEY = "sunbeam_bootstrapped"
 
+    # This key is used to determine if Juju controller is migrated to k8s
+    # from lxd. This is used only in local type deployment.
+    JUJU_CONTROLLER_MIGRATE_KEY = "juju_controller_migrated_to_k8s"
+
     def bootstrap(
         self, name: str, address: str, role: list[str], machineid: int = -1
     ) -> None:
@@ -298,6 +302,24 @@ class ClusterService(MicroClusterService, ExtendedAPIService):
         """Check if the sunbeam deployment has been bootstrapped."""
         try:
             state = json.loads(self.get_config(self.SUNBEAM_BOOTSTRAP_KEY))
+        except service.ConfigItemNotFoundException:
+            state = False
+        except service.ClusterServiceUnavailableException:
+            state = False
+        return state
+
+    def unset_juju_controller_migrated(self) -> None:
+        """Remove juju controller migrated key."""
+        self.update_config(self.JUJU_CONTROLLER_MIGRATE_KEY, json.dumps("False"))
+
+    def set_juju_controller_migrated(self) -> None:
+        """Mark juju controller as migrated."""
+        self.update_config(self.JUJU_CONTROLLER_MIGRATE_KEY, json.dumps("True"))
+
+    def check_juju_controller_migrated(self) -> bool:
+        """Check if juju controller has been migrated."""
+        try:
+            state = json.loads(self.get_config(self.JUJU_CONTROLLER_MIGRATE_KEY))
         except service.ConfigItemNotFoundException:
             state = False
         except service.ClusterServiceUnavailableException:

--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -52,6 +52,7 @@ from juju.unit import Unit
 from packaging import version
 from snaphelpers import Snap
 
+from sunbeam import utils
 from sunbeam.clusterd.client import Client
 from sunbeam.core.common import SunbeamException
 from sunbeam.versions import JUJU_BASE, SUPPORTED_RELEASE
@@ -82,6 +83,12 @@ class JujuException(SunbeamException):
 
 class ControllerNotFoundException(JujuException):
     """Raised when controller is missing."""
+
+    pass
+
+
+class ControllerNotReachableException(JujuException):
+    """Raised when controller is not reachable."""
 
     pass
 
@@ -1369,6 +1376,17 @@ class JujuHelper:
         }
         return credentials
 
+    @staticmethod
+    def empty_credential(cloud: str):
+        """Create empty credential definition."""
+        credentials: dict[str, dict] = {"credentials": {}}
+        credentials["credentials"][cloud] = {
+            "empty-creds": {
+                "auth-type": "empty",
+            }
+        }
+        return credentials
+
     async def get_spaces(self, model: str) -> list[dict]:
         """Get spaces in model."""
         model_impl = await self.get_model(model)
@@ -1559,6 +1577,23 @@ class JujuStepHelper:
             LOG.debug(e)
             raise ControllerNotFoundException() from e
 
+    def get_controller_ip(self, controller: str) -> str:
+        """Get Controller IP of given juju controller.
+
+        Returns Juju Controller IP.
+        Raises ControllerNotFoundException or ControllerNotReachableException.
+        """
+        controller_details = self.get_controller(controller)
+        endpoints = controller_details.get("details", {}).get("api-endpoints", [])
+        controller_ip_port = utils.first_connected_server(endpoints)
+        if not controller_ip_port:
+            raise ControllerNotReachableException(
+                f"Juju Controller {controller} not reachable"
+            )
+
+        controller_ip = controller_ip_port.rsplit(":", 1)[0]
+        return controller_ip
+
     def add_cloud(self, name: str, cloud: dict, controller: str | None) -> bool:
         """Add cloud to client clouds.
 
@@ -1589,8 +1624,35 @@ class JujuStepHelper:
 
         return True
 
+    def add_k8s_cloud_in_client(self, name: str, kubeconfig: dict):
+        """Add k8s cloud in juju client."""
+        with tempfile.NamedTemporaryFile() as temp:
+            temp.write(yaml.dump(kubeconfig).encode("utf-8"))
+            temp.flush()
+            cmd = [
+                self._get_juju_binary(),
+                "add-k8s",
+                name,
+                "--client",
+                "--region=localhost/localhost",
+            ]
+
+            env = os.environ.copy()
+            env.update({"KUBECONFIG": temp.name})
+            LOG.debug(f'Running command {" ".join(cmd)}')
+            process = subprocess.run(
+                cmd, capture_output=True, text=True, check=True, env=env
+            )
+            LOG.debug(
+                f"Command finished. stdout={process.stdout}, stderr={process.stderr}"
+            )
+
     def add_credential(self, cloud: str, credential: dict, controller: str | None):
-        """Add credential to client credentials."""
+        """Add credentials to client or controller.
+
+        If controller is specidifed, credential is added to controller.
+        If controller is None, credential is added to client.
+        """
         with tempfile.NamedTemporaryFile() as temp:
             temp.write(yaml.dump(credential).encode("utf-8"))
             temp.flush()
@@ -1600,10 +1662,11 @@ class JujuStepHelper:
                 cloud,
                 "--file",
                 temp.name,
-                "--client",
             ]
             if controller:
                 cmd.extend(["--controller", controller])
+            else:
+                cmd.extend(["--client"])
             LOG.debug(f'Running command {" ".join(cmd)}')
             process = subprocess.run(cmd, capture_output=True, text=True, check=True)
             LOG.debug(

--- a/sunbeam-python/sunbeam/core/terraform.py
+++ b/sunbeam-python/sunbeam/core/terraform.py
@@ -143,6 +143,13 @@ class TerraformHelper:
                 )
             )
 
+    def reload_env(self, env: dict) -> None:
+        """Update environment variables."""
+        if self.env:
+            self.env.update(env)
+        else:
+            self.env = env
+
     def init(self) -> None:
         """Terraform init."""
         os_env = os.environ.copy()

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -422,7 +422,20 @@ def get_juju_bootstrap_plans(
     """Get Juju Bootstrap related plans."""
     client = deployment.get_client()
     proxy_settings = deployment.get_proxy_settings()
-    bootstrap_args.extend(["--config", "controller-service-type=loadbalancer"])
+
+    # If the secret backend is left to defaults i.e., auto, the secret backend
+    # is set to k8s if the controller is k8s based and non-k8s machines cannot
+    # get secrets as they try to connect to k8s on service_ip which is not
+    # reachable from non-k8s machines.
+    # https://bugs.launchpad.net/snap-openstack/+bug/2091724
+    # To avoid the bug, change the default secret backend to internal
+    bootstrap_args.extend(
+        [
+            "--config",
+            "controller-service-type=loadbalancer",
+            "--model-default=secret-backend=internal",
+        ]
+    )
 
     return [
         AddK8SCloudInClientStep(deployment),

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -710,7 +710,7 @@ def bootstrap(
 
         # Reload deployment with sunbeam-controller {fqdn} user credentials
         deployment.reload_credentials()
-        deployments.write()
+        deployments.update_deployment(deployment)
         deployment.reload_tfhelpers()
         jhelper = JujuHelper(deployment.get_connected_controller())
 

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -120,10 +120,7 @@ class LocalDeployment(Deployment):
     @property
     def openstack_machines_model(self) -> str:
         """Return the openstack machines model name."""
-        if self.juju_controller and self.juju_controller.is_external:
-            return "openstack-machines"
-
-        return "controller"
+        return "openstack-machines"
 
     @property
     def controller(self) -> str:

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -317,6 +317,41 @@ class AddK8SCloudStep(BaseStep, JujuStepHelper):
         return Result(ResultType.COMPLETED)
 
 
+class AddK8SCloudInClientStep(BaseStep, JujuStepHelper):
+    _KUBECONFIG = K8S_KUBECONFIG_KEY
+
+    def __init__(self, deployment: Deployment, jhelper: JujuHelper):
+        super().__init__("Add K8S cloud in client", "Adding K8S cloud to Juju client")
+        self.client = deployment.get_client()
+        self.jhelper = jhelper
+        self.cloud_name = f"{deployment.name}{K8S_CLOUD_SUFFIX}"
+        self.credential_name = f"{self.cloud_name}{CREDENTIAL_SUFFIX}"
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        clouds = self.get_clouds("k8s", local=True)
+        LOG.debug(f"Clouds registered in the client: {clouds}")
+        if self.cloud_name in clouds:
+            return Result(ResultType.SKIPPED)
+
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Status | None = None) -> Result:
+        """Add microk8s clouds to Juju controller."""
+        try:
+            kubeconfig = read_config(self.client, self._KUBECONFIG)
+            self.add_k8s_cloud_in_client(self.cloud_name, kubeconfig)
+        except (ConfigItemNotFoundException, UnsupportedKubeconfigException) as e:
+            LOG.debug("Failed to add k8s cloud to Juju client", exc_info=True)
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)
+
+
 class UpdateK8SCloudStep(BaseStep, JujuStepHelper):
     _KUBECONFIG = K8S_KUBECONFIG_KEY
 

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -320,10 +320,9 @@ class AddK8SCloudStep(BaseStep, JujuStepHelper):
 class AddK8SCloudInClientStep(BaseStep, JujuStepHelper):
     _KUBECONFIG = K8S_KUBECONFIG_KEY
 
-    def __init__(self, deployment: Deployment, jhelper: JujuHelper):
+    def __init__(self, deployment: Deployment):
         super().__init__("Add K8S cloud in client", "Adding K8S cloud to Juju client")
         self.client = deployment.get_client()
-        self.jhelper = jhelper
         self.cloud_name = f"{deployment.name}{K8S_CLOUD_SUFFIX}"
         self.credential_name = f"{self.cloud_name}{CREDENTIAL_SUFFIX}"
 

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -307,7 +307,7 @@ def first_connected_server(servers: list) -> str | None:
             LOG.debug(f"Server {server} not in <ip>:<port> format")
             continue
 
-        ip = ipaddress.ip_address(ip_port[0])
+        ip = ipaddress.ip_address(ip_port[0].lstrip("[").rstrip("]"))
         port = int(ip_port[1])
 
         try:

--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -182,6 +182,7 @@ def jhelper_base(tmp_path: Path) -> juju.JujuHelper:
     jhelper = juju.JujuHelper.__new__(juju.JujuHelper)
     jhelper.data_location = tmp_path
     jhelper.controller = AsyncMock()  # type: ignore
+    jhelper.model_connectors = []
     return jhelper
 
 


### PR DESCRIPTION
Currently the juju controller is bootstrapped on the local machine as manual cloud. This will cause issues for maintaining HA controller and during upgrades. So the strategy has been changed to bootstrap lxd controller instead and finally migrating them to a juju controller on k8s.

Deploying LXD controller should be performed manually by the user. sunbeam bootstrap checks for LXD controller on localhost cloud and perform the following steps:
* Add manual cloud and Empty credentials
* Add machine model
* Add the bootstrap machine to the model
* Add juju space and update the model with the space
* Deploy sunbeam-machine plan and microk8s/k8s plan
* Add k8s cloud on juju client
* Bootstrap juju controller on k8s with controller-service-type loadbalancer (The flag will create a lb ip for controller so that it will be reachable for non-bootstrap machines). Set model defaults for secret-backend to internal to avoid [LP#2091724](https://bugs.launchpad.net/snap-openstack/+bug/2091724)
* Add manual cloud and empty credentials on juju controller on k8s
* Migrate machine model from lxd controller to k8s based juju controller
* Add k8s credential to juju controller on k8s

Some other internal changes:
* Add new config `juju_controller_migrated_to_k8s` in cluster database to identify whether juju controller migration to k8s is completed
* Add checks to verify if user is part of lxd group and controller exists on cloud `localhost`