### PR TITLE
hypervisor: make cinder-volume dep external

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -835,6 +835,7 @@ def bootstrap(
             client,
             hypervisor_tfhelper,
             openstack_tfhelper,
+            cinder_volume_tfhelper,
             jhelper,
             manifest,
             deployment.openstack_machines_model,
@@ -1107,6 +1108,8 @@ def join(
                 openstack_tfhelper,
             )
         )
+        cinder_volume_tfhelper = deployment.get_tfhelper("cinder-volume-plan")
+        plan4.append(TerraformInitStep(cinder_volume_tfhelper))
         # Re-deploy control plane if this is the first storage node joining
         # the cluster to enable mandatory storage services
         storage_nodes = client.cluster.list_nodes_by_role(Role.STORAGE.name.lower())
@@ -1139,8 +1142,6 @@ def join(
                 )
             )
             # Fill AMQP / Keystone / MySQL offers from openstack model
-            cinder_volume_tfhelper = deployment.get_tfhelper("cinder-volume-plan")
-            plan4.append(TerraformInitStep(cinder_volume_tfhelper))
             plan4.append(
                 DeployCinderVolumeApplicationStep(
                     deployment,
@@ -1161,6 +1162,7 @@ def join(
                 client,
                 hypervisor_tfhelper,
                 openstack_tfhelper,
+                cinder_volume_tfhelper,
                 jhelper,
                 manifest,
                 deployment.openstack_machines_model,

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -760,6 +760,7 @@ def deploy(
             client,
             tfhelper_hypervisor_deploy,
             tfhelper_openstack_deploy,
+            tfhelper_cinder_volume,
             jhelper,
             manifest,
             deployment.openstack_machines_model,

--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -67,6 +67,7 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
         client: Client,
         tfhelper: TerraformHelper,
         openstack_tfhelper: TerraformHelper,
+        cinder_volume_tfhelper: TerraformHelper,
         jhelper: JujuHelper,
         manifest: Manifest,
         model: str,
@@ -87,6 +88,7 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
         )
         self.openstack_tfhelper = openstack_tfhelper
         self.openstack_model = OPENSTACK_MODEL
+        self.cinder_volume_tfhelper = cinder_volume_tfhelper
 
     def extra_tfvars(self) -> dict:
         """Extra terraform vars to pass to terraform apply."""
@@ -111,8 +113,7 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
         extra_tfvars = {offer: openstack_tf_output.get(offer) for offer in juju_offers}
 
         if len(storage_nodes) > 0:
-            cinder_volume_tfhelper = self.deployment.get_tfhelper("cinder-volume-plan")
-            cinder_volume_tf_output = cinder_volume_tfhelper.output()
+            cinder_volume_tf_output = self.cinder_volume_tfhelper.output()
 
             app_name_key = "cinder-volume-ceph-application-name"
             if app_name := cinder_volume_tf_output.get(app_name_key):


### PR DESCRIPTION
Cinder Volume terraform plan was called internally to the DeployHypervisorApp step, this made harder to ensure terraform plan is initialized before deploying the hypervisor. Make that dependency external.

Closes-Bug: #2100921