### PR TITLE
MAAS: implement cluster destroy

### DIFF
--- a/sunbeam-python/sunbeam/clusterd/service.py
+++ b/sunbeam-python/sunbeam/clusterd/service.py
@@ -107,7 +107,13 @@ class URLNotFoundException(RemoteException):
 class BaseService(ABC):
     """BaseService is the base service class for sunbeam clusterd services."""
 
-    def __init__(self, session: Session, endpoint: str, certs=None):
+    def __init__(
+        self,
+        session: Session,
+        endpoint: str,
+        certs=None,
+        timeout: int | float | None = None,
+    ):
         """Creates a new BaseService for the sunbeam clusterd API.
 
         The service class is used to provide convenient APIs for clients to
@@ -120,6 +126,17 @@ class BaseService(ABC):
         self.__session = session
         self._endpoint = endpoint
         self._certs = certs
+        self._timeout = timeout
+
+    @property
+    def timeout(self):
+        """Get the timeout for the service."""
+        return self._timeout
+
+    @timeout.setter
+    def timeout(self, timeout: int | float | None):
+        """Set the timeout for the service."""
+        self._timeout = timeout
 
     def _request(self, method, path, **kwargs):  # noqa: C901 too complex
         if path.startswith("/"):
@@ -130,7 +147,11 @@ class BaseService(ABC):
         try:
             LOG.debug("[%s] %s, args=%s", method, url, kwargs)
             response = self.__session.request(
-                method=method, url=url, cert=self._certs, **kwargs
+                method=method,
+                url=url,
+                cert=self._certs,
+                timeout=self._timeout,
+                **kwargs,
             )
             output = response.text
             if redact_response:

--- a/sunbeam-python/sunbeam/core/deployment.py
+++ b/sunbeam-python/sunbeam/core/deployment.py
@@ -316,9 +316,6 @@ class Deployment(pydantic.BaseModel):
 
     def _load_tfhelpers(self):
         feature_manager = self.get_feature_manager()
-        # TODO(gboutry): Remove snap instanciation
-        snap = Snap()
-
         tfvar_map = copy.deepcopy(MANIFEST_ATTRIBUTES_TFVAR_MAP)
         tfvar_map_feature = feature_manager.get_all_feature_manifest_tfvar_map()
         tfvar_map = sunbeam_utils.merge_dict(tfvar_map, tfvar_map_feature)
@@ -356,7 +353,7 @@ class Deployment(pydantic.BaseModel):
         for tfplan, tf_manifest in terraform_plans.items():
             tfplan_dir = TERRAFORM_DIR_NAMES.get(tfplan, tfplan)
             src = tf_manifest.source
-            dst = snap.paths.user_common / "etc" / self.name / tfplan_dir
+            dst = self.plans_directory / tfplan_dir
             LOG.debug(f"Updating {dst} from {src}...")
             shutil.copytree(src, dst, dirs_exist_ok=True)
 
@@ -368,6 +365,13 @@ class Deployment(pydantic.BaseModel):
                 env=env,
                 clusterd_address=self.get_clusterd_http_address(),
             )
+
+    @property
+    def plans_directory(self) -> pathlib.Path:
+        """Return plans directory."""
+        # TODO(gboutry): Remove snap instanciation
+        snap = Snap()
+        return snap.paths.user_common / "etc" / self.name
 
     def get_tfhelper(self, tfplan: str) -> TerraformHelper:
         """Get an instance of TerraformHelper for the given tfplan.

--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -291,6 +291,17 @@ class JujuHelper:
         finally:
             os.environ["HOME"] = old_home
 
