### PR TITLE
Reapply Hypervisor plan with optional integrations as target

### DIFF
--- a/sunbeam-python/sunbeam/core/steps.py
+++ b/sunbeam-python/sunbeam/core/steps.py
@@ -88,6 +88,10 @@ class DeployMachineApplicationStep(BaseStep):
         """Extra terraform vars to pass to terraform apply."""
         return {}
 
+    def tf_apply_extra_args(self) -> list:
+        """Extra args for the terraform apply command."""
+        return []
+
     def get_application_timeout(self) -> int:
         """Application timeout in seconds."""
         return 600
@@ -144,6 +148,7 @@ class DeployMachineApplicationStep(BaseStep):
                 self.manifest,
                 tfvar_config=self.config,
                 override_tfvars=extra_tfvars,
+                tf_apply_extra_args=self.tf_apply_extra_args(),
             )
         except TerraformException as e:
             return Result(ResultType.FAILED, str(e))

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -112,6 +112,7 @@ from sunbeam.steps.clusterd import (
 from sunbeam.steps.hypervisor import (
     AddHypervisorUnitsStep,
     DeployHypervisorApplicationStep,
+    ReapplyHypervisorOptionalIntegrationsStep,
     ReapplyHypervisorTerraformPlanStep,
     RemoveHypervisorUnitStep,
 )
@@ -1156,7 +1157,7 @@ def join(
         hypervisor_tfhelper = deployment.get_tfhelper("hypervisor-plan")
         plan4.append(TerraformInitStep(hypervisor_tfhelper))
         plan4.append(
-            DeployHypervisorApplicationStep(
+            ReapplyHypervisorOptionalIntegrationsStep(
                 deployment,
                 client,
                 hypervisor_tfhelper,

--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -179,6 +179,28 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
         return HYPERVISOR_APP_TIMEOUT
 
 
+class ReapplyHypervisorOptionalIntegrationsStep(DeployHypervisorApplicationStep):
+    """Reapply openstack-hypervisor optional integrations using Terraform cloud.
+
+    The optional integrations related to storage or any features will be reapplied
+    at this step. This is to ensure the integrations are created irrespective of
+    the order of the roles joining the cluster.
+
+    This class is similar to DeployHypervisorApplicationStep but it refreshes only
+    integrations after getting the necessary CMR offer URLs.
+    """
+
+    def tf_apply_extra_args(self) -> list:
+        """Extra args for the terraform apply command."""
+        return [
+            "-target=juju_integration.hypervisor-cert-distributor",
+            "-target=juju_integration.hypervisor-certs",
+            "-target=juju_integration.hypervisor-ceilometer",
+            "-target=juju_integration.hypervisor-cinder-ceph",
+            "-target=juju_integration.hypervisor-masakari",
+        ]
+
+
 class AddHypervisorUnitsStep(AddMachineUnitsStep):
     def __init__(
         self,

--- a/sunbeam-python/tests/unit/sunbeam/core/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_steps.py
@@ -171,6 +171,7 @@ class TestDeployMachineApplicationStep:
             manifest,
             tfvar_config=tfconfig,
             override_tfvars={"machine_ids": machines, "machine_model": model},
+            tf_apply_extra_args=[],
         )
         assert result.result_type == ResultType.COMPLETED
 


### PR DESCRIPTION
When multiple nodes are joined with compute+storage role, the DeployOpenStackHypervisorApplication step updates the machine-id's with known juju machines at that point of time. However due to parallel node joins, the machines might have been updated in juju just before applying the terraform plan which makes discrepancy in machine_id's in terraform vars resulted in removal of machines.

This step is introduced in join workflow to update any missing integrations, especially ceph. So reapply the terraform plan with target as integrations instead of the complete plan. It is safe to update only optional integrations in this step since they are dynamic in nature and applied when certain roles are tagged or features are enabled.

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2103499