### PR TITLE
Prompt user for database topology

### DIFF
--- a/sunbeam-python/sunbeam/commands/resize.py
+++ b/sunbeam-python/sunbeam/commands/resize.py
@@ -15,6 +15,7 @@
 import logging
 
 import click
+from click.core import ParameterSource
 from rich.console import Console
 
 from sunbeam.clusterd.client import Client
@@ -36,7 +37,13 @@ console = Console()
 @click.command()
 @click_option_topology
 @click.option(
-    "-f", "--force", help="Force resizing to incompatible topology.", is_flag=True
+    "-f",
+    "--force",
+    help=(
+        "Force resizing to incompatible topology. "
+        "This option is deprecated and the value is ignored."
+    ),
+    is_flag=True,
 )
 @click_option_show_hints
 @click.pass_context
@@ -53,6 +60,10 @@ def resize(
     jhelper = JujuHelper(deployment.get_connected_controller())
 
     storage_nodes = client.cluster.list_nodes_by_role("storage")
+
+    parameter_source = click.get_current_context().get_parameter_source("force")
+    if parameter_source == ParameterSource.COMMANDLINE:
+        LOG.warning("WARNING: Option --force is deprecated and the value is ignored.")
 
     plan = []
     if len(storage_nodes):
@@ -86,9 +97,7 @@ def resize(
                 jhelper,
                 manifest,
                 topology,
-                "auto",
                 deployment.openstack_machines_model,
-                force=force,
             ),
         ]
     )

--- a/sunbeam-python/sunbeam/core/common.py
+++ b/sunbeam-python/sunbeam/core/common.py
@@ -359,10 +359,9 @@ def click_option_database(func: click.decorators.FC) -> click.decorators.FC:
             case_sensitive=False,
         ),
         help=(
-            "Allows definition of the intended cluster configuration: "
-            "'auto' for automatic determination, "
-            "'single' for a single database, "
-            "'multi' for a database per service, "
+            "This option is deprecated and the value is ignored. "
+            "Instead user is prompted to select the database topology. "
+            "The database topology can also be set via manifest."
         ),
     )(func)
 

--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -214,6 +214,7 @@ class CoreConfig(pydantic.BaseModel):
 
     proxy: _ProxyConfig | None = None
     bootstrap: _BootstrapConfig | None = None
+    database: str | None = None
     region: str | None = None
     addons: _Addons | None = None
     k8s_addons: _K8sAddons | None = pydantic.Field(default=None, alias="k8s-addons")

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -19,6 +19,7 @@ from typing import Tuple, Type
 
 import click
 import yaml
+from click.core import ParameterSource
 from rich.console import Console
 from snaphelpers import Snap
 
