### PR TITLE
Ensure model is always closed

### DIFF
--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -613,8 +613,9 @@ class SetHypervisorUnitsOptionsStep(BaseStep):
                 continue
             node = self.client.cluster.get_node_info(name)
             self.machine_id = str(node.get("machineid"))
+            model = run_sync(self.jhelper.get_model(self.model))
             unit = run_sync(
-                self.jhelper.get_unit_from_machine(app, self.machine_id, self.model)
+                self.jhelper.get_unit_from_machine(app, self.machine_id, model)
             )
             action_result = run_sync(
                 self.jhelper.run_action(
@@ -626,6 +627,7 @@ class SetHypervisorUnitsOptionsStep(BaseStep):
                     },
                 )
             )
+            run_sync(model.disconnect())
             if action_result.get("return-code", 0) > 1:
                 _message = "Unable to set hypervisor {name!r} configuration"
                 return Result(ResultType.FAILED, _message)

--- a/sunbeam-python/sunbeam/commands/generate_cloud_config.py
+++ b/sunbeam-python/sunbeam/commands/generate_cloud_config.py
@@ -38,7 +38,7 @@ from sunbeam.core.common import (
     run_plan,
 )
 from sunbeam.core.deployment import Deployment
-from sunbeam.core.juju import JujuHelper, ModelNotFoundException, run_sync
+from sunbeam.core.juju import JujuHelper, run_sync
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.terraform import TerraformHelper
 from sunbeam.utils import click_option_show_hints
@@ -261,9 +261,7 @@ def cloud_config(
     preflight_checks.append(VerifyBootstrappedCheck(client))
     run_preflight_checks(preflight_checks, console)
     jhelper = JujuHelper(deployment.get_connected_controller())
-    try:
-        run_sync(jhelper.get_model(OPENSTACK_MODEL))
-    except ModelNotFoundException:
+    if not run_sync(jhelper.model_exists(OPENSTACK_MODEL)):
         LOG.error(f"Expected model {OPENSTACK_MODEL} missing")
         raise click.ClickException("Please run `sunbeam cluster bootstrap` first")
     admin_credentials = retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)

--- a/sunbeam-python/sunbeam/commands/launch.py
+++ b/sunbeam-python/sunbeam/commands/launch.py
@@ -24,7 +24,7 @@ from snaphelpers import Snap
 
 from sunbeam.commands.configure import retrieve_admin_credentials
 from sunbeam.core.deployment import Deployment
-from sunbeam.core.juju import JujuHelper, ModelNotFoundException, run_sync
+from sunbeam.core.juju import JujuHelper, run_sync
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.terraform import TerraformException
 
@@ -61,9 +61,7 @@ def launch(
     deployment: Deployment = ctx.obj
     jhelper = JujuHelper(deployment.get_connected_controller())
     with console.status("Fetching user credentials ... "):
-        try:
-            run_sync(jhelper.get_model(OPENSTACK_MODEL))
-        except ModelNotFoundException:
+        if not run_sync(jhelper.model_exists(OPENSTACK_MODEL)):
             LOG.error(f"Expected model {OPENSTACK_MODEL} missing")
             raise click.ClickException("Please run `sunbeam cluster bootstrap` first")
 

--- a/sunbeam-python/sunbeam/features/dns/feature.py
+++ b/sunbeam-python/sunbeam/features/dns/feature.py
@@ -223,11 +223,11 @@ class DnsFeature(OpenStackControlPlaneFeature):
         model = OPENSTACK_MODEL
         application = "bind"
         jhelper = JujuHelper(deployment.get_connected_controller())
-        model_impl = await jhelper.get_model(model)
-        status = await model_impl.get_status([application])
-        if application not in status["applications"]:
-            return None
-        return status["applications"][application].public_address
+        async with jhelper.controller, await jhelper.get_model(model) as model_impl:
+            status = await model_impl.get_status([application])
+            if application not in status["applications"]:
+                return None
+            return status["applications"][application].public_address
 
     @click.command()
     @pass_method_obj

--- a/sunbeam-python/sunbeam/features/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/openstack.py
@@ -719,12 +719,11 @@ class WaitForApplicationsStep(BaseStep):
         LOG.debug(f"Application monitored for readiness: {self.apps}")
         units = []
         accepted_unit_status = {"agent": ["idle"], "workload": ["active"]}
+        model = run_sync(self.jhelper.get_model(self.model))
         try:
             for app in self.apps:
                 try:
-                    application = run_sync(
-                        self.jhelper.get_application(app, self.model)
-                    )
+                    application = run_sync(self.jhelper.get_application(app, model))
                     units.extend(application.units)
                 except ApplicationNotFoundException:
                     # Ignore if the application is not found
@@ -741,5 +740,7 @@ class WaitForApplicationsStep(BaseStep):
         except (JujuWaitException, TimeoutException) as e:
             LOG.debug(str(e))
             return Result(ResultType.FAILED, str(e))
+        finally:
+            run_sync(model.disconnect())
 
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/features/ldap/feature.py
+++ b/sunbeam-python/sunbeam/features/ldap/feature.py
@@ -121,9 +121,9 @@ class DisableLDAPDomainStep(BaseStep, JujuStepHelper):
                 )
             )
             run_sync(
-                self.jhelper.wait_all_units_ready(
-                    "keystone",
+                self.jhelper.wait_until_desired_status(
                     self.model,
+                    ["keystone"],
                     timeout=APPLICATION_REMOVE_TIMEOUT,
                 )
             )

--- a/sunbeam-python/sunbeam/features/pro/feature.py
+++ b/sunbeam-python/sunbeam/features/pro/feature.py
@@ -107,6 +107,7 @@ class EnableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
 
         # Note(gboutry): application is in state unknown when it's deployed
         # without units
+        model = run_sync(self.jhelper.get_model(self.model))
         try:
             run_sync(
                 self.jhelper.wait_application_ready(
@@ -118,12 +119,7 @@ class EnableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
             )
 
             # Check status of pro application for any token issues
-            pro_app = run_sync(
-                self.jhelper.get_application(
-                    APPLICATION,
-                    self.model,
-                )
-            )
+            pro_app = run_sync(self.jhelper.get_application(APPLICATION, model))
             if pro_app.status == "blocked":
                 message = "unknown error"
                 for unit in pro_app.units:
@@ -134,6 +130,8 @@ class EnableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
         except TimeoutException as e:
             LOG.warning(str(e))
             return Result(ResultType.FAILED, str(e))
+        finally:
+            run_sync(model.disconnect())
 
         return Result(ResultType.COMPLETED)
 

--- a/sunbeam-python/sunbeam/features/secrets/feature.py
+++ b/sunbeam-python/sunbeam/features/secrets/feature.py
@@ -90,10 +90,12 @@ class SecretsFeature(OpenStackControlPlaneFeature):
 
     def is_vault_application_active(self, jhelper: JujuHelper) -> bool:
         """Check if Vault application is active."""
-        application = run_sync(jhelper.get_application("vault", OPENSTACK_MODEL))
-        if application.status == "active":
+        model = run_sync(jhelper.get_model(OPENSTACK_MODEL))
+        application = run_sync(jhelper.get_application("vault", model))
+        status = application.status
+        run_sync(model.disconnect())
+        if status == "active":
             return True
-
         return False
 
     def pre_enable(

--- a/sunbeam-python/sunbeam/features/vault/feature.py
+++ b/sunbeam-python/sunbeam/features/vault/feature.py
@@ -317,13 +317,15 @@ class VaultUnsealStep(BaseStep):
         """
         unseal_status = {}
 
+        model = None
         try:
+            model = run_sync(self.jhelper.get_model(OPENSTACK_MODEL))
             # Run vault unseal on leader unit
             leader_unit = run_sync(
                 self.jhelper.get_leader_unit(VAULT_APPLICATION_NAME, OPENSTACK_MODEL)
             )
             application = run_sync(
-                self.jhelper.get_application(VAULT_APPLICATION_NAME, OPENSTACK_MODEL)
+                self.jhelper.get_application(VAULT_APPLICATION_NAME, model)
             )
             non_leader_units = [
                 unit.name for unit in application.units if unit.name != leader_unit
@@ -385,6 +387,9 @@ class VaultUnsealStep(BaseStep):
         except VaultCommandFailedException as e:
             LOG.debug("Failed to run vault unseal", exc_info=True)
             return Result(ResultType.FAILED, str(e))
+        finally:
+            if model:
+                run_sync(model.disconnect())
 
 
 class AuthorizeVaultCharmStep(BaseStep, JujuStepHelper):
@@ -485,10 +490,11 @@ class VaultStatusStep(BaseStep):
         :return: ResultType.COMPLETED or ResultType.FAILED
         """
         consolidated_status = {}
-
+        model = None
         try:
+            model = run_sync(self.jhelper.get_model(OPENSTACK_MODEL))
             application = run_sync(
-                self.jhelper.get_application(VAULT_APPLICATION_NAME, OPENSTACK_MODEL)
+                self.jhelper.get_application(VAULT_APPLICATION_NAME, model)
             )
             for unit in application.units:
                 vault_status = self.vhelper.get_vault_status(unit.name)
@@ -504,6 +510,9 @@ class VaultStatusStep(BaseStep):
         except JujuException as e:
             LOG.debug("Failed to run vault unseal", exc_info=True)
             return Result(ResultType.FAILED, str(e))
+        finally:
+            if model:
+                run_sync(model.disconnect())
 
 
 class VaultFeature(OpenStackControlPlaneFeature):

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -78,7 +78,6 @@ from sunbeam.core.deployments import DeploymentsConfig, deployment_path
 from sunbeam.core.juju import (
     JujuHelper,
     JujuStepHelper,
-    ModelNotFoundException,
     run_sync,
 )
 from sunbeam.core.k8s import K8S_CLOUD_SUFFIX
@@ -1356,9 +1355,7 @@ def configure_cmd(
 
     name = utils.get_fqdn(deployment.get_management_cidr())
     jhelper = JujuHelper(deployment.get_connected_controller())
-    try:
-        run_sync(jhelper.get_model(OPENSTACK_MODEL))
-    except ModelNotFoundException:
+    if not run_sync(jhelper.model_exists(OPENSTACK_MODEL)):
         LOG.error(f"Expected model {OPENSTACK_MODEL} missing")
         raise click.ClickException("Please run `sunbeam cluster bootstrap` first")
     admin_credentials = retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)

--- a/sunbeam-python/sunbeam/provider/local/steps.py
+++ b/sunbeam-python/sunbeam/provider/local/steps.py
@@ -83,13 +83,14 @@ class LocalSetHypervisorUnitsOptionsStep(SetHypervisorUnitsOptionsStep):
         name = self.names[0]  # always only one name in local mode
         node = self.client.cluster.get_node_info(name)
         machine_id = str(node.get("machineid"))
+        model = run_sync(self.jhelper.get_model(self.model))
         unit = await self.jhelper.get_unit_from_machine(
-            "openstack-hypervisor", machine_id, self.model
+            "openstack-hypervisor", machine_id, model
         )
-
         action_result = await self.jhelper.run_action(
             unit.entity_id, self.model, "list-nics"
         )
+        run_sync(model.disconnect())
 
         if action_result.get("return-code", 0) > 1:
             _message = f"Unable to fetch hypervisor {name!r} nics"

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -69,7 +69,6 @@ from sunbeam.core.juju import (
     CONTROLLER_APPLICATION,
     CONTROLLER_MODEL,
     JujuHelper,
-    ModelNotFoundException,
     run_sync,
 )
 from sunbeam.core.manifest import AddManifestStep
@@ -821,9 +820,7 @@ def configure_cmd(
     LOG.debug(f"Manifest used for deployment - features: {manifest.features}")
 
     jhelper = JujuHelper(deployment.get_connected_controller())
-    try:
-        run_sync(jhelper.get_model(OPENSTACK_MODEL))
-    except ModelNotFoundException:
+    if not run_sync(jhelper.model_exists(OPENSTACK_MODEL)):
         LOG.error(f"Expected model {OPENSTACK_MODEL} missing")
         raise click.ClickException("Please run `sunbeam cluster bootstrap` first")
     admin_credentials = retrieve_admin_credentials(jhelper, OPENSTACK_MODEL)

--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -245,12 +245,12 @@ class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
             LOG.debug(f"Machine {self.name} does not exist, skipping.")
             return Result(ResultType.SKIPPED)
 
+        model = run_sync(self.jhelper.get_model(self.model))
         try:
-            application = run_sync(
-                self.jhelper.get_application(APPLICATION, self.model)
-            )
+            application = run_sync(self.jhelper.get_application(APPLICATION, model))
         except ApplicationNotFoundException as e:
             LOG.debug(str(e))
+            run_sync(model.disconnect())
             return Result(
                 ResultType.SKIPPED, "Hypervisor application has not been deployed yet"
             )
@@ -260,6 +260,7 @@ class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
                 LOG.debug(f"Unit {unit.name} is deployed on machine: {self.machine_id}")
                 self.unit = unit.name
                 break
+        run_sync(model.disconnect())
         if not self.unit:
             LOG.debug(f"Unit is not deployed on machine: {self.machine_id}, skipping.")
             return Result(ResultType.SKIPPED)

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -83,6 +83,7 @@ class LatestInChannel(BaseStep, JujuStepHelper):
         and the deployed app is same, run juju refresh.
         Otherwise ignore so that terraform plan apply will take care of charm upgrade.
         """
+        model_impl = run_sync(self.jhelper.get_model(model))
         for app_name, (charm, channel, _) in apps.items():
             manifest_charm = self.manifest.core.software.charms.get(charm)
             if not manifest_charm:
@@ -94,10 +95,11 @@ class LatestInChannel(BaseStep, JujuStepHelper):
                 continue
 
             if not manifest_charm.revision and manifest_charm.channel == channel:
-                app = run_sync(self.jhelper.get_application(app_name, model))
+                app = run_sync(self.jhelper.get_application(app_name, model_impl))
                 LOG.debug(f"Running refresh for app {app_name}")
                 # refresh() checks for any new revision and updates if available
                 run_sync(app.refresh())
+        run_sync(model_impl.disconnect())
 
     def run(self, status: Status | None = None) -> Result:
         """Refresh all charms identified as needing a refresh.

--- a/sunbeam-python/tests/unit/sunbeam/core/test_checks.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_checks.py
@@ -329,7 +329,7 @@ class TestLxdGroupCheck:
         result = check.run()
 
         assert result is False
-        assert f"{user} not part of lxd group" in check.message
+        assert f"{user!r} not part of lxd group" in check.message
 
 
 class TestLxdControllerRegistrationCheck:

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -962,7 +962,7 @@ class TestMaasDeployMachinesStep:
             {"name": "test_node3"},
             {"name": "test_node4"},
         ]
-        maas_deploy_machines_step.jhelper.get_model.return_value = Mock(
+        maas_deploy_machines_step.jhelper.get_model.return_value = AsyncMock(
             machines={
                 "1": Mock(hostname="test_node3", id=1),
                 "2": Mock(hostname="test_node4", id=2),
@@ -1049,6 +1049,8 @@ class TestMaasConfigureMicrocephOSDStep:
         jhelper = Mock()
         jhelper.get_leader_unit = AsyncMock(return_value="leader_unit")
         jhelper.get_unit_from_machine = AsyncMock(return_value="unit/1")
+        jhelper.get_model = AsyncMock()
+        jhelper.get_model_closing = AsyncMock()
         return jhelper
 
     @pytest.fixture
@@ -1124,12 +1126,16 @@ class TestMaasConfigureMicrocephOSDStep:
             "machine1": Mock(hostname="test_node1"),
             "machine2": Mock(hostname="test_node2"),
         }
-        step.jhelper.get_model.return_value = Mock(
+
+        ctxt_mgr = AsyncMock()
+        ctxt_mgr.__aenter__.return_value = Mock(
             machines={
                 "1": Mock(hostname="test_node1", id=1),
                 "2": Mock(hostname="test_node2", id=2),
             }
         )
+        ctxt_mgr.__aexit__.return_value = None
+        step.jhelper.get_model_closing = Mock(return_value=ctxt_mgr)
 
         # Call the method under test
         result = await step._get_microceph_disks()

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_juju.py
@@ -67,7 +67,7 @@ class TestWriteJujuStatusStep:
         assert result.result_type == ResultType.COMPLETED
 
     def test_is_skip_when_model_not_present(self, jhelper):
-        jhelper.get_model.side_effect = ModelNotFoundException("not found")
+        jhelper.model_exists.return_value = False
         with tempfile.NamedTemporaryFile() as tmpfile:
             step = juju.WriteJujuStatusStep(jhelper, "openstack", tmpfile)
             result = step.is_skip()


### PR DESCRIPTION
Each time a model is connected to the controller, it will spawn a background task with a watcher communicating to the controller. While this can bring many features, Sunbeam does not make use of them, nor does it want to make use of them. This can create issues in case of unstable connection, with coroutines raising exceptions in the background. Error such as: `Unknown watcher id` or `reconnect error in coro`

Always close a model once usage is done. There are some cases where the JujuHelper "leak" entities connected to the model. In this case, it's the caller responsibility to closed the model after usage of these entities is over.

Depends-On: https://github.com/canonical/snap-openstack/pull/447