### PR TITLE
Use config file for juju bootstrap config args

### DIFF
--- a/sunbeam-python/tox.ini
+++ b/sunbeam-python/tox.ini
@@ -18,6 +18,8 @@ setenv = OS_STDOUT_CAPTURE=1
          OS_STDERR_CAPTURE=1
          OS_TEST_TIMEOUT=60
 deps =
+  # Pin setuptools to avoid py3 disutils import error
+  setuptools<77
   -r{toxinidir}/test-requirements.txt
   -r{toxinidir}/requirements.txt
   -c{toxinidir}/upper-constraints.txt


### PR DESCRIPTION
Currently the config args are part of juju bootstrap command and they are visible in process list. This poses security risk if admin-secret is passed as config arg.

Write all config args in a config file and use --config <file path> as argument to juju bootstrap.

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2103637