### PR TITLE
Make unit tests py3.12 compatible

### DIFF
--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -303,7 +303,7 @@ async def test_jhelper_get_leader_unit(
     app = "k8s"
     unit = await jhelper.get_leader_unit(app, "control-plane")
     assert unit is not None
-    assert applications.get.called_with(app)
+    applications.get.assert_called_with(app)
 
 
 @pytest.mark.asyncio
@@ -334,7 +334,7 @@ async def test_jhelper_get_application(
 ):
     app = await jhelper.get_application("k8s", "control-plane")
     assert app is not None
-    assert applications.get.called_with("k8s")
+    applications.get.assert_called_with("k8s")
 
 
 @pytest.mark.asyncio

--- a/sunbeam-python/tests/unit/sunbeam/test_utils.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_utils.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 import textwrap
-from dataclasses import InitVar
 from unittest.mock import mock_open, patch
 
 import pytest
-from pydantic import PrivateAttr
-from pydantic.dataclasses import dataclass
 
 import sunbeam.utils as utils
 
@@ -56,25 +53,6 @@ def ifaddresses():
     with patch("sunbeam.utils.netifaces.ifaddresses") as p:
         p.side_effect = lambda nic: IFADDRESSES.get(nic)
         yield p
-
-
-@dataclass
-class B:
-    b_str: str | None = None
-    b_dict: dict | None = None
-
-
-@dataclass
-class A:
-    a_init: InitVar[str]
-    a_priv: str = PrivateAttr(default="a_priv")
-    a_int: int | None = None
-    a_str: str | None = None
-    a_dict: dict | None = None
-    a_dict_b: dict[str, B] | None = None
-
-    def __post_init__(self, a_init):
-        self.a_priv = "a_priv"
 
 
 class TestUtils:


### PR DESCRIPTION
* Use `assert_called_with` instead of `called_with`
* Remove unnecessary code in test_utils.py