### PR TITLE
fix deployment with ipv6 management network

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ipaddress
 import logging
 
 import petname  # type: ignore [import-untyped]
@@ -154,6 +155,8 @@ class LocalDeployment(Deployment):
     def get_clusterd_http_address(self) -> str:
         """Return the address of the clusterd server."""
         local_ip = utils.get_local_ip_by_cidr(self.get_management_cidr())
+        if ipaddress.ip_address(local_ip).version == 6:
+            local_ip = f"[{local_ip}]"
         address = f"https://{local_ip}:{CLUSTERD_PORT}"
         return address
 

--- a/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
@@ -69,6 +69,16 @@ class TestClusterdSteps:
         assert result.result_type == ResultType.COMPLETED
         init_step.client.cluster.bootstrap.assert_called_once()
 
+    def test_init_step_ipv6(self, cclient, mocker):
+        role = "control"
+        init_step = ClusterInitStep(cclient, [role], 0, "fd00::/108")
+        init_step.client = MagicMock()
+        init_step.fqdn = "node1"
+        mocker.patch("sunbeam.utils.get_local_ip_by_cidr", return_value="fd00::2")
+        result = init_step.run()
+        assert result.result_type == ResultType.COMPLETED
+        init_step.client.cluster.bootstrap.assert_called_once()
+
     def test_add_node_step(self, cclient):
         add_node_step = ClusterAddNodeStep(cclient, name="node-1")
         add_node_step.client = MagicMock()


### PR DESCRIPTION
The sunbeam bootstrap cannot process an IPv6 CIDR for the management network. It errors out with `Error: 400 Client Error: Bad Request for url: http+unix://%2Fvar%2Fsnap%2Fopenstack%2Fcommon%2Fstate%2Fcontrol.socket/core/control` and to find out what was causing that, I sniffed the communication using socat and got the following capture:

```
HTTP/1.1 400 Bad Request\r
Content-Type: application/json\r
X-Content-Type-Options: nosniff\r
Date: Wed, 08 Jan 2025 15:53:11 GMT\r
Content-Length: 203\r
\r
{"type":"error","status":"","status_code":0,"operation":"","error_code":400,"error":"invalid ip:port \"fd00::2:7000\", IPv6 addresses must be surrounded by square brackets","metadata":null}
```

This pull request should wrap the IP address returned in square brackets when preparing the http address for clusterd. I also added a bootstrap test that checks against an IPv6 private network, cribbed from the existing test.