### PR TITLE
Add host-only to microceph list-disks action

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -1585,7 +1585,9 @@ class MaasConfigureMicrocephOSDStep(BaseStep):
     async def _list_disks(self, unit: str) -> tuple[dict, dict]:
         """Call list-disks action on an unit."""
         LOG.debug("Running list-disks on : %r", unit)
-        action_result = await self.jhelper.run_action(unit, self.model, "list-disks")
+        action_result = await self.jhelper.run_action(
+            unit, self.model, "list-disks", action_params={"host-only": True}
+        )
         LOG.debug(
             "Result after running action list-disks on %r: %r",
             unit,

--- a/sunbeam-python/sunbeam/steps/microceph.py
+++ b/sunbeam-python/sunbeam/steps/microceph.py
@@ -70,7 +70,9 @@ def microceph_questions():
 async def list_disks(jhelper: JujuHelper, model: str, unit: str) -> tuple[dict, dict]:
     """Call list-disks action on an unit."""
     LOG.debug("Running list-disks on : %r", unit)
-    action_result = await jhelper.run_action(unit, model, "list-disks")
+    action_result = await jhelper.run_action(
+        unit, model, "list-disks", action_params={"host-only": True}
+    )
     LOG.debug(
         "Result after running action list-disks on %r: %r",
         unit,


### PR DESCRIPTION
host-only param is introduced to list-disks action in [1]. Use the flag in sunbeam while configuring
disks so that only disks on that host will be
retrieved.

The change is backward compatible as using the new param on action with older charm-microceph returns the OSDs of all hosts just like earlier.

[1] https://github.com/canonical/charm-microceph/pull/147

Fixes: [LP#2098626](https://bugs.launchpad.net/snap-openstack/+bug/2098626)