### PR TITLE
Feat: parameterise image resource version

### DIFF
--- a/cloud/etc/demo-setup/main.tf
+++ b/cloud/etc/demo-setup/main.tf
@@ -53,7 +53,7 @@ resource "openstack_compute_flavor_v2" "m1_large" {
 
 resource "openstack_images_image_v2" "ubuntu" {
   name             = "ubuntu"
-  image_source_url = "http://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  image_source_url = "http://cloud-images.ubuntu.com/${var.distro_version}/current/${var.distro_version}-server-cloudimg-amd64.img"
   container_format = "bare"
   disk_format      = "qcow2"
   visibility       = "public"

--- a/cloud/etc/demo-setup/variables.tf
+++ b/cloud/etc/demo-setup/variables.tf
@@ -26,7 +26,6 @@ variable "user" {
 
 # Image resource
 variable "distro_version" {
-  type = string({
-    distro_version = "noble"
-  })
+  type = string
+  default = "noble"
 }

--- a/cloud/etc/demo-setup/variables.tf
+++ b/cloud/etc/demo-setup/variables.tf
@@ -27,5 +27,5 @@ variable "user" {
 # Image resource
 variable "distro_version" {
   type = string
-  default = "noble"
+  default = "jammy"
 }

--- a/cloud/etc/demo-setup/variables.tf
+++ b/cloud/etc/demo-setup/variables.tf
@@ -22,3 +22,11 @@ variable "user" {
   })
   sensitive = true
 }
+
+
+# Image resource
+variable "distro_version" {
+  type = string({
+    distro_version = "noble"
+  })
+}


### PR DESCRIPTION
It looks like as of 2024.1/edge 660 onwards we are based on 24.04 but still pulling in 22.04 images. We should parameterise so Ubuntu distro's can be defined (ultimately perhaps based on risk level)