### PR TITLE
Validate will exit 1 on failed tests

### DIFF
--- a/sunbeam-python/sunbeam/features/validation/feature.py
+++ b/sunbeam-python/sunbeam/features/validation/feature.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 import logging
+import re
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -533,7 +535,19 @@ class ValidationFeature(OpenStackControlPlaneFeature):
             progress_message=progress_message,
         )
 
-        console.print(action_result.get("summary", "").strip())
+        summary = action_result.get("summary", "").strip()
+        console.print(summary)
+
+        failed_match = re.search(r"Failed:\s+(\d+)", summary)
+        unexpected_success_match = re.search(r"Unexpected Success:\s+(\d+)", summary)
+
+        failed = int(failed_match.group(1)) if failed_match else 0
+        unexpected_success = (
+            int(unexpected_success_match.group(1)) if unexpected_success_match else 0
+        )
+
+        if failed > 0 or unexpected_success > 0:
+            sys.exit(1)
 
         if output:
             # Due to shelling out to the juju cli (rather than using libjuju),


### PR DESCRIPTION
`sunbeam validate` will now exit `1` when there are failed or unexpected successful Tempest tests.

[LP #2093175](https://bugs.launchpad.net/snap-openstack/+bug/2093175)