### PR TITLE
Remove OS variable from running process

### DIFF
--- a/sunbeam-python/sunbeam/main.py
+++ b/sunbeam-python/sunbeam/main.py
@@ -33,7 +33,7 @@ from sunbeam.commands import proxy as proxy_cmds
 from sunbeam.commands import utils as utils_cmds
 from sunbeam.core import deployments as deployments_jobs
 from sunbeam.provider import commands as provider_cmds
-from sunbeam.utils import CatchGroup
+from sunbeam.utils import CatchGroup, clean_env
 
 LOG = logging.getLogger()
 
@@ -98,6 +98,7 @@ def juju(ctx):
 
 
 def main():
+    clean_env()
     snap = Snap()
     logfile = log.prepare_logfile(snap.paths.user_common / "logs", "sunbeam")
     log.setup_root_logging(logfile)

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -18,6 +18,7 @@ import collections.abc
 import ipaddress
 import json
 import logging
+import os
 import re
 import secrets
 import socket
@@ -440,3 +441,15 @@ class DefaultableMappingParameter(click.ParamType):
 
         # Use square braces to indicate an option or optional argument.
         return f"[{repr_str}]"
+
+
+def clean_env():
+    """Remove unwanted environment variables from running process.
+
+    OpenStack variables defined in the environment can interfere with
+    the operation of the snap. When these variables are actually needed,
+    the snap set them itself.
+    """
+    for key in os.environ:
+        if key.startswith("OS_"):
+            os.environ.pop(key)


### PR DESCRIPTION
If the user sets OS Environment variables, it can interfere with some usage of the openstacksdk library or the terraform provider. When the snap actually needs to set these values, it will do so.

Remove the variables from the environment, to ensure proper control from the snap.