### PR TITLE
Move cinder-volume to machine

### DIFF
--- a/.github/assets/testing/edge.yml
+++ b/.github/assets/testing/edge.yml
@@ -5,7 +5,9 @@ core:
         - --bootstrap-constraints
         - root-disk=5G
     charms:
-      cinder-ceph-k8s:
+      cinder-volume:
+        channel: 2024.1/edge
+      cinder-volume-ceph:
         channel: 2024.1/edge
       cinder-k8s:
         channel: 2024.1/edge

--- a/.github/assets/testing/manifest.yml
+++ b/.github/assets/testing/manifest.yml
@@ -7,7 +7,9 @@ core:
         channel: OS_CHARM
       ceilometer-k8s:
         channel: OS_CHARM
-      cinder-ceph-k8s:
+      cinder-volume:
+        channel: OS_CHARM
+      cinder-volume-ceph:
         channel: OS_CHARM
       cinder-k8s:
         channel: OS_CHARM

--- a/cloud/etc/deploy-cinder-volume/main.tf
+++ b/cloud/etc/deploy-cinder-volume/main.tf
@@ -1,0 +1,149 @@
+# Copyright (c) 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "= 0.17.0"
+    }
+  }
+
+}
+
+provider "juju" {}
+
+data "juju_model" "machine_model" {
+  name = var.machine_model
+}
+
+resource "juju_application" "cinder-volume" {
+  name  = "cinder-volume"
+  model = data.juju_model.machine_model.name
+  units = length(var.machine_ids)
+
+  charm {
+    name     = "cinder-volume"
+    channel  = var.charm_cinder_volume_channel
+    revision = var.charm_cinder_volume_revision
+    base     = "ubuntu@24.04"
+  }
+
+  config = merge({
+    snap-channel = var.cinder_volume_channel
+  }, var.charm_cinder_volume_config)
+  endpoint_bindings = var.endpoint_bindings
+}
+
+resource "juju_offer" "storage-backend-offer" {
+  application_name = juju_application.cinder-volume.name
+  endpoint         = "storage-backend"
+  model            = data.juju_model.machine_model.name
+}
+
+resource "juju_integration" "cinder-volume-identity" {
+  count = (var.keystone-offer-url != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.cinder-volume.name
+    endpoint = "identity-credentials"
+  }
+
+  application {
+    offer_url = var.keystone-offer-url
+  }
+}
+
+resource "juju_integration" "cinder-volume-amqp" {
+  count = (var.amqp-offer-url != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.cinder-volume.name
+    endpoint = "amqp"
+  }
+
+  application {
+    offer_url = var.amqp-offer-url
+  }
+}
+
+resource "juju_integration" "cinder-volume-database" {
+  count = (var.database-offer-url != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.cinder-volume.name
+    endpoint = "database"
+  }
+
+  application {
+    offer_url = var.database-offer-url
+  }
+}
+
+
+resource "juju_application" "cinder-volume-ceph" {
+  name  = "cinder-volume-ceph"
+  model = data.juju_model.machine_model.name
+
+  # charm is subordinate
+  units = 0
+  charm {
+    name     = "cinder-volume-ceph"
+    channel  = var.charm_cinder_volume_ceph_channel
+    revision = var.charm_cinder_volume_ceph_revision
+    base     = "ubuntu@24.04"
+  }
+
+  config            = var.charm_cinder_volume_ceph_config
+  endpoint_bindings = var.cinder_volume_ceph_endpoint_bindings
+}
+
+resource "juju_integration" "cinder-volume-ceph-to-cinder-volume" {
+  model = var.machine_model
+
+  application {
+    name     = juju_application.cinder-volume-ceph.name
+    endpoint = "cinder-volume"
+  }
+
+  application {
+    name     = juju_application.cinder-volume.name
+    endpoint = "cinder-volume"
+  }
+}
+
+resource "juju_integration" "cinder-volume-ceph-to-ceph" {
+  count = (var.ceph-application-name != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.cinder-volume-ceph.name
+    endpoint = "ceph"
+  }
+
+  application {
+    name     = var.ceph-application-name
+    endpoint = "ceph"
+  }
+}
+
+
+output "cinder-volume-ceph-application-name" {
+  value = juju_application.cinder-volume-ceph.name
+}

