### PR TITLE
Add flavors for SEV in configure command

### DIFF
--- a/cloud/etc/demo-setup/main.tf
+++ b/cloud/etc/demo-setup/main.tf
@@ -12,35 +12,43 @@ provider "openstack" {}
 
 # Flavors
 resource "openstack_compute_flavor_v2" "m1_tiny" {
-  name      = "m1.tiny"
-  ram       = "512"
-  vcpus     = "1"
-  disk      = "4"
-  is_public = true
+  for_each    = toset(["m1.tiny", "m1.tiny-sev"])
+  name        = each.key
+  ram         = "512"
+  vcpus       = "1"
+  disk        = "4"
+  is_public   = true
+  extra_specs = strcontains(each.key, "sev") ? { "hw:mem_encryption" : true } : {}
 }
 
 resource "openstack_compute_flavor_v2" "m1_small" {
-  name      = "m1.small"
-  ram       = "2048"
-  vcpus     = "1"
-  disk      = "30"
-  is_public = true
+  for_each    = toset(["m1.small", "m1.small-sev"])
+  name        = each.key
+  ram         = "2048"
+  vcpus       = "1"
+  disk        = "30"
+  is_public   = true
+  extra_specs = strcontains(each.key, "sev") ? { "hw:mem_encryption" : true } : {}
 }
 
 resource "openstack_compute_flavor_v2" "m1_medium" {
-  name      = "m1.medium"
-  ram       = "4096"
-  vcpus     = "2"
-  disk      = "60"
-  is_public = true
+  for_each    = toset(["m1.medium", "m1.medium-sev"])
+  name        = each.key
+  ram         = "4096"
+  vcpus       = "2"
+  disk        = "60"
+  is_public   = true
+  extra_specs = strcontains(each.key, "sev") ? { "hw:mem_encryption" : true } : {}
 }
 
 resource "openstack_compute_flavor_v2" "m1_large" {
-  name      = "m1.large"
-  ram       = "8192"
-  vcpus     = "4"
-  disk      = "90"
-  is_public = true
+  for_each    = toset(["m1.large", "m1.large-sev"])
+  name        = each.key
+  ram         = "8192"
+  vcpus       = "4"
+  disk        = "90"
+  is_public   = true
+  extra_specs = strcontains(each.key, "sev") ? { "hw:mem_encryption" : true } : {}
 }
 
 resource "openstack_images_image_v2" "ubuntu" {
@@ -51,8 +59,9 @@ resource "openstack_images_image_v2" "ubuntu" {
   visibility       = "public"
 
   properties = {
-    architecture    = "x86_64"
-    hypervisor_type = "qemu"
+    architecture     = "x86_64"
+    hypervisor_type  = "qemu"
+    hw_firmware_type = "uefi"
   }
 }
 


### PR DESCRIPTION
Update demo-setup terraform plan to create sev
enabled flavors and image.

* Create m1.* flavors with property hw:mem_encryption=true
* Add property hw_firmware_type=uefi in image creation