### PR TITLE
Validate will exit 1 on failed tests

### DIFF
--- a/sunbeam-python/sunbeam/features/validation/feature.py
+++ b/sunbeam-python/sunbeam/features/validation/feature.py
@@ -15,6 +15,7 @@
 
 import logging
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -543,6 +544,10 @@ class ValidationFeature(OpenStackControlPlaneFeature):
             self._copy_file_from_tempest_container(
                 deployment, TEMPEST_VALIDATION_RESULT, output
             )
+
+        failed_tests_flag = int(action_result.get("failed-tests", 0))
+        if failed_tests_flag != 0:
+            sys.exit(failed_tests_flag)
 
     @click.command()
     def list_profiles(self) -> None:


### PR DESCRIPTION
The goal is to read the result of the juju action from the charm stored as a `failed-tests` flag in the `event.set_results()` call and exit with code 1 if there are test failures or unexpected successes. There is also a `return-code` value stored in the ActionEvent but it gets reset to `0` and I wasn't able to find a way for manually setting it to `1` carry through to the `run_validate_action()` call. Let me know if there's a better approach to this. There is a change in `sunbeam-charms` that goes along with this that will be uploaded tomorrow once I make a unit test adjustment.

[LP#2093175](https://bugs.launchpad.net/snap-openstack/+bug/2093175)