### PR TITLE
Remove k8s from observability

### DIFF
--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -262,7 +262,7 @@ class DeployGrafanaAgentStep(BaseStep, JujuStepHelper):
 
     def run(self, status: Status | None = None) -> Result:
         """Execute configuration using terraform."""
-        integration_apps = ["k8s", "openstack-hypervisor"]
+        integration_apps = ["openstack-hypervisor"]
         extra_tfvars = {
             "principal-application-model": self.model,
             "grafana-agent-integration-apps": integration_apps,


### PR DESCRIPTION
This reverts commit c6bc2f7b710a2c310877452624a0011e0088d1a3, reversing changes made to 6379629c001a16348a8bd7600c7057260aabe225.

This feature is being removed for the time being as multiple grafana-agents on the same machine is not a supported feature.