--- a/cloud/etc/deploy-cinder-volume/variables.tf
+++ b/cloud/etc/deploy-cinder-volume/variables.tf
@@ -1,0 +1,103 @@
+# Copyright (c) 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "charm_cinder_volume_channel" {
+  description = "Operator channel for cinder_volume deployment"
+  type        = string
+  default     = "2024.1/edge"
+}
+
+variable "charm_cinder_volume_revision" {
+  description = "Operator channel revision for cinder_volume deployment"
+  type        = number
+  default     = null
+}
+
+variable "charm_cinder_volume_config" {
+  description = "Operator config for cinder_volume deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cinder_volume_channel" {
+  description = "Cinder Volume channel to deploy, not the operator channel"
+  default     = "2024.1/edge"
+}
+
+variable "charm_cinder_volume_ceph_channel" {
+  description = "Operator channel for cinder_volume_ceph deployment"
+  type        = string
+  default     = "2024.1/edge"
+}
+
+variable "charm_cinder_volume_ceph_revision" {
+  description = "Operator channel revision for cinder_volume_ceph deployment"
+  type        = number
+  default     = null
+}
+
+variable "charm_cinder_volume_ceph_config" {
+  description = "Operator config for cinder_volume_ceph deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "machine_ids" {
+  description = "List of machine ids to include"
+  type        = list(string)
+  default     = []
+}
+
+variable "machine_model" {
+  description = "Model to deploy to"
+  type        = string
+}
+
+variable "endpoint_bindings" {
+  description = "Endpoint bindings for cinder_volume"
+  type        = set(map(string))
+  default     = null
+}
+
+variable "cinder_volume_ceph_endpoint_bindings" {
+  description = "Endpoint bindings for cinder_volume_ceph"
+  type        = set(map(string))
+  default     = null
+}
+
+variable "keystone-offer-url" {
+  description = "Offer URL for openstack keystone credentials"
+  type        = string
+  default     = null
+}
+
+variable "amqp-offer-url" {
+  description = "Offer URL for amqp"
+  type        = string
+  default     = null
+}
+
+variable "database-offer-url" {
+  description = "Offer URL for database"
+  type        = string
+  default     = null
+}
+
+# Microceph is hosted in the same model as cinder-volume-ceph
+variable "ceph-application-name" {
+  description = "Ceph application name"
+  type        = string
+  default     = null
+}

--- a/cloud/etc/deploy-microceph/main.tf
+++ b/cloud/etc/deploy-microceph/main.tf
@@ -97,3 +97,7 @@ resource "juju_integration" "microceph-cert-distributor" {
     offer_url = var.cert-distributor-offer-url
   }
 }
+
+output "ceph-application-name" {
+  value = juju_application.microceph.name
+}

