### PR TITLE
Increase model migration timeout to 16 minutes

### DIFF
--- a/sunbeam-python/sunbeam/steps/juju.py
+++ b/sunbeam-python/sunbeam/steps/juju.py
@@ -2173,7 +2173,7 @@ class MigrateModelStep(BaseStep, JujuStepHelper):
 
     @tenacity.retry(
         wait=tenacity.wait_fixed(10),
-        stop=tenacity.stop_after_delay(300),
+        stop=tenacity.stop_after_delay(960),
         retry=tenacity.retry_if_exception_type(ValueError),
         reraise=True,
     )


### PR DESCRIPTION
5 minutes is too short for more constrained environment, moreover, juju
 has a default value of 15 minutes [0] to wait for an agent to start its
 migration. Since this migration happens on a single node, the number of
 agents is relatively low (1), therefore let's put the total timeout
 higher than this agent wait time.

 0: https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/configuration/list-of-controller-configuration-keys/#controller-config-migration-agent-wait-time