### PR TITLE
Allow passing --database on a maas deployment

### DIFF
--- a/sunbeam-python/sunbeam/core/common.py
+++ b/sunbeam-python/sunbeam/core/common.py
@@ -346,6 +346,27 @@ def click_option_topology(func: decorators.FC) -> decorators.FC:
     )(func)
 
 
+def click_option_database(func: click.decorators.FC) -> click.decorators.FC:
+    return click.option(
+        "--database",
+        default="auto",
+        type=click.Choice(
+            [
+                "auto",
+                "single",
+                "multi",
+            ],
+            case_sensitive=False,
+        ),
+        help=(
+            "Allows definition of the intended cluster configuration: "
+            "'auto' for automatic determination, "
+            "'single' for a single database, "
+            "'multi' for a database per service, "
+        ),
+    )(func)
+
+
 def update_config(client: Client, key: str, config: dict):
     client.cluster.update_config(key, json.dumps(config))
 

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -63,6 +63,7 @@ from sunbeam.core.common import (
     BaseStep,
     ResultType,
     Role,
+    click_option_database,
     click_option_topology,
     get_step_message,
     get_step_result,
@@ -547,24 +548,7 @@ def deploy_and_migrate_juju_controller(
     " Can be repeated and comma separated.",
 )
 @click_option_topology
-@click.option(
-    "--database",
-    default="auto",
-    type=click.Choice(
-        [
-            "auto",
-            "single",
-            "multi",
-        ],
-        case_sensitive=False,
-    ),
-    help=(
-        "Allows definition of the intended cluster configuration: "
-        "'auto' for automatic determination, "
-        "'single' for a single database, "
-        "'multi' for a database per service, "
-    ),
-)
+@click_option_database
 @click.option(
     "-c",
     "--controller",

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -57,6 +57,8 @@ from sunbeam.core.common import (
     FORMAT_TABLE,
     FORMAT_YAML,
     BaseStep,
+    click_option_database,
+    click_option_topology,
     get_step_message,
     run_plan,
     str_presenter,
@@ -499,6 +501,8 @@ def _name_mapper(node: dict) -> str:
     help="Manifest file.",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
 )
+@click_option_topology
+@click_option_database
 @click_option_show_hints
 @click.pass_context
 def deploy(
@@ -506,6 +510,7 @@ def deploy(
     manifest_path: Path | None = None,
     accept_defaults: bool = False,
     topology: str = "auto",
+    database: str = "auto",
     show_hints: bool = False,
 ) -> None:
     """Deploy the MAAS-backed deployment.
@@ -682,8 +687,7 @@ def deploy(
             jhelper,
             manifest,
             topology,
-            # maas deployment always deploys multiple databases
-            "large",
+            database,
             deployment.openstack_machines_model,
             proxy_settings=proxy_settings,
         )


### PR DESCRIPTION
Constrained MAAS deployments might benefit from using a single central mysql cluster instead of a many-mysql approach. 3 nodes deployment will still be deployed as many-mysql, making this option opt-in at 3+ nodes.