### PR TITLE
Fix missing node name in cluster list

### DIFF
--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -243,7 +243,13 @@ class ExtendedAPIService(service.BaseService):
         """Get status of the cluster."""
         cluster = self._get("/1.0/status")
         members = cluster.get("metadata", {})
-        return {member["name"]: {"status": member["status"]} for member in members}
+        return {
+            member["name"]: {
+                "status": member["status"],
+                "address": member["address"],
+            }
+            for member in members
+        }
 
 
 class ClusterService(MicroClusterService, ExtendedAPIService):

--- a/sunbeam-python/sunbeam/steps/cluster_status.py
+++ b/sunbeam-python/sunbeam/steps/cluster_status.py
@@ -192,8 +192,11 @@ class ClusterStatusStep(abc.ABC, BaseStep):
         machines_status = {}
         status = run_sync(self.jhelper.get_model_status(model))
         for machine, machine_status in status["machines"].items():
+            machine_name = machine_status.get("hostname")
+            if not machine_name:
+                machine_name = machine_status.get("dns-name")
             machines_status[machine] = {
-                "name": machine_status["hostname"],
+                "name": machine_name,
                 "status": machine_status["instance-status"]["status"],
             }
         return machines_status

--- a/sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
@@ -20,6 +20,7 @@ import pytest
 import sunbeam.core.questions
 import sunbeam.provider.local.steps as local_steps
 import sunbeam.utils
+from sunbeam.core.common import ResultType
 
 
 @pytest.fixture(autouse=True)
@@ -63,6 +64,11 @@ def question_bank():
 @pytest.fixture()
 def jhelper():
     yield AsyncMock()
+
+
+@pytest.fixture()
+def deployment():
+    yield Mock()
 
 
 class TestLocalSetHypervisorUnitsOptionsStep:
@@ -154,3 +160,109 @@ class TestLocalSetHypervisorUnitsOptionsStep:
         step._fetch_nics = AsyncMock(return_value=nics_result)
         step.prompt()
         assert step.nics["maas0.local"] == "eth2"
+
+
+class TestLocalClusterStatusStep:
+    def test_run(self, deployment, jhelper):
+        status = Mock()
+        deployment.get_client().cluster.get_status.return_value = {
+            "node-1": {"status": "ONLINE", "address": "10.0.0.1"}
+        }
+
+        step = local_steps.LocalClusterStatusStep(deployment, jhelper)
+        result = step.run(status)
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_compute_status(self, deployment, jhelper):
+        model = "test-model"
+        hostname = "node-1"
+        host_ip = "10.0.0.1"
+
+        deployment.get_client().cluster.get_status.return_value = {
+            hostname: {"status": "ONLINE", "address": f"{host_ip}:7000"}
+        }
+        deployment.openstack_machines_model = model
+        jhelper.get_model_status.return_value = {
+            "machines": {
+                "0": {
+                    "hostname": hostname,
+                    "dns-name": host_ip,
+                    "instance-status": {"status": "running"},
+                }
+            },
+            "applications": {
+                "k8s": {
+                    "units": {
+                        "k8s/0": {
+                            "machine": "0",
+                            "workload-status": {"status": "active"},
+                        }
+                    }
+                }
+            },
+        }
+        expected_status = {
+            model: {
+                "0": {
+                    "hostname": hostname,
+                    "status": {
+                        "cluster": "ONLINE",
+                        "machine": "running",
+                        "control": "active",
+                    },
+                }
+            }
+        }
+
+        step = local_steps.LocalClusterStatusStep(deployment, jhelper)
+        actual_status = step._compute_status()
+
+        assert expected_status == actual_status
+
+    def test_compute_status_with_missing_hostname_in_model_status(
+        self, deployment, jhelper
+    ):
+        model = "test-model"
+        hostname = "node-1"
+        host_ip = "10.0.0.1"
+
+        deployment.get_client().cluster.get_status.return_value = {
+            hostname: {"status": "ONLINE", "address": f"{host_ip}:7000"}
+        }
+        deployment.openstack_machines_model = model
+        # missing hostname attribute in model status
+        jhelper.get_model_status.return_value = {
+            "machines": {
+                "0": {
+                    "dns-name": host_ip,
+                    "instance-status": {"status": "running"},
+                }
+            },
+            "applications": {
+                "k8s": {
+                    "units": {
+                        "k8s/0": {
+                            "machine": "0",
+                            "workload-status": {"status": "active"},
+                        }
+                    }
+                }
+            },
+        }
+        expected_status = {
+            model: {
+                "0": {
+                    "hostname": hostname,
+                    "status": {
+                        "cluster": "ONLINE",
+                        "machine": "running",
+                        "control": "active",
+                    },
+                }
+            }
+        }
+
+        step = local_steps.LocalClusterStatusStep(deployment, jhelper)
+        actual_status = step._compute_status()
+
+        assert expected_status == actual_status


### PR DESCRIPTION
In case of machines deployed before migration from lxd based juju controller
to k8s based juju controller, the hostname is missing in juju model status [1].
Because of which the cluster list command is broken and not showing node name.

As a workaround for bug [1], if hostname is not available in model status compare
dns-name with the IP address in microcluster status. If it matches update the node
name and cluster status based on microcluster record.

Fixes: LP#2095063

[1] https://github.com/juju/juju/issues/18641