### PR TITLE
Don't show an unnecessary red error message

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -152,7 +152,7 @@ EOF
 fi
 # Bootstrap juju onto LXD
 echo 'Bootstrapping Juju onto LXD'
-sudo --user $USER juju show-controller
+sudo --user $USER juju show-controller 2>/dev/null
 if [ $? -ne 0 ]; then
     sudo --user $USER juju bootstrap localhost
 fi


### PR DESCRIPTION
The step is expected to output the following error.

> ERROR there is no active controller

However, it's well expected so don't show the message since there is no action necessary by the users at all.

Closes-Bug: [LP: #2095410](https://bugs.launchpad.net/snap-openstack/+bug/2095410)