+    async def destroy_model(
+        self, model: str, destroy_storage: bool = False, force: bool = False
+    ):
+        """Destroy model.
+
+        :model: Name of the model
+        """
+        await self.controller.destroy_models(
+            model, destroy_storage=destroy_storage, force=force
+        )
+
     async def integrate(
         self,
         model: str,

--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -63,6 +63,9 @@ class JujuManifest(pydantic.BaseModel):
     scale_args: list[str] = Field(
         default=[], description="Extra args for juju enable-ha"
     )
+    destroy_args: list[str] = Field(
+        default=[], description="Extra args for juju destroy-controller"
+    )
 
 
 class CharmManifest(pydantic.BaseModel):

--- a/sunbeam-python/sunbeam/features/interface/v1/base.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/base.py
@@ -71,7 +71,11 @@ class DisabledFeatureError(FeatureError):
 
 
 class NotAutomaticFeatureError(FeatureError):
-    """Exception rased when feature cannot be automatically enabled."""
+    """Exception raised when feature cannot be automatically enabled."""
+
+
+class HasRequirersFeaturesError(FeatureError):
+    """Exception raised when feature has requirers features."""
 
 
 class ClickInstantiator:
@@ -685,7 +689,7 @@ class EnableDisableFeature(BaseFeature, Generic[ConfigType]):
                 if requirement.name != self.name:
                     continue
                 if state == "disable":
-                    raise FeatureError(
+                    raise HasRequirersFeaturesError(
                         f"{feature.name} is enabled and requires {self.name}"
                     )
                 message = (

--- a/sunbeam-python/sunbeam/steps/features.py
+++ b/sunbeam-python/sunbeam/steps/features.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import queue
+
+from rich.console import Console
+
+from sunbeam.clusterd.service import ClusterServiceUnavailableException
+from sunbeam.core.common import BaseStep, Result, ResultType, Status, SunbeamException
+from sunbeam.core.deployment import Deployment
+from sunbeam.core.juju import (
+    ModelNotFoundException,
+)
+from sunbeam.features.interface.v1.base import (
+    EnableDisableFeature,
+    HasRequirersFeaturesError,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+class DisableEnabledFeatures(BaseStep):
+    """Destroy a set of features in a Juju model."""
+
+    def __init__(self, deployment: Deployment, no_prompt: bool = False):
+        super().__init__("Disable features", "Disabling features")
+        self.deployment = deployment
+        self.no_prompt = no_prompt
+        self.feature_manager = deployment.get_feature_manager()
+        self.enabled_features: queue.Queue["EnableDisableFeature"] | None
+
+    def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user."""
+        return not self.no_prompt
+
+    def prompt(self, console: Console | None = None, show_hint: bool = False) -> None:
+        """Determines if the step can take input from the user."""
+        return super().prompt(console, show_hint)
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Check if the step should be skipped."""
+        try:
+            enabled_features = self.feature_manager.enabled_features(self.deployment)
+        except ClusterServiceUnavailableException:
+            return Result(ResultType.SKIPPED)
+        if not enabled_features:
+            return Result(ResultType.SKIPPED)
+        self.enabled_features = queue.Queue()
+        for feature in enabled_features:
+            self.enabled_features.put(feature)
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Status | None = None) -> Result:
+        """Disable the features."""
+        if not self.enabled_features:
+            return Result(ResultType.COMPLETED)
+
+        while not self.enabled_features.empty():
+            feature = self.enabled_features.get()
+            LOG.info("Disabling feature %s", feature.name)
+            try:
+                feature.disable_feature(self.deployment, False)
+            except HasRequirersFeaturesError:
+                LOG.info("Feature %s has requirers, retrying later", feature.name)
+                self.enabled_features.put(feature)
+                continue
+            except ModelNotFoundException as e:
+                return Result(
+                    ResultType.FAILED,
+                    f"Model not found: {e}",
+                )
+            except SunbeamException as e:
+                return Result(
+                    ResultType.FAILED,
+                    f"Failed to disable feature {feature}: {e}",
+                )
+        return Result(ResultType.COMPLETED, "Features disabled")

--- a/sunbeam-python/sunbeam/steps/microk8s.py
+++ b/sunbeam-python/sunbeam/steps/microk8s.py
@@ -58,6 +58,7 @@ from sunbeam.steps.k8s import (
     CheckOvnK8SDistributionStep,
     CheckRabbitmqK8SDistributionStep,
     CordonK8SUnitStep,
+    DestroyK8SApplicationStep,
     DrainK8SUnitStep,
     MigrateK8SKubeconfigStep,
     RemoveK8SUnitsStep,
@@ -338,3 +339,8 @@ class CordonMicroK8SUnitStep(CordonK8SUnitStep):
 
 class DrainMicroK8SUnitStep(DrainK8SUnitStep):
     _SUBSTRATE = APPLICATION
+
+
+class DestroyMicroK8SApplicationStep(DestroyK8SApplicationStep):
+    _APPLICATION = APPLICATION
+    _CONFIG_KEY = MICROK8S_CONFIG_KEY

--- a/sunbeam-python/sunbeam/steps/sunbeam_machine.py
+++ b/sunbeam-python/sunbeam/steps/sunbeam_machine.py
@@ -22,6 +22,7 @@ from sunbeam.core.manifest import Manifest
 from sunbeam.core.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
+    DestroyMachineApplicationStep,
     RemoveMachineUnitsStep,
 )
 from sunbeam.core.terraform import TerraformHelper
@@ -128,3 +129,31 @@ class RemoveSunbeamMachineUnitsStep(RemoveMachineUnitsStep):
     def get_unit_timeout(self) -> int:
         """Return unit timeout in seconds."""
         return SUNBEAM_MACHINE_UNIT_TIMEOUT
+
+
+class DestroySunbeamMachineApplicationStep(DestroyMachineApplicationStep):
+    """Destroy Sunbeam Machine application using Terraform."""
+
+    def __init__(
+        self,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+        model: str,
+    ):
+        super().__init__(
+            client,
+            tfhelper,
+            jhelper,
+            manifest,
+            CONFIG_KEY,
+            [APPLICATION],
+            model,
+            "Destroy Sunbeam Machine",
+            "Destroying Sunbeam Machine",
+        )
+
+    def get_application_timeout(self) -> int:
+        """Return application timeout in seconds."""
+        return SUNBEAM_MACHINE_APP_TIMEOUT

--- a/sunbeam-python/sunbeam/steps/terraform.py
+++ b/sunbeam-python/sunbeam/steps/terraform.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2024 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import shutil
+
+from rich.status import Status
+
+from sunbeam.core.common import BaseStep, Result, ResultType
+from sunbeam.core.deployment import Deployment
+
+LOG = logging.getLogger(__name__)
+
+
+class CleanTerraformPlansStep(BaseStep):
+    def __init__(self, deployment: Deployment):
+        super().__init__(
+            "Clean terraform directories", "Cleaning terraform directories"
+        )
+        self.tf_plans = deployment.plans_directory
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        if not self.tf_plans.exists():
+            return Result(ResultType.SKIPPED)
+
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Status | None = None) -> Result:
+        """Delete terraform plan directories."""
+        try:
+            shutil.rmtree(self.tf_plans)
+        except Exception as e:
+            LOG.error("Error cleaning terraform directories: %s", e)
+            return Result(ResultType.FAILED)
+        return Result(ResultType.COMPLETED)

--- a/sunbeam-python/tests/unit/sunbeam/core/test_deployment.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_deployment.py
@@ -68,6 +68,7 @@ def deployment(mocker, snap):
             Deployment._load_tfhelpers, dep
         )
         dep.get_client.side_effect = ValueError("No clusterd in testing...")
+        dep.plans_directory = Path("/tmp/plans")
         dep.__setattr__("_tfhelpers", {})
         dep._manifest = None
         dep.__setattr__("name", "test_deployment")
@@ -136,7 +137,7 @@ class TestDeployment:
             [
                 call(
                     Path(snap.paths.snap / "etc" / tfplan_dir),
-                    Path(snap.paths.user_common / "etc" / deployment.name / tfplan_dir),
+                    Path(deployment.plans_directory / tfplan_dir),
                     dirs_exist_ok=True,
                 )
                 for tfplan_dir in TERRAFORM_DIR_NAMES.values()
@@ -165,7 +166,7 @@ class TestDeployment:
                     "source"
                 ]
             ),
-            Path(snap.paths.user_common / "etc" / deployment.name / tfplan_dir),
+            Path(deployment.plans_directory / tfplan_dir),
             dirs_exist_ok=True,
         )
         assert tfhelper.plan == tfplan


### PR DESCRIPTION
Add command to destroy current MAAS deployment.

Add several workarounds for charm deletion to ensure they get out of the deployment.

At the end, the deployment should be ready to re-run bootstrap and deploy.