### PR TITLE
[tls] Fix group names

### DIFF
--- a/sunbeam-python/sunbeam/features/tls/ca.py
+++ b/sunbeam-python/sunbeam/features/tls/ca.py
@@ -503,8 +503,8 @@ class CaTlsFeature(TlsFeature):
         Return the commands available once the feature is enabled.
         """
         return {
-            "init": [{"name": self.group, "command": self.tls_group}],
-            "init.tls": [{"name": self.name, "command": self.ca_group}],
+            "init": [{"name": self.group.name, "command": self.tls_group}],
+            "init.tls": [{"name": "ca", "command": self.ca_group}],
             "init.tls.ca": [
                 {"name": "unit_certs", "command": self.configure},
                 {


### PR DESCRIPTION
Fix tls group name to 'tls' instead of FeatureGroup class 
and ca group name to 'ca'

Fixes:[ LP#2091259](https://bugs.launchpad.net/snap-openstack/+bug/2091259)