### PR TITLE
Include openssh-client in the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -215,6 +215,8 @@ parts:
       - cython3
       - rustc
       - cargo
+    stage-packages:
+      - openssh-client
     override-prime: |
       craftctl default
       # Write out snap hooks


### PR DESCRIPTION
Juju 3.6 is using scp to upload the controller to the juju machine in MAAS mode.