### PR TITLE
Remove deprecated parameters

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -79,7 +79,7 @@ jobs:
 
           sg snap_daemon "openstack.sunbeam enable orchestration"
           sg snap_daemon "openstack.sunbeam enable loadbalancer"
-          sg snap_daemon "openstack.sunbeam enable dns --nameservers=testing.github."
+          sg snap_daemon "openstack.sunbeam enable dns testing.github."
           sg snap_daemon "openstack.sunbeam disable dns"
           sg snap_daemon "openstack.sunbeam disable loadbalancer"
           sg snap_daemon "openstack.sunbeam disable orchestration"

--- a/.github/workflows/test-snap.yml
+++ b/.github/workflows/test-snap.yml
@@ -95,7 +95,7 @@ jobs:
           sg snap_daemon "sunbeam launch"
           sg snap_daemon "sunbeam enable orchestration"
           sg snap_daemon "sunbeam enable loadbalancer"
-          sg snap_daemon "sunbeam enable dns --nameservers=testing.github."
+          sg snap_daemon "sunbeam enable dns testing.github."
           sg snap_daemon "sunbeam enable telemetry"
           sg snap_daemon "sunbeam enable observability"
           sg snap_daemon "sunbeam enable vault --dev-mode"

--- a/sunbeam-python/sunbeam/commands/manifest.py
+++ b/sunbeam-python/sunbeam/commands/manifest.py
@@ -31,7 +31,6 @@ from sunbeam.clusterd.service import (
 from sunbeam.core.common import FORMAT_TABLE, FORMAT_YAML
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.manifest import Manifest, SoftwareConfig
-from sunbeam.utils import argument_with_deprecated_option
 
 if typing.TYPE_CHECKING:
     from sunbeam.features.interface.v1.base import BaseFeature
@@ -138,7 +137,7 @@ def list_manifests(ctx: click.Context, format: str) -> None:
 
 
 @click.command()
-@argument_with_deprecated_option("id", type=str, help="Manifest ID")
+@click.argument("id", type=str)
 @click.pass_context
 def show(ctx: click.Context, id: str) -> None:
     """Show Manifest data.

--- a/sunbeam-python/sunbeam/commands/plans.py
+++ b/sunbeam-python/sunbeam/commands/plans.py
@@ -28,7 +28,6 @@ from sunbeam.core.common import (
     FORMAT_YAML,
 )
 from sunbeam.core.deployment import Deployment
-from sunbeam.utils import argument_with_deprecated_option
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -74,9 +73,7 @@ def list_plans(ctx: click.Context, format: str):
 
 
 @plans.command("unlock")
-@argument_with_deprecated_option(
-    "plan", type=str, help="Name of the terraform plan to unlock."
-)
+@click.argument("plan", type=str)
 @click.option("--force", is_flag=True, default=False, help="Force unlock the plan.")
 @click.pass_context
 def unlock_plan(ctx: click.Context, plan: str, force: bool):

--- a/sunbeam-python/sunbeam/features/dns/README.md
+++ b/sunbeam-python/sunbeam/features/dns/README.md
@@ -7,7 +7,7 @@ This feature provides a DNS service for Sunbeam. It's based on [Designate](https
 To enable the DNS service, you need an already bootstraped Sunbeam instance. Then, you can install the feature with:
 
 ```bash
-sunbeam enable dns --nameservers="<ns records>"
+sunbeam enable dns "<ns records>"
 ```
 
 ## Contents
@@ -22,7 +22,7 @@ Services are constituted of charms, i.e. operator code, and ROCKs, the correspon
 
 ## Configuration
 
-The NS records you pass to the `--nameservers` must be a fully qualified domain name ending with a dot.
+The NS records you pass to the `nameservers` must be a fully qualified domain name ending with a dot.
 It must redirect towards the IP address of the bind instance. See [#commands](#commands) to retrieve the address of the bind instance.
 
 ## Commands

--- a/sunbeam-python/sunbeam/features/dns/feature.py
+++ b/sunbeam-python/sunbeam/features/dns/feature.py
@@ -42,7 +42,6 @@ from sunbeam.features.interface.v1.openstack import (
     TerraformPlanLocation,
 )
 from sunbeam.utils import (
-    argument_with_deprecated_option,
     click_option_show_hints,
     pass_method_obj,
 )
@@ -190,15 +189,7 @@ class DnsFeature(OpenStackControlPlaneFeature):
         }
 
     @click.command()
-    @argument_with_deprecated_option(
-        "nameservers",
-        type=str,
-        help="""\
-        Space delimited list of nameservers. These are the nameservers that
-        have been provided to the domain registrar in order to delegate
-        the domain to DNS service. e.g. "ns1.example.com. ns2.example.com."
-        """,
-    )
+    @click.argument("nameservers", type=str)
     @click_option_show_hints
     @pass_method_obj
     def enable_cmd(

--- a/sunbeam-python/sunbeam/features/pro/feature.py
+++ b/sunbeam-python/sunbeam/features/pro/feature.py
@@ -42,7 +42,6 @@ from sunbeam.core.terraform import (
 )
 from sunbeam.features.interface.v1.base import EnableDisableFeature
 from sunbeam.utils import (
-    argument_with_deprecated_option,
     click_option_show_hints,
     pass_method_obj,
 )
@@ -258,9 +257,7 @@ class ProFeature(EnableDisableFeature):
 
     @click.command()
     @pass_method_obj
-    @argument_with_deprecated_option(
-        "token", type=str, short_form="t", help="Ubuntu Pro token"
-    )
+    @click.argument("token", type=str)
     @click_option_show_hints
     def enable_cmd(self, deployment: Deployment, token: str, show_hints: bool) -> None:
         """Enable Ubuntu Pro across deployment.

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -158,7 +158,6 @@ from sunbeam.steps.sunbeam_machine import (
 )
 from sunbeam.utils import (
     CatchGroup,
-    argument_with_deprecated_option,
     click_option_show_hints,
 )
 
@@ -677,7 +676,7 @@ def _write_to_file(token: str, output: Path):
 
 
 @click.command()
-@argument_with_deprecated_option("name", type=str, help="Fully qualified node name.")
+@click.argument("name", type=str)
 @click.option(
     "-f",
     "--format",
@@ -752,7 +751,7 @@ def add(
 
 
 @click.command()
-@argument_with_deprecated_option("token", type=str, help="Join token.")
+@click.argument("token", type=str)
 @click.option("-a", "--accept-defaults", help="Accept all defaults.", is_flag=True)
 @click.option(
     "--role",
@@ -956,7 +955,7 @@ def list_nodes(
     help=("Skip safety checks and ignore cleanup errors for some tasks"),
     is_flag=True,
 )
-@argument_with_deprecated_option("name", type=str, help="Fully qualified node name.")
+@click.argument("name", type=str)
 @click_option_show_hints
 @click.pass_context
 def remove(ctx: click.Context, name: str, force: bool, show_hints: bool) -> None:

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -185,7 +185,6 @@ from sunbeam.steps.terraform import CleanTerraformPlansStep
 from sunbeam.utils import (
     CatchGroup,
     DefaultableMappingParameter,
-    argument_with_deprecated_option,
     click_option_show_hints,
 )
 
@@ -865,9 +864,9 @@ def list_nodes(ctx: click.Context, format: str, show_hints: bool) -> None:
 
 
 @click.command("maas")
-@argument_with_deprecated_option("name", type=str, help="Name of the deployment")
-@argument_with_deprecated_option("token", type=str, help="API token")
-@argument_with_deprecated_option("url", type=str, help="API URL")
+@click.argument("name", type=str)
+@click.argument("token", type=str)
+@click.argument("url", type=str)
 @click_option_show_hints
 def add_maas(name: str, token: str, url: str, show_hints: bool) -> None:
     """Add MAAS-backed deployment to registered deployments."""

--- a/sunbeam-python/sunbeam/utils.py
+++ b/sunbeam-python/sunbeam/utils.py
@@ -328,55 +328,6 @@ def first_connected_server(servers: list) -> str | None:
     return None
 
 
-def argument_with_deprecated_option(
-    name: str,
-    type=str,
-    help: str | None = None,
-    short_form: str | None = None,
-    **kwargs,
-):
-    """Decorator to create an argument with a deprecated option."""
-    option_name = name + "_option"
-
-    def callback(ctx: click.Context, param: click.Parameter, argument_value):
-        """Swap option value from option to argument."""
-        option_value = ctx.params.pop(option_name, None)
-        if option_value is not None:
-            if argument_value:
-                raise click.UsageError(
-                    f"{name} cannot be used as both an option and an argument,"
-                    " use argument."
-                )
-            # Set the value of the argument by the option value
-            return option_value
-        return argument_value
-
-    def decorator(func: click.decorators.FC) -> click.decorators.FC:
-        arg_def = click.argument(
-            name,
-            type=type,
-            required=False,
-            callback=callback,
-            **kwargs,
-        )
-        option: tuple[str, str] | tuple[str]
-        if short_form:
-            option = (f"-{short_form}", f"--{name}")
-        else:
-            option = (f"--{name}",)
-        option_def = click.option(
-            *option,
-            option_name,
-            # This is the key to make the option processed before argument
-            is_eager=True,
-            help=(help + ". Deprecated, use argument instead" if help else None),
-            **kwargs,
-        )
-        return arg_def(option_def(func))
-
-    return decorator
-
-
 def click_option_show_hints(func: click.decorators.FC) -> click.decorators.FC:
     """Common decorator to show hints for questions."""
     return click.option(


### PR DESCRIPTION
All these parameter options have been deprecated months ago in favor of using an argument. This allows for a better semantic use of the CLI.

The following commands have lost the highlighted option in favor of an argument:
Local mode:
 sunbeam cluster add `--name`
 sunbeam cluster join `--token`
 sunbeam cluster remove `--token`
 
MaaS mode:
 sunbeam deployment add maas `--name` `--token` `--url`

utils:
 sunbeam plans unlock `--plan`
 sunbeam manifest show `--id`
 
features:
 sunbeam enable dns `--nameservers`
 sunbeam enable pro `--token`