### PR TITLE
Set juju-mgmt-space flag for juju bootstrap

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -431,6 +431,10 @@ def get_juju_bootstrap_plans(
     client = deployment.get_client()
     proxy_settings = deployment.get_proxy_settings()
 
+    # Set juju-mgmt-space flag during bootstrap so that juju agent communicate
+    # over management space in case of internal juju controller
+    management_space = deployment.get_space(Networks.MANAGEMENT)
+
     # If the secret backend is left to defaults i.e., auto, the secret backend
     # is set to k8s if the controller is k8s based and non-k8s machines cannot
     # get secrets as they try to connect to k8s on service_ip which is not
@@ -441,6 +445,8 @@ def get_juju_bootstrap_plans(
         [
             "--config",
             "controller-service-type=loadbalancer",
+            "--config",
+            f"juju-mgmt-space={management_space}",
             "--model-default=secret-backend=internal",
         ]
     )

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -384,6 +384,12 @@ def bootstrap(
     )
 
     if not juju_controller:
+        management_space = deployment.get_space(Networks.MANAGEMENT)
+        bootstrap_args = manifest.core.software.juju.bootstrap_args
+        # Set juju-mgmt-space flag so that juju agent communicate over
+        # management space in case of internal juju controller
+        bootstrap_args.extend(["--config", f"juju-mgmt-space={management_space}"])
+
         # Workaround for bug https://bugs.launchpad.net/juju/+bug/2044481
         # Remove the below step and dont pass controller charm as bootstrap
         # arguments once the above bug is fixed


### PR DESCRIPTION
Currently in case of internal controller on maas mode, juju controller api is exposed over management network and pxe network and the juju agent conf has the IP addresses from both the networks. For isolation of traffic, the agents should communicate with juju controller over management network. This can be achieved by setting juju-mgmt-space flag in juju
bootstrap command.