--- a/cloud/etc/deploy-openstack-hypervisor/main.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/main.tf
@@ -128,7 +128,7 @@ resource "juju_integration" "hypervisor-ceilometer" {
 }
 
 resource "juju_integration" "hypervisor-cinder-ceph" {
-  count = (var.cinder-ceph-offer-url != null) ? 1 : 0
+  count = (var.cinder-volume-ceph-application-name != null) ? 1 : 0
   model = var.machine_model
 
   application {
@@ -137,7 +137,8 @@ resource "juju_integration" "hypervisor-cinder-ceph" {
   }
 
   application {
-    offer_url = var.cinder-ceph-offer-url
+    name = var.cinder-volume-ceph-application-name
+    endpoint = "ceph-access"
   }
 }
 

--- a/cloud/etc/deploy-openstack-hypervisor/variables.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/variables.tf
@@ -95,8 +95,8 @@ variable "ceilometer-offer-url" {
   default     = null
 }
 
-variable "cinder-ceph-offer-url" {
-  description = "Offer URL for openstack cinder-ceph"
+variable "cinder-volume-ceph-application-name" {
+  description = "Name for cinder-volume-ceph application"
   type        = string
   default     = null
 }

--- a/manifests/beta.yml
+++ b/manifests/beta.yml
@@ -1,7 +1,9 @@
 core:
   software:
     charms:
-      cinder-ceph-k8s:
+      cinder-volume:
+        channel: 2024.1/beta
+      cinder-volume-ceph:
         channel: 2024.1/beta
       cinder-k8s:
         channel: 2024.1/beta

--- a/manifests/candidate.yml
+++ b/manifests/candidate.yml
@@ -1,7 +1,9 @@
 core:
   software:
     charms:
-      cinder-ceph-k8s:
+      cinder-volume:
+        channel: 2024.1/candidate
+      cinder-volume-ceph:
         channel: 2024.1/candidate
       cinder-k8s:
         channel: 2024.1/candidate

--- a/manifests/edge.yml
+++ b/manifests/edge.yml
@@ -1,7 +1,9 @@
 core:
   software:
     charms:
-      cinder-ceph-k8s:
+      cinder-volume:
+        channel: 2024.1/edge
+      cinder-volume-ceph:
         channel: 2024.1/edge
       cinder-k8s:
         channel: 2024.1/edge

--- a/sunbeam-python/sunbeam/core/steps.py
+++ b/sunbeam-python/sunbeam/core/steps.py
@@ -98,6 +98,10 @@ class DeployMachineApplicationStep(BaseStep):
 
         return Result(ResultType.SKIPPED)
 
+    def get_accepted_application_status(self) -> list[str]:
+        """Accepted status to pass wait_application_ready function."""
+        return ["active", "unknown"]
+
     def run(self, status: Status | None = None) -> Result:
         """Apply terraform configuration to deploy sunbeam machine."""
         machine_ids: list[int] = []
@@ -131,7 +135,7 @@ class DeployMachineApplicationStep(BaseStep):
                 self.jhelper.wait_application_ready(
                     self.application,
                     self.model,
-                    accepted_status=["active", "unknown"],
+                    accepted_status=self.get_accepted_application_status(),
                     timeout=self.get_application_timeout(),
                 )
             )

--- a/sunbeam-python/sunbeam/steps/cinder_volume.py
+++ b/sunbeam-python/sunbeam/steps/cinder_volume.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any
+
+from rich.status import Status
+
+import sunbeam.steps.microceph as microceph
+from sunbeam.clusterd.client import Client
+from sunbeam.clusterd.service import (
+    ConfigItemNotFoundException,
+    NodeNotExistInClusterException,
+)
+from sunbeam.core.common import BaseStep, Result, ResultType, Role, read_config
+from sunbeam.core.deployment import Deployment, Networks
+from sunbeam.core.juju import (
+    ApplicationNotFoundException,
+    JujuHelper,
+    run_sync,
+)
+from sunbeam.core.manifest import Manifest
+from sunbeam.core.steps import (
+    AddMachineUnitsStep,
+    DeployMachineApplicationStep,
+    DestroyMachineApplicationStep,
+    RemoveMachineUnitsStep,
+)
+from sunbeam.core.terraform import TerraformException, TerraformHelper
+
+LOG = logging.getLogger(__name__)
+CONFIG_KEY = "TerraformVarsCinderVolumePlan"
+APPLICATION = "cinder-volume"
+CINDER_VOLUME_APP_TIMEOUT = 1200
+CINDER_VOLUME_UNIT_TIMEOUT = (
+    1200  # 20 minutes, adding / removing units can take a long time
+)
+
+
+def get_mandatory_control_plane_offers(
+    tfhelper: TerraformHelper,
+) -> dict[str, str | None]:
+    """Get mandatory control plane offers."""
+    openstack_tf_output = tfhelper.output()
+
+    tfvars = {
+        "keystone-offer-url": openstack_tf_output.get("keystone-offer-url"),
+        "database-offer-url": openstack_tf_output.get(
+            "cinder-volume-database-offer-url"
+        ),
+        "amqp-offer-url": openstack_tf_output.get("rabbitmq-offer-url"),
+    }
+    return tfvars
+
+
+class DeployCinderVolumeApplicationStep(DeployMachineApplicationStep):
+    """Deploy Cinder Volume application using Terraform."""
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+        model: str,
+        refresh: bool = False,
+    ):
+        super().__init__(
+            deployment,
+            client,
+            tfhelper,
+            jhelper,
+            manifest,
+            CONFIG_KEY,
+            APPLICATION,
+            model,
+            "Deploy Cinder Volume",
+            "Deploying Cinder Volume",
+            refresh,
+        )
+        self._offers: dict[str, str | None] = {}
+
+    def get_application_timeout(self) -> int:
+        """Return application timeout in seconds."""
+        return CINDER_VOLUME_APP_TIMEOUT
+
+    def get_accepted_application_status(self) -> list[str]:
+        """Return accepted application status."""
+        accepted_status = super().get_accepted_application_status()
+        offers = self._get_offers()
+        if not offers or not all(offers.values()):
+            accepted_status.append("blocked")
+        return accepted_status
+
+    def _get_offers(self):
+        if not self._offers:
+            self._offers = get_mandatory_control_plane_offers(
+                self.deployment.get_tfhelper("openstack-plan")
+            )
+        return self._offers
+
+    def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
+        storage_nodes = self.client.cluster.list_nodes_by_role("storage")
+        tfvars: dict[str, Any] = {
+            "endpoint_bindings": [
+                {
+                    "space": self.deployment.get_space(Networks.MANAGEMENT),
+                },
+                {
+                    "endpoint": "amqp",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "database",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "cinder-volume",
+                    "space": self.deployment.get_space(Networks.MANAGEMENT),
+                },
+                {
+                    "endpoint": "identity-credentials",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    # relation to cinder-api
+                    "endpoint": "storage-backend",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+            ],
+            "cinder_volume_ceph_endpoint_bindings": [
+                {
+                    "space": self.deployment.get_space(Networks.MANAGEMENT),
+                },
+                {
+                    # relation between hypervisor and cinder-volume-ceph
+                    # providing credentials to access Ceph
+                    "space": self.deployment.get_space(Networks.MANAGEMENT),
+                    "endpoint": "ceph-access",
+                },
+                {
+                    "space": self.deployment.get_space(Networks.STORAGE),
+                    "endpoint": "ceph",
+                },
+            ],
+            "charm_cinder_volume_config": {},
+            "charm_cinder_volume_ceph_config": {
+                "ceph-osd-replication-count": microceph.ceph_replica_scale(
+                    len(storage_nodes)
+                ),
+            },
+        }
+
+        if len(storage_nodes):
+            microceph_tfhelper = self.deployment.get_tfhelper("microceph-plan")
+            microceph_tf_output = microceph_tfhelper.output()
+
+            ceph_application_name = microceph_tf_output.get("ceph-application-name")
+
+            if ceph_application_name:
+                tfvars["ceph-application-name"] = ceph_application_name
+            tfvars.update(self._get_offers())
+
+        return tfvars
+
+
+class AddCinderVolumeUnitsStep(AddMachineUnitsStep):
+    """Add Cinder Volume Unit."""
+
+    def __init__(
+        self,
+        client: Client,
+        names: list[str] | str,
+        jhelper: JujuHelper,
+        model: str,
+        openstack_tfhelper: TerraformHelper,
+    ):
+        super().__init__(
+            client,
+            names,
+            jhelper,
+            CONFIG_KEY,
+            APPLICATION,
+            model,
+            "Add Cinder Volume unit",
+            "Adding Cinder Volume unit to machine",
+        )
+        self.os_tfhelper = openstack_tfhelper
+
+    def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
+        return CINDER_VOLUME_UNIT_TIMEOUT
+
+    def get_accepted_unit_status(self) -> dict[str, list[str]]:
+        """Accepted status to pass wait_units_ready function."""
+        offers = get_mandatory_control_plane_offers(self.os_tfhelper)
+
+        allow_blocked = {"agent": ["idle"], "workload": ["active", "blocked"]}
+        if not offers or not all(offers.values()):
+            return allow_blocked
+
+        try:
+            config = read_config(self.client, CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            config = {}
+
+        # check if values in offers are the same in config
+        for key, value in offers.items():
+            if key not in config or config[key] != value:
+                return allow_blocked
+
+        return super().get_accepted_unit_status()
+
+
+class RemoveCinderVolumeUnitsStep(RemoveMachineUnitsStep):
+    """Remove Cinder Volume Unit."""
+
+    def __init__(
+        self, client: Client, names: list[str] | str, jhelper: JujuHelper, model: str
+    ):
+        super().__init__(
+            client,
+            names,
+            jhelper,
+            CONFIG_KEY,
+            APPLICATION,
+            model,
+            "Remove Cinder Volume unit(s)",
+            "Removing Cinder Volume unit(s) from machine",
+        )
+
+    def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
+        return CINDER_VOLUME_UNIT_TIMEOUT
+
+
+class CheckCinderVolumeDistributionStep(BaseStep):
+    _APPLICATION = APPLICATION
+
+    def __init__(
+        self,
+        client: Client,
+        name: str,
+        jhelper: JujuHelper,
+        model: str,
+        force: bool = False,
+    ):
+        super().__init__(
+            "Check Cinder Volume distribution",
+            "Check if node is hosting units of Cinder Volume",
+        )
+        self.client = client
+        self.node = name
+        self.jhelper = jhelper
+        self.model = model
+        self.force = force
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        try:
+            node_info = self.client.cluster.get_node_info(self.node)
+        except NodeNotExistInClusterException:
+            return Result(ResultType.FAILED, f"Node {self.node} not found in cluster")
+        if Role.STORAGE.name.lower() not in node_info.get("role", ""):
+            LOG.debug("Node %s is not a storage node", self.node)
+            return Result(ResultType.SKIPPED)
+        try:
+            app = run_sync(self.jhelper.get_application(self._APPLICATION, self.model))
+        except ApplicationNotFoundException:
+            LOG.debug("Failed to get application", exc_info=True)
+            return Result(
+                ResultType.SKIPPED,
+                f"Application {self._APPLICATION} has not been deployed yet",
+            )
+
+        for unit in app.units:
+            if unit.machine.id == str(node_info.get("machineid")):
+                LOG.debug("Unit %s is running on node %s", unit.name, self.node)
+                break
+        else:
+            LOG.debug("No %s units found on %s", self._APPLICATION, self.node)
+            return Result(ResultType.SKIPPED)
+
+        nb_storage_nodes = len(self.client.cluster.list_nodes_by_role("storage"))
+        if nb_storage_nodes == 1 and not self.force:
+            return Result(
+                ResultType.FAILED,
+                "Cannot remove the last cinder-volume,"
+                "--force to override, volume capabilities"
+                " will be lost.",
+            )
+
+        return Result(ResultType.COMPLETED)
+
+
+class DestroyCinderVolumeApplicationStep(DestroyMachineApplicationStep):
+    """Destroy Cinder Volume application using Terraform."""
+
+    def __init__(
+        self,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+        model: str,
+    ):
+        super().__init__(
+            client,
+            tfhelper,
+            jhelper,
+            manifest,
+            CONFIG_KEY,
+            [APPLICATION],
+            model,
+            "Destroy Cinder Volume",
+            "Destroying Cinder Volume",
+        )
+
+    def get_application_timeout(self) -> int:
+        """Return application timeout in seconds."""
+        return CINDER_VOLUME_APP_TIMEOUT
+
+    def run(self, status: Status | None = None) -> Result:
+        """Destroy Cinder Volume application."""
+        # note(gboutry):this is a workaround for
+        # https://github.com/juju/terraform-provider-juju/issues/473
+        try:
+            resources = self.tfhelper.state_list()
+        except TerraformException as e:
+            LOG.debug(f"Failed to list terraform state: {str(e)}")
+            return Result(ResultType.FAILED, "Failed to list terraform state")
+
+        for resource in resources:
+            if "integration" in resource:
+                try:
+                    self.tfhelper.state_rm(resource)
+                except TerraformException as e:
+                    LOG.debug(f"Failed to remove resource {resource}: {str(e)}")
+                    return Result(
+                        ResultType.FAILED,
+                        f"Failed to remove resource {resource} from state",
+                    )
+
+        return super().run(status)

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -22,6 +22,7 @@ from sunbeam.core.common import BaseStep, Result, ResultType
 from sunbeam.core.juju import JujuHelper, JujuStepHelper, run_sync
 from sunbeam.core.manifest import Manifest
 from sunbeam.core.terraform import TerraformInitStep
+from sunbeam.steps.cinder_volume import DeployCinderVolumeApplicationStep
 from sunbeam.steps.hypervisor import ReapplyHypervisorTerraformPlanStep
 from sunbeam.steps.k8s import DeployK8SApplicationStep
 from sunbeam.steps.microceph import DeployMicrocephApplicationStep
@@ -172,6 +173,16 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                     self.deployment,
                     self.client,
                     self.deployment.get_tfhelper("microceph-plan"),
+                    self.jhelper,
+                    self.manifest,
+                    self.deployment.openstack_machines_model,
+                    refresh=True,
+                ),
+                TerraformInitStep(self.deployment.get_tfhelper("cinder-volume-plan")),
+                DeployCinderVolumeApplicationStep(
+                    self.deployment,
+                    self.client,
+                    self.deployment.get_tfhelper("cinder-volume-plan"),
                     self.jhelper,
                     self.manifest,
                     self.deployment.openstack_machines_model,

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -37,7 +37,6 @@ LXD_CHANNEL = "5.21/stable"
 
 # List of charms with default channels
 OPENSTACK_CHARMS_K8S = {
-    "cinder-ceph-k8s": OPENSTACK_CHANNEL,
     "cinder-k8s": OPENSTACK_CHANNEL,
     "glance-k8s": OPENSTACK_CHANNEL,
     "horizon-k8s": OPENSTACK_CHANNEL,
@@ -66,6 +65,8 @@ MACHINE_CHARMS = {
     "sunbeam-machine": SUNBEAM_MACHINE_CHANNEL,
     "sunbeam-clusterd": SUNBEAM_CLUSTERD_CHANNEL,
     "sunbeam-ssc": SUNBEAM_SSC_CHANNEL,
+    "cinder-volume": OPENSTACK_CHANNEL,
+    "cinder-volume-ceph": OPENSTACK_CHANNEL,
 }
 
 
@@ -85,6 +86,7 @@ TERRAFORM_DIR_NAMES = {
     "sunbeam-machine-plan": "deploy-sunbeam-machine",
     "k8s-plan": "deploy-k8s",
     "microceph-plan": "deploy-microceph",
+    "cinder-volume-plan": "deploy-cinder-volume",
     "openstack-plan": "deploy-openstack",
     "hypervisor-plan": "deploy-openstack-hypervisor",
     "demo-setup": "demo-setup",
@@ -201,6 +203,20 @@ DEPLOY_SUNBEAM_MACHINE_TFVAR_MAP = {
         }
     }
 }
+DEPLOY_CINDER_VOLUME_TFVAR_MAP = {
+    "charms": {
+        "cinder-volume": {
+            "channel": "charm_cinder_volume_channel",
+            "revision": "charm_cinder_volume_revision",
+            "config": "charm_cinder_volume_config",
+        },
+        "cinder-volume-ceph": {
+            "channel": "charm_cinder_volume_ceph_channel",
+            "revision": "charm_cinder_volume_ceph_revision",
+            "config": "charm_cinder_volume_ceph_config",
+        },
+    }
+}
 
 
 MANIFEST_ATTRIBUTES_TFVAR_MAP = {
@@ -209,4 +225,5 @@ MANIFEST_ATTRIBUTES_TFVAR_MAP = {
     "microceph-plan": DEPLOY_MICROCEPH_TFVAR_MAP,
     "openstack-plan": DEPLOY_OPENSTACK_TFVAR_MAP,
     "hypervisor-plan": DEPLOY_OPENSTACK_HYPERVISOR_TFVAR_MAP,
+    "cinder-volume-plan": DEPLOY_CINDER_VOLUME_TFVAR_MAP,
 }

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_cinder_volume.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_cinder_volume.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+from sunbeam.clusterd.service import ConfigItemNotFoundException
+from sunbeam.steps.cinder_volume import (
+    CINDER_VOLUME_APP_TIMEOUT,
+    CINDER_VOLUME_UNIT_TIMEOUT,
+    AddCinderVolumeUnitsStep,
+    DeployCinderVolumeApplicationStep,
+    RemoveCinderVolumeUnitsStep,
+)
+
+
+class TestDeployCinderVolumeApplicationStep(unittest.TestCase):
+    def setUp(self):
+        self.deployment = MagicMock()
+        self.client = MagicMock()
+        self.tfhelper = MagicMock()
+        self.os_tfhelper = MagicMock()
+        self.mceph_tfhelper = MagicMock()
+        self.jhelper = MagicMock()
+        self.manifest = MagicMock()
+        self.model = "test-model"
+        self.deployment.get_tfhelper.side_effect = lambda plan: {
+            "microceph-plan": self.mceph_tfhelper,
+            "openstack-plan": self.os_tfhelper,
+        }[plan]
+        self.deploy_cinder_volume_step = DeployCinderVolumeApplicationStep(
+            self.deployment,
+            self.client,
+            self.tfhelper,
+            self.jhelper,
+            self.manifest,
+            self.model,
+        )
+
+    def test_get_unit_timeout(self):
+        self.assertEqual(
+            self.deploy_cinder_volume_step.get_application_timeout(),
+            CINDER_VOLUME_APP_TIMEOUT,
+        )
+
+    @patch(
+        "sunbeam.steps.cinder_volume.get_mandatory_control_plane_offers",
+        return_value={"keystone-offer-url": "url"},
+    )
+    def test_get_offers(self, mandatory_control_plane_offers):
+        self.assertDictEqual(self.deploy_cinder_volume_step._offers, {})
+        self.deploy_cinder_volume_step._get_offers()
+        mandatory_control_plane_offers.assert_called_once()
+        self.assertDictEqual(
+            self.deploy_cinder_volume_step._offers,
+            mandatory_control_plane_offers.return_value,
+        )
+        mandatory_control_plane_offers.reset_mock()
+        self.deploy_cinder_volume_step._get_offers()
+        # Should not call again
+        mandatory_control_plane_offers.assert_not_called()
+
+    def test_get_accepted_application_status(self):
+        self.deploy_cinder_volume_step._get_offers = Mock(
+            return_value={"keystone-offer-url": None}
+        )
+
+        accepted_status = (
+            self.deploy_cinder_volume_step.get_accepted_application_status()
+        )
+        self.assertIn("blocked", accepted_status)
+
+    def test_get_accepted_application_status_with_offers(self):
+        self.deploy_cinder_volume_step._get_offers = Mock(
+            return_value={"keystone-offer-url": "url"}
+        )
+
+        accepted_status = (
+            self.deploy_cinder_volume_step.get_accepted_application_status()
+        )
+        self.assertNotIn("blocked", accepted_status)
+
+    @patch("sunbeam.steps.cinder_volume.microceph.ceph_replica_scale", return_value=3)
+    def test_extra_tfvars(self, mock_ceph_replica_scale):
+        self.client.cluster.list_nodes_by_role.return_value = ["node1"]
+        self.mceph_tfhelper.output.return_value = {"ceph-application-name": "ceph-app"}
+        tfvars = self.deploy_cinder_volume_step.extra_tfvars()
+        self.assertEqual(tfvars["ceph-application-name"], "ceph-app")
+        self.assertEqual(
+            tfvars["charm_cinder_volume_ceph_config"]["ceph-osd-replication-count"], 3
+        )
+
+    def test_extra_tfvars_after_openstack_model(self):
+        self.client.cluster.list_nodes_by_role.return_value = ["node1"]
+        self.os_tfhelper.output.return_value = {
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        }
+        self.mceph_tfhelper.output.return_value = {"ceph-application-name": "ceph-app"}
+        self.manifest.get_model.return_value = "openstack"
+        tfvars = self.deploy_cinder_volume_step.extra_tfvars()
+        self.assertEqual(tfvars["ceph-application-name"], "ceph-app")
+        self.assertEqual(
+            tfvars["charm_cinder_volume_ceph_config"]["ceph-osd-replication-count"], 1
+        )
+
+    @patch(
+        "sunbeam.steps.cinder_volume.get_mandatory_control_plane_offers",
+        return_value={"keystone-offer-url": "url"},
+    )
+    def test_extra_tfvars_no_storage_nodes(self, get_mandatory_control_plane_offers):
+        self.client.cluster.list_nodes_by_role.return_value = []
+        tfvars = self.deploy_cinder_volume_step.extra_tfvars()
+        self.mceph_tfhelper.output.assert_not_called()
+        get_mandatory_control_plane_offers.assert_not_called()
+        self.assertNotIn("ceph-application-name", tfvars)
+        self.assertNotIn("keystone-offer-url", tfvars)
+
+
+class TestAddCinderVolumeUnitsStep(unittest.TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+        self.names = ["node1"]
+        self.jhelper = MagicMock()
+        self.model = "test-model"
+        self.os_tfhelper = MagicMock()
+        self.add_cinder_volume_units_step = AddCinderVolumeUnitsStep(
+            self.client,
+            self.names,
+            self.jhelper,
+            self.model,
+            self.os_tfhelper,
+        )
+
+    def test_get_unit_timeout(self):
+        self.assertEqual(
+            self.add_cinder_volume_units_step.get_unit_timeout(),
+            CINDER_VOLUME_UNIT_TIMEOUT,
+        )
+
+    @patch(
+        "sunbeam.steps.cinder_volume.get_mandatory_control_plane_offers",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    @patch(
+        "sunbeam.steps.cinder_volume.read_config",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    def test_get_accepted_unit_status(
+        self, get_mandatory_control_plane_offers, read_config
+    ):
+        self.client.cluster.list_nodes_by_role.return_value = ["node1"]
+        accepted_status = self.add_cinder_volume_units_step.get_accepted_unit_status()
+        self.assertNotIn("blocked", accepted_status["workload"])
+        get_mandatory_control_plane_offers.assert_called_once()
+        read_config.assert_called_once()
+
+    @patch(
+        "sunbeam.steps.cinder_volume.get_mandatory_control_plane_offers",
+        return_value={"keystone-offer-url": None},
+    )
+    def test_get_accepted_unit_status_with_missing_offers(
+        self, get_mandatory_control_plane_offers
+    ):
+        accepted_status = self.add_cinder_volume_units_step.get_accepted_unit_status()
+        self.assertIn("blocked", accepted_status["workload"])
+        get_mandatory_control_plane_offers.assert_called_once()
+
+    @patch(
+        "sunbeam.steps.cinder_volume.get_mandatory_control_plane_offers",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    @patch(
+        "sunbeam.steps.cinder_volume.read_config",
+        return_value={
+            "keystone-offer-url": "keystone-differ",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    def test_get_accepted_unit_status_with_different_config(
+        self, get_mandatory_control_plane_offers, read_config
+    ):
+        accepted_status = self.add_cinder_volume_units_step.get_accepted_unit_status()
+        self.assertIn("blocked", accepted_status["workload"])
+        get_mandatory_control_plane_offers.assert_called_once()
+        read_config.assert_called_once()
+
+    @patch(
+        "sunbeam.steps.cinder_volume.get_mandatory_control_plane_offers",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    @patch(
+        "sunbeam.steps.cinder_volume.read_config",
+        side_effect=ConfigItemNotFoundException("config not found"),
+    )
+    def test_get_accepted_unit_status_with_config_exception(
+        self, get_mandatory_control_plane_offers, read_config
+    ):
+        accepted_status = self.add_cinder_volume_units_step.get_accepted_unit_status()
+        self.assertIn("blocked", accepted_status["workload"])
+        get_mandatory_control_plane_offers.assert_called_once()
+        read_config.assert_called_once()
+
+
+class TestRemoveCinderVolumeUnitsStep(unittest.TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+        self.names = ["node1"]
+        self.jhelper = MagicMock()
+        self.model = "test-model"
+        self.remove_cinder_volume_units_step = RemoveCinderVolumeUnitsStep(
+            self.client,
+            self.names,
+            self.jhelper,
+            self.model,
+        )
+
+    def test_get_unit_timeout(self):
+        self.assertEqual(
+            self.remove_cinder_volume_units_step.get_unit_timeout(),
+            CINDER_VOLUME_UNIT_TIMEOUT,
+        )


### PR DESCRIPTION
Cinder-volume service needs increased security posture since CVE-2024-32498. This would require running a k8s container as privileged to continue working, and this is contrary to Sunbeam tenets. All applications requiring more access rights must run in snap sandbox to ensure security is enforced correctly.

Cinder-Volume gets deployed on all storage nodes currently, in the future, when application placement is better managed by the juju terraform provider, we will be able to easily manage only 3 units for HA. Ref: https://github.com/juju/terraform-provider-juju/issues/179

Closes-Bug: #2091269

Requires:
- https://github.com/canonical/sunbeam-terraform/pull/104