### PR TITLE
Update Observability feature

### DIFF
--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/main.tf
@@ -30,7 +30,7 @@ resource "juju_model" "cos" {
 
   cloud {
     name   = var.cloud
-    region = "localhost"
+    region = var.region
   }
 
   credential = var.credential

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/variables.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/variables.tf
@@ -25,6 +25,11 @@ variable "cloud" {
   default     = "k8s"
 }
 
+variable "region" {
+  description = "The region of K8S cloud to use for deployment"
+  default     = "localhost"
+}
+
 # https://github.com/juju/terraform-provider-juju/issues/147
 variable "credential" {
   description = "Name of credential to use for deployment"

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/main.tf
@@ -34,7 +34,7 @@ resource "juju_application" "grafana-agent" {
     name     = "grafana-agent"
     channel  = var.grafana-agent-channel
     revision = var.grafana-agent-revision
-    base     = "ubuntu@24.04"
+    base     = var.grafana-agent-base
   }
 
   config = var.grafana-agent-config

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/variables.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/variables.tf
@@ -38,6 +38,12 @@ variable "grafana-agent-revision" {
   default     = null
 }
 
+variable "grafana-agent-base" {
+  description = "Base to use when deploying grafana agent machine charm"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "grafana-agent-config" {
   description = "Config to use when deploying grafana agent machine charm"
   type        = map(string)

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/variables.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/variables.tf
@@ -29,9 +29,7 @@ variable "principal-application-model" {
 variable "grafana-agent-channel" {
   description = "Channel to use when deploying grafana agent machine charm"
   type        = string
-  # Note: Currently, latest/stable is not available for grafana-agent. So,
-  # defaulting to latest/candidate.
-  default     = "latest/candidate"
+  default     = "latest/stable"
 }
 
 variable "grafana-agent-revision" {


### PR DESCRIPTION
- remove hardcode region in cos feautre (I was trying to use this terraform module but the cloud is not in `localhost` region, it will be good that this can be changed as a variable) 
- bump grafana-agent to latest/stable (grafana-agent has latest/stable release https://charmhub.io/grafana-agent)