### PR TITLE
Avoid using block_until when waiting for unit

### DIFF
--- a/sunbeam-python/sunbeam/features/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/openstack.py
@@ -498,7 +498,7 @@ class UpgradeOpenStackApplicationStep(BaseStep, JujuStepHelper):
                 self.jhelper.wait_until_desired_status(
                     self.model,
                     apps,
-                    expected_wls,
+                    status=expected_wls,
                     timeout=timeout,
                     queue=queue,
                 )

--- a/sunbeam-python/sunbeam/steps/upgrades/inter_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/inter_channel.py
@@ -143,7 +143,7 @@ class BaseUpgrade(BaseStep, JujuStepHelper):
                 self.jhelper.wait_until_desired_status(
                     model,
                     apps,
-                    expected_wls,
+                    status=expected_wls,
                     timeout=timeout,
                     queue=queue,
                 )

--- a/sunbeam-python/tests/unit/sunbeam/core/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_steps.py
@@ -301,14 +301,14 @@ class TestAddMachineUnitsStep:
         assert result.message == "Application missing..."
 
     def test_run_timeout(self, cclient, jhelper, read_config):
-        jhelper.wait_units_ready.side_effect = TimeoutException("timed out")
+        jhelper.wait_until_desired_status.side_effect = TimeoutException("timed out")
 
         step = AddMachineUnitsStep(
             cclient, "machine1", jhelper, "tfconfig", "app1", "model1"
         )
         result = step.run()
 
-        jhelper.wait_units_ready.assert_called_once()
+        jhelper.wait_until_desired_status.assert_called_once()
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
 


### PR DESCRIPTION
Block_until has an issue in certain code paths when a controller disconnect happens.