### PR TITLE
MAAS: Fix clusterd address not set

### DIFF
--- a/sunbeam-python/sunbeam/feature_manager.py
+++ b/sunbeam-python/sunbeam/feature_manager.py
@@ -194,7 +194,11 @@ class FeatureManager:
             except AttributeError:
                 LOG.debug("Feature %r is not enable / disable feature", feature.name)
                 enabled = False
-            except (SunbeamException, ClusterServiceUnavailableException) as e:
+            except (
+                SunbeamException,
+                ValueError,
+                ClusterServiceUnavailableException,
+            ) as e:
                 LOG.debug(
                     "Feature %r failed to check if it is enabled: %r", feature.name, e
                 )


### PR DESCRIPTION
In the beginning, MAAS does not have a clusterd address set. In this case, a value error is raised, catch it and consider the feature not enabled.