### PR TITLE
Wait for a VM longer

### DIFF
--- a/sunbeam-python/sunbeam/commands/launch.py
+++ b/sunbeam-python/sunbeam/commands/launch.py
@@ -29,6 +29,7 @@ from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.terraform import TerraformException
 
 LOG = logging.getLogger(__name__)
+INSTANCE_WAIT_TIMEOUT = 360  # 6 min
 console = Console()
 snap = Snap()
 
@@ -134,7 +135,7 @@ def launch(
                 key_name=keypair.name,
             )
 
-            server = conn.compute.wait_for_server(server)
+            server = conn.compute.wait_for_server(server, wait=INSTANCE_WAIT_TIMEOUT)
         except openstack.exceptions.SDKException as e:
             LOG.error(f"Instance creation request failed: {e}")
             raise click.ClickException(


### PR DESCRIPTION
The default timeout from the library is 120 seconds, but it's too short in some cases. It's fair to wait for a VM a bit longer. The new value as 6 minutes is one more minute to the default vif_plugging_timeout of Nova to wait for a Neutron port.

Closes-Bug: [LP: #2104156](https://bugs.launchpad.net/snap-openstack/+bug/2104156)

The library API doc:
https://docs.openstack.org/openstacksdk/latest/user/proxies/compute.html#the-compute-class