### PR TITLE
Add env to run_cmd_on_unit_payload

### DIFF
--- a/sunbeam-python/sunbeam/steps/mysql.py
+++ b/sunbeam-python/sunbeam/steps/mysql.py
@@ -118,9 +118,12 @@ class ConfigureMySQLStep(BaseStep):
                         OPENSTACK_MODEL,
                         cmd,
                         "mysql",
-                        SET_MAX_CONNECTIONS_TIMEOUT,
+                        env=None,
+                        timeout=SET_MAX_CONNECTIONS_TIMEOUT,
                     )
                 )
+                if res["return-code"] != 0:
+                    return Result(ResultType.FAILED, res.get("stderr"))
                 LOG.debug("Set max_connections on %s: %s", mysql, res)
             except TimeoutException as e:
                 LOG.debug(f"Timeout setting max_connections on {mysql}", exc_info=True)

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_mysql.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_mysql.py
@@ -46,6 +46,7 @@ class TestConfigureMySQLStep(unittest.TestCase):
             "sunbeam.steps.mysql.get_mysqls",
             Mock(return_value=["mysql"]),
         ):
+            self.jhelper.run_cmd_on_unit_payload.return_value = {"return-code": 0}
             step = ConfigureMySQLStep(self.jhelper)
             result = step.run()
 
@@ -91,6 +92,7 @@ class TestConfigureMySQLStep(unittest.TestCase):
             "sunbeam.steps.mysql.get_mysqls",
             Mock(return_value=["mysql"]),
         ):
+            self.jhelper.run_cmd_on_unit_payload.return_value = {"return-code": 1}
             step = ConfigureMySQLStep(self.jhelper)
             result = step.run()
 


### PR DESCRIPTION
* Add env parameter to run_cmd_on_unit_payload to pass environment to pebble exec command.
* Do not check return-code in run_cmd_on-Unit_payload. The caller should do the error handling based on
return-code. There are few examples in vault command that return code 2 but provides necessary output.
* Update ConfigureMySqlStep based on above changes.