### PR TITLE
Hide upgrade-release option

### DIFF
--- a/sunbeam-python/sunbeam/commands/refresh.py
+++ b/sunbeam-python/sunbeam/commands/refresh.py
@@ -52,6 +52,8 @@ console = Console()
     is_flag=True,
     show_default=True,
     default=False,
+    # note(gboutry): Hidden until supported
+    hidden=True,
     help="Upgrade OpenStack release.",
 )
 @click_option_show_hints


### PR DESCRIPTION
Hide upgrade-release option until upgrading to a newer release is supported. 2024.1 will be the base release, from which upgrade will be possible in the future.