### PR TITLE
ca: Increase unit certs timeout

### DIFF
--- a/sunbeam-python/sunbeam/features/tls/common.py
+++ b/sunbeam-python/sunbeam/features/tls/common.py
@@ -48,7 +48,7 @@ from sunbeam.utils import pass_method_obj
 
 CERTIFICATE_FEATURE_KEY = "TlsProvider"
 # Time out for keystone to settle once ingress change relation data
-INGRESS_CHANGE_APPLICATION_TIMEOUT = 900
+INGRESS_CHANGE_APPLICATION_TIMEOUT = 1200
 LOG = logging.getLogger(__name__)
 console = Console()
 

--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -453,22 +453,14 @@ async def test_jhelper_add_k8s_cloud_unsupported_kubeconfig(jhelper: juju.JujuHe
 
 test_data_k8s = [
     ("wait_application_ready", "k8s", "application 'k8s'", [["blocked"]]),
-    (
-        "wait_units_ready",
-        "k8s/0",
-        "units k8s/0",
-        [{"agent": "idle", "workload": "blocked"}],
-    ),
 ]
 
 test_data_custom_status = [
     ("wait_application_ready", "mk8s", ["unknown"]),
-    ("wait_units_ready", "k8s/1", {"agent": "unknown", "workload": "unknown"}),
 ]
 
 test_data_missing = [
     ("wait_application_ready", "mysql"),
-    ("wait_units_ready", "mysql/0"),
 ]
 
 


### PR DESCRIPTION
When running the `sunbeam tls ca unit_certs`, sunbeam will wait on traefiks' and keystone's units for readiness. The timeout of 900 is a little short, with keystone still being in execution at the end of timer. Keystone needs to update 14+ services in its database + relations. And this can happen only after the multiple traefik have updated all their endpoints + their own relations.

Remove `wait_unit_ready` to the new code `wait_until_desired_status` with the same parameter. This will improve logs and avoid risky code paths in pylibjuju.

Closes-Bug: LP#2104115