@@ -164,6 +165,7 @@ from sunbeam.steps.microceph import (
 from sunbeam.steps.openstack import (
     DeployControlPlaneStep,
     OpenStackPatchLoadBalancerServicesIPStep,
+    PromptDatabaseTopologyStep,
     PromptRegionStep,
 )
 from sunbeam.steps.sunbeam_machine import (
@@ -586,6 +588,14 @@ def bootstrap(
     deployments = DeploymentsConfig.load(path)
     manifest = deployment.get_manifest(manifest_path)
 
+    parameter_source = click.get_current_context().get_parameter_source("database")
+    if parameter_source == ParameterSource.COMMANDLINE:
+        LOG.warning(
+            "WARNING: Option --database is deprecated and the value is ignored. "
+            "Instead user is prompted to select the database topology. "
+            "The database topology can also be set via manifest."
+        )
+
     LOG.debug(f"Manifest used for deployment - core: {manifest.core}")
     LOG.debug(f"Manifest used for deployment - features: {manifest.features}")
 
@@ -669,6 +679,7 @@ def bootstrap(
             deployment, accept_defaults=accept_defaults, manifest=manifest
         )
     )
+    plan.append(PromptDatabaseTopologyStep(client, manifest, accept_defaults))
     plan.append(PromptRegionStep(client, manifest, accept_defaults))
     run_plan(plan, console, show_hints)
 
@@ -785,7 +796,6 @@ def bootstrap(
                 jhelper,
                 manifest,
                 topology,
-                database,
                 deployment.openstack_machines_model,
                 proxy_settings=proxy_settings,
             )
@@ -1120,7 +1130,6 @@ def join(
                     openstack_tfhelper,
                     jhelper,
                     manifest,
-                    "auto",
                     "auto",
                     deployment.openstack_machines_model,
                 )

--- a/sunbeam-python/sunbeam/steps/openstack.py
+++ b/sunbeam-python/sunbeam/steps/openstack.py
@@ -71,6 +71,7 @@ DATABASE_MEMORY_KEY = "DatabaseMemory"
 DATABASE_STORAGE_KEY = "DatabaseStorage"
 REGION_CONFIG_KEY = "Region"
 DEFAULT_REGION = "RegionOne"
+DEFAULT_DATABASE_TOPOLOGY = "single"
 
 DATABASE_MAX_POOL_SIZE = 2
 DATABASE_ADDITIONAL_BUFFER_SIZE = 600
@@ -378,10 +379,8 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         jhelper: JujuHelper,
         manifest: Manifest,
         topology: str,
-        database: str,
         machine_model: str,
         proxy_settings: dict | None = None,
-        force: bool = False,
     ):
         super().__init__(
             "Deploying OpenStack Control Plane",
@@ -392,12 +391,11 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         self.jhelper = jhelper
         self.manifest = manifest
         self.topology = topology
-        self.database = database
         self.machine_model = machine_model
         self.proxy_settings = proxy_settings or {}
-        self.force = force
         self.model = OPENSTACK_MODEL
         self.cloud = K8SHelper.get_cloud(deployment.name)
+        self.database = DEFAULT_DATABASE_TOPOLOGY
 
     def get_storage_tfvars(self, storage_nodes: list[dict]) -> dict:
         """Create terraform variables related to storage."""
@@ -483,6 +481,8 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         self.update_status(status, "determining appropriate configuration")
         try:
             previous_config = read_config(self.client, TOPOLOGY_KEY)
+            self.database = previous_config.get("database", DEFAULT_DATABASE_TOPOLOGY)
+            LOG.debug(f"database topology {self.database}")
         except ConfigItemNotFoundException:
             # Config was never registered in database
             previous_config = {}
@@ -492,28 +492,6 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         if self.topology == "auto":
             self.topology = determined_topology
         LOG.debug(f"topology {self.topology}")
-
-        if self.database == "auto":
-            self.database = previous_config.get("database", determined_topology)
-        if self.database == "large":
-            # multi and large are the same
-            self.database = "multi"
-        LOG.debug(f"database topology {self.database}")
-        if (database := previous_config.get("database")) and database != self.database:
-            return Result(
-                ResultType.FAILED,
-                "Database topology cannot be changed, please destroy and re-bootstrap",
-            )
-
-        is_not_compatible = self.database == "single" and self.topology == "large"
-        if not self.force and is_not_compatible:
-            return Result(
-                ResultType.FAILED,
-                (
-                    "Cannot deploy control plane to large with single database,"
-                    " use -f/--force to override"
-                ),
-            )
 
         # Check for database size modifications in manifest
         # TODO: Force flag to update storage sizes once resize database on k8s
@@ -829,6 +807,94 @@ class PromptRegionStep(BaseStep):
         :return:
         """
         return Result(ResultType.COMPLETED, f"Region set to {self.variables['region']}")
+
+
+def validate_database_topologies(database: str):
+    """Checkf if topology is either single or multi."""
+    if database not in ["single", "multi"]:
+        raise ValueError("Database topology should be single or multi.")
+
+
+def database_topology_questions():
+    return {
+        "database": PromptQuestion(
+            "Enter database toplogy: single/multi (cannot be changed later)",
+            default_value=DEFAULT_DATABASE_TOPOLOGY,
+            validation_function=validate_database_topologies,
+            description=(
+                "This will configure number of databases, single for entire cluster "
+                "or multiple databases with one per openstack service."
+            ),
+        )
+    }
+
+
+class PromptDatabaseTopologyStep(BaseStep):
+    """Prompt user for database topology."""
+
+    def __init__(
+        self,
+        client: Client,
+        manifest: Manifest | None = None,
+        accept_defaults: bool = False,
+    ):
+        super().__init__("Database", "Query user for database topology")
+        self.client = client
+        self.manifest = manifest
+        self.accept_defaults = accept_defaults
+        self.variables: dict = {}
+
+    def prompt(
+        self,
+        console: Console | None = None,
+        show_hint: bool = False,
+    ) -> None:
+        """Determines if the step can take input from the user.
+
+        Prompts are used by Steps to gather the necessary input prior to
+        running the step. Steps should not expect that the prompt will be
+        available and should provide a reasonable default where possible.
+        """
+        self.variables = load_answers(self.client, TOPOLOGY_KEY)
+
+        if database := self.variables.get("database"):
+            # Region cannot be modified once set
+            LOG.debug(f"Database topology already set to {database}")
+            return
+
+        preseed = {}
+        if self.manifest:
+            preseed["database"] = self.manifest.core.config.database
+
+        database_topology_bank = QuestionBank(
+            questions=database_topology_questions(),
+            console=console,
+            preseed=preseed,
+            previous_answers=self.variables,
+            accept_defaults=self.accept_defaults,
+            show_hint=show_hint,
+        )
+        self.variables["database"] = database_topology_bank.database.ask()
+        write_answers(self.client, TOPOLOGY_KEY, self.variables)
+
+    def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user.
+
+        :return: True if the step can ask the user for prompts,
+                 False otherwise
+        """
+        return True
+
+    def run(self, status: Status | None) -> Result:
+        """Run the step to completion.
+
+        Invoked when the step is run and returns a ResultType to indicate
+        :return:
+        """
+        return Result(
+            ResultType.COMPLETED,
+            f"Database topology set to {self.variables['database']}",
+        )
 
 
 class DestroyControlPlaneStep(BaseStep):

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
@@ -50,7 +50,6 @@ from sunbeam.steps.openstack import (
 )
 
 TOPOLOGY = "single"
-DATABASE = "single"
 MODEL = "test-model"
 
 
@@ -120,7 +119,6 @@ class TestDeployControlPlaneStep(unittest.TestCase):
             self.jhelper,
             self.manifest,
             TOPOLOGY,
-            DATABASE,
             MODEL,
         )
         result = step.run()
@@ -140,7 +138,6 @@ class TestDeployControlPlaneStep(unittest.TestCase):
             self.jhelper,
             self.manifest,
             TOPOLOGY,
-            DATABASE,
             MODEL,
         )
         result = step.run()
