### PR TITLE
Use the system default key type where possible

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -60,8 +60,8 @@ dpkg -s curl &> /dev/null || {{
 sudo usermod --append --groups snap_daemon $USER
 
 # Generate keypair and set-up prompt-less access to local machine
-[ -f $HOME/.ssh/id_rsa ] || ssh-keygen -b 4096 -f $HOME/.ssh/id_rsa -t rsa -N ""
-cat $HOME/.ssh/id_rsa.pub >> $HOME/.ssh/authorized_keys
+[ -f $HOME/.ssh/id_ed25519 ] || ssh-keygen -f $HOME/.ssh/id_ed25519 -t ed25519 -N ""
+cat $HOME/.ssh/id_ed25519.pub >> $HOME/.ssh/authorized_keys
 ssh-keyscan -H $(hostname --all-ip-addresses) >> $HOME/.ssh/known_hosts
 
 if ! grep -E 'HTTPS?_PROXY' /etc/environment &> /dev/null && \


### PR DESCRIPTION
Noble's default key type is Ed25519.

https://manpages.ubuntu.com/manpages/noble/en/man1/ssh-keygen.1.html
> The type of key to be generated is specified with the -t option. If
> invoked without any arguments, ssh-keygen will generate an Ed25519
> key.

Partial-Bug: [LP: #2097434](https://bugs.launchpad.net/snap-openstack/+bug/2097434)


Tested the patch by hand, and the Juju controller imported the Ed25519 into the authorized_keys file without any human intervention.

```bash
sunbeam-multi-node-1:~$ sunbeam prepare-node-script --bootstrap


sunbeam-multi-node-1:~$ juju ssh -m localhost-localhost:controller controller/0 -- cat ~ubuntu/.ssh/authorized_keys
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCCdGwY4lBHVrZNQlLYQCKO7Ib816k8wdxkUabqCZm1iqmuaIJAuPKTEp8YNBwNMGbvQm4aoKXmTVdimLZjzObsZHXZ7NMMQZMs+ctPY01YteAyM6/LVXWU9w4OrEJ0+6jhpYJeUYDr65Db8rQwju5kfR89TBqWWFYSdNmEBSWvxFp7njFN5I0kw+L0A4gp6LIbfLlHidFRBgnOPJILxQTbse8bObFFlWZazLMVf2CfVVRp/4gVyovDPH49oMIgKNEVLDCv479YKJJD3xO7SEoFfdLwwVo/qhQpxH4JHI7qSLpg+4jFJjcl+EDSzQeBDX0sOrzQkgwFTm8rU1ttV6+Xo6MBTzPialSUAdjyylKIwFPCxdNIxCCyhHoev6EVpO3GyeXbucjLnPADPFNjlRMw+V642rkyBHe2hmVUGJIdi0DHMEHpykjIiJVH0Rh8l41oh5ceU3Zfv5CX/7ioUpvB8kKVW30yv+ptJcIzNvBWiNbNALun2hQCxYnIM3HzQ85NxIsAAaT8iWd9FBPHlttypRF5/Z6rtdWTNUxwKlm1Gx0LRpGrjVSNaw44oVFZORV8IjPFmWjGq3OUBlkUQXcpD/uOtMz+l74dhSfID+tGHBU4MQ88+k6R3FSSNBTieelIIRhooWbJB3YGClCHHOaLfirYX4umQHaAkUuFAqcSw== Juju:juju-client-key
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICkY2YFdWOtrrHfD00cqR5AJE9Niudq7ZU9QFfm0MVvH Juju:ubuntu@sunbeam-multi-node-1
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDHw7MNdsvgnJotFwgBe5JJNy3jVVovtzCiJMMHDcV7teE/iXmIGJFdr2vCV7MsHMG9keFqfOpu9LZ8UFfPdvb9A2dMmxmc1lXlEIqnW+ViRbdDtAxoWqEYZu5LLBs+wbvp+GYOVQETq+NMc7jrC0IG+7OgPjmvXMPmBvXxtswSfuFY4ORyg5L1e2U2WY79UB69FNhfq7ajsLt+nA23QThlkpTDaoqG2/bvC7pO42lgerHuGFOeC5dUQAVpBm3D6qTIOkXZEMaaGykD0TSMUzgvTte/6S1NXmu5+g6YFdyDUVIz8qoCKizpWEnj5Muk+FeccTaGSrfn0L4pKd317EegDvu1sfLNXTVNFLa98IYDq0EVLky7ahIFdjSgKqHLpRrwjQiGDjSlNZfqggNmuied338QsvHPPhacPovuLwVXXaq3SskxzPzTLEvtCfg8LIYkuGCAGe0B4FWcUk4YXqaTrGb7CjlEaH9VTaO+wdkROR8sBd7B0nHEhz4yo2Ox8cbSYa5VAeIQs1Y3oIWGNXmfGUoi/3oppf75v29VVs7F4f9qKQ2NPHT1zBAVctb1ZYF7YSJPzxKIOYpbzRJeZKZIQcdvK474piqc/hdT7ey8vKd3tg4e4V6z+jbyQeZACE2cUa4xyZ0ECEbKQ3uLCuNiRpaGP5WJnlhPBVN191SaCQ== Juju:juju-system-key
Connection to 10.80.182.97 closed.
```