### PR TITLE
Add support for multiple ippools

### DIFF
--- a/sunbeam-python/sunbeam/features/interface/v1/base.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/base.py
@@ -32,6 +32,7 @@ from sunbeam.core.manifest import FeatureConfig, Manifest, SoftwareConfig
 
 # from sunbeam.feature_manager import FeatureManager
 from sunbeam.features.interface import utils
+from sunbeam.provider.maas.deployment import MAAS_TYPE
 
 LOG = logging.getLogger(__name__)
 _GROUPS: dict[str, Type["BaseFeatureGroup"]] = {}
@@ -841,3 +842,11 @@ class EnableDisableFeature(BaseFeature, Generic[ConfigType]):
         Return the commands available once the feature is enabled.
         """
         return {}
+
+
+def is_maas_deployment(deployment: Deployment) -> bool:
+    """Check if deployment type is maas."""
+    if deployment.type == MAAS_TYPE:
+        return True
+
+    return False

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -148,7 +148,7 @@ from sunbeam.steps.microk8s import (
 )
 from sunbeam.steps.openstack import (
     DeployControlPlaneStep,
-    OpenStackPatchLoadBalancerServicesStep,
+    OpenStackPatchLoadBalancerServicesIPStep,
     PromptRegionStep,
 )
 from sunbeam.steps.sunbeam_machine import (
@@ -652,7 +652,7 @@ def bootstrap(
     plan5: list[BaseStep] = []
 
     if is_control_node:
-        plan5.append(OpenStackPatchLoadBalancerServicesStep(client))
+        plan5.append(OpenStackPatchLoadBalancerServicesIPStep(client))
 
     # NOTE(jamespage):
     # As with MicroCeph, always deploy the openstack-hypervisor charm

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -98,6 +98,7 @@ from sunbeam.provider.maas.steps import (
     MaasBootstrapJujuStep,
     MaasClusterStatusStep,
     MaasConfigureMicrocephOSDStep,
+    MaasCreateLoadBalancerIPPoolsStep,
     MaasDeployInfraMachinesStep,
     MaasDeployK8SApplicationStep,
     MaasDeployMachinesStep,
@@ -185,7 +186,8 @@ from sunbeam.steps.microk8s import (
 from sunbeam.steps.openstack import (
     DeployControlPlaneStep,
     DestroyControlPlaneStep,
-    OpenStackPatchLoadBalancerServicesStep,
+    OpenStackPatchLoadBalancerServicesIPPoolStep,
+    OpenStackPatchLoadBalancerServicesIPStep,
     PromptRegionStep,
 )
 from sunbeam.steps.sunbeam_machine import (
@@ -734,6 +736,12 @@ def deploy(
             proxy_settings=proxy_settings,
         )
     )
+    plan2.append(MaasCreateLoadBalancerIPPoolsStep(deployment, client, maas_client))
+    plan2.append(
+        OpenStackPatchLoadBalancerServicesIPPoolStep(
+            client, deployment.public_api_label
+        )
+    )
     # Redeploy of Microceph is required to fill terraform vars
     # related to traefik-rgw/keystone-endpoints offers from
     # openstack model
@@ -748,7 +756,7 @@ def deploy(
             refresh=True,
         )
     )
-    plan2.append(OpenStackPatchLoadBalancerServicesStep(client))
+    plan2.append(OpenStackPatchLoadBalancerServicesIPStep(client))
     plan2.append(TerraformInitStep(tfhelper_hypervisor_deploy))
     plan2.append(
         DeployHypervisorApplicationStep(


### PR DESCRIPTION
Add support to create multiple ippools
in maas mode.

* In maas mode, make internal ip address pool as default so that LB IPs will be allocated
by default from this pool.
* Add step to create or update IPAddressPool k8s resource with addresspool from public_api.
* As part of the same step create or update L2Advertisement for the pool to allow connectivity over L2.
* Update Service annotations to include ip address pool for services that requires public connectivity.