@@ -159,7 +156,6 @@ class TestDeployControlPlaneStep(unittest.TestCase):
             self.jhelper,
             self.manifest,
             TOPOLOGY,
-            DATABASE,
             MODEL,
         )
         result = step.run()
@@ -180,7 +176,6 @@ class TestDeployControlPlaneStep(unittest.TestCase):
             self.jhelper,
             self.manifest,
             TOPOLOGY,
-            DATABASE,
             MODEL,
         )
         result = step.run()
@@ -197,7 +192,6 @@ class TestDeployControlPlaneStep(unittest.TestCase):
             self.jhelper,
             self.manifest,
             TOPOLOGY,
-            DATABASE,
             MODEL,
         )
         with patch(
@@ -216,69 +210,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
             self.jhelper,
             self.manifest,
             TOPOLOGY,
-            DATABASE,
             MODEL,
-        )
-        with patch(
-            "sunbeam.steps.openstack.read_config",
-            Mock(return_value={"topology": "single", "database": "single"}),
-        ):
-            result = step.is_skip()
-
-        assert result.result_type == ResultType.COMPLETED
-
-    def test_is_skip_database_changed(self):
-        self.snap_mock().config.get.return_value = "k8s"
-        step = DeployControlPlaneStep(
-            self.deployment,
-            self.tfhelper,
-            self.jhelper,
-            self.manifest,
-            TOPOLOGY,
-            DATABASE,
-            MODEL,
-        )
-        with patch(
-            "sunbeam.steps.openstack.read_config",
-            Mock(return_value={"topology": "single", "database": "multi"}),
-        ):
-            result = step.is_skip()
-
-        assert result.result_type == ResultType.FAILED
-
-    def test_is_skip_incompatible_topology(self):
-        self.snap_mock().config.get.return_value = "k8s"
-        step = DeployControlPlaneStep(
-            self.deployment,
-            self.tfhelper,
-            self.jhelper,
-            self.manifest,
-            "large",
-            "auto",
-            MODEL,
-            force=False,
-        )
-        with patch(
-            "sunbeam.steps.openstack.read_config",
-            Mock(return_value={"topology": "single", "database": "single"}),
-        ):
-            result = step.is_skip()
-
-        assert result.result_type == ResultType.FAILED
-        assert result.message
-        assert "use -f/--force to override" in result.message
-
-    def test_is_skip_force_incompatible_topology(self):
-        self.snap_mock().config.get.return_value = "k8s"
-        step = DeployControlPlaneStep(
-            self.deployment,
-            self.tfhelper,
-            self.jhelper,
-            self.manifest,
-            "large",
-            "auto",
-            MODEL,
-            force=True,
         )
         with patch(
             "sunbeam.steps.openstack.read_config",


### PR DESCRIPTION
Currently bootstrap in local provider and deploy in maas provider have option --database 
with choices auto, single,multi. Auto tries to determine the database topology. 
Remove auto determination of database topology and ask user for the database topology.

Prompt User for database topology selection.
Add new key database in manifest config section to set database topology.
Default value of database topology is single.
Deprecate --database option in bootstrap and deploy commands.

DeployControlPlaneStep has --force function attribute to check incompatibilities and force deploy.
This is no more required as user explicitly sets the database topology.
Deprecate --force flag in resize command which is used for the same purpose.