### PR TITLE
Bump MAX_LOG_FILES

### DIFF
--- a/sunbeam-python/sunbeam/log.py
+++ b/sunbeam-python/sunbeam/log.py
@@ -20,7 +20,7 @@ from typing import Union
 
 from rich.logging import RichHandler
 
-MAX_LOG_FILES = 10
+MAX_LOG_FILES = 100
 
 
 def setup_root_logging(logfile: Path | None = None):


### PR DESCRIPTION
Ideally the log files should be handled by a proper log rotating, etc. Until then, bump the MAX_LOG_FILES not to delete recent Sunbeam's command log files so easily. Based on my experience, 100 log files are going to be ~10MB in total.

Related-Bug: LP: #2071906