### PR TITLE
Integrate k8s to observability stack

### DIFF
--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/main.tf
@@ -41,8 +41,9 @@ resource "juju_application" "grafana-agent" {
 }
 
 # juju integrate <principal-application>:cos-agent grafana-agent:cos-agent
-resource "juju_integration" "principal-application-to-grafana-agent" {
-  model = var.principal-application-model
+resource "juju_integration" "grafana_agent_integrations" {
+  for_each = toset(var.grafana-agent-integration-apps)
+  model    = var.principal-application-model
 
   application {
     name     = juju_application.grafana-agent.name
@@ -50,7 +51,7 @@ resource "juju_integration" "principal-application-to-grafana-agent" {
   }
 
   application {
-    name     = var.principal-application
+    name     = each.value
     endpoint = "cos-agent"
   }
 }
@@ -71,7 +72,7 @@ resource "juju_integration" "grafana-agent-to-cos-prometheus" {
 
 # juju integrate grafana-agent cos.loki-logging
 resource "juju_integration" "grafana-agent-to-cos-loki" {
-  count = var.logging-offer-url != null ? 1 : 0 
+  count = var.logging-offer-url != null ? 1 : 0
   model = var.principal-application-model
 
   application {

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/variables.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/variables.tf
@@ -15,8 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "principal-application" {
-  description = "Name of the deployed principal application that integrates with grafana-agent"
+variable "grafana-agent-integration-apps" {
+  description = "List of the deployed principal applications that integrate with grafana-agent"
+  type        = list(string)
+  default     = []
 }
 
 variable "principal-application-model" {

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -262,9 +262,10 @@ class DeployGrafanaAgentStep(BaseStep, JujuStepHelper):
 
     def run(self, status: Status | None = None) -> Result:
         """Execute configuration using terraform."""
+        integration_apps = ["k8s", "openstack-hypervisor"]
         extra_tfvars = {
             "principal-application-model": self.model,
-            "principal-application": "openstack-hypervisor",
+            "grafana-agent-integration-apps": integration_apps,
         }
         # Offer URLs from COS are added from feature
         extra_tfvars.update(


### PR DESCRIPTION
The COS dashboard now shows k8s cluster-related information including logging, alerts, and other usage data. It can be enabled with `sunbeam enable observability <embedded/external>`.