### PR TITLE
Do not dump init result in logs

### DIFF
--- a/sunbeam-python/sunbeam/features/vault/feature.py
+++ b/sunbeam-python/sunbeam/features/vault/feature.py
@@ -256,7 +256,6 @@ class VaultInitStep(BaseStep):
             res = self.vhelper.initialize_vault(
                 self.leader_unit, self.key_shares, self.key_threshold
             )
-            LOG.debug(f"Vault init command output: {res}")
             keys: str = json.dumps(res)
         except LeaderNotFoundException as e:
             LOG.debug(f"Failed to get {VAULT_APPLICATION_NAME} leader", exc_info=True)


### PR DESCRIPTION
Init result will contain the key shares used to unseal Vault, these keys are private and should never be logged.