### PR TITLE
Comment out multiline question description

### DIFF
--- a/sunbeam-python/sunbeam/core/questions.py
+++ b/sunbeam-python/sunbeam/core/questions.py
@@ -362,7 +362,8 @@ def show_questions(
             default = ""
         lines.append(f"{outer_indent}{comment}{indent}# {question.question}")
         if description := question.description:
-            lines.append(f"{outer_indent}{comment}{indent}# {description}")
+            for line in description.splitlines():
+                lines.append(f"{outer_indent}{comment}{indent}# {line}")
         lines.append(f"{outer_indent}{comment}{indent}{key}: {default}")
 
     return lines


### PR DESCRIPTION
Having a multine question was not properly commented out, rending the manifest invalid yaml.

Closes-Bug: #2098077