### PR TITLE
Implement ARP resolution per host per iface

### DIFF
--- a/sunbeam-python/sunbeam/core/deployment.py
+++ b/sunbeam-python/sunbeam/core/deployment.py
@@ -403,3 +403,13 @@ class Deployment(pydantic.BaseModel):
     def get_space(self, network: Networks) -> str:
         """Get space associated to network."""
         return NotImplemented
+
+    @property
+    def internal_ip_pool(self):
+        """Name of the internal IP pool."""
+        raise NotImplementedError
+
+    @property
+    def public_ip_pool(self):
+        """Name of the public IP pool."""
+        raise NotImplementedError

--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -581,6 +581,20 @@ class JujuHelper:
         """
         return model.machines
 
+    async def get_machine_interfaces(self, model: str, machine: str) -> dict[str, dict]:
+        """Fetch machine interfaces.
+
+        :model: Name of the model where the machine is located
+        :machine: id of the machine
+        """
+        status = await self.get_model_status(model)
+        m_status = status["machines"].get(machine)
+        if machine is None:
+            raise MachineNotFoundException(
+                f"Machine {machine!r} is missing from model {model.name!r}"
+            )
+        return m_status["network-interfaces"]
+
     async def set_model_config(self, model: str, config: dict) -> None:
         """Set model config for the given model."""
         async with self.get_model_closing(model) as model_impl:

--- a/sunbeam-python/sunbeam/core/k8s.py
+++ b/sunbeam-python/sunbeam/core/k8s.py
@@ -39,6 +39,7 @@ SERVICE_LB_ANNOTATION = "io.cilium/lb-ipam-ips"
 METALLB_IP_ANNOTATION = "metallb.universe.tf/loadBalancerIPs"
 METALLB_ADDRESS_POOL_ANNOTATION = "metallb.universe.tf/address-pool"
 METALLB_ALLOCATED_POOL_ANNOTATION = "metallb.universe.tf/ip-allocated-from-pool"
+METALLB_INTERNAL_POOL_NAME = "metallb-loadbalancer-ck-loadbalancer"
 
 CREDENTIAL_SUFFIX = "-creds"
 K8S_CLOUD_SUFFIX = "-k8s"
@@ -126,6 +127,11 @@ class K8SHelper:
     def get_loadbalancer_namespace(cls) -> str:
         """Return namespace for loadbalancer."""
         return "metallb-system"
+
+    @classmethod
+    def get_internal_pool_name(cls) -> str:
+        """Return internal pool name."""
+        return METALLB_INTERNAL_POOL_NAME
 
 
 def find_node(client: KubeClient, name: str) -> Node:

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -150,6 +150,7 @@ from sunbeam.steps.k8s import (
     CordonK8SUnitStep,
     DeployK8SApplicationStep,
     DrainK8SUnitStep,
+    EnsureL2AdvertisementByHostStep,
     MigrateK8SKubeconfigStep,
     RemoveK8SUnitsStep,
     StoreK8SKubeConfigStep,
@@ -282,6 +283,14 @@ def get_k8s_plans(
             AddK8SUnitsStep(client, fqdn, jhelper, deployment.openstack_machines_model),
             StoreK8SKubeConfigStep(
                 deployment, client, jhelper, deployment.openstack_machines_model
+            ),
+            EnsureL2AdvertisementByHostStep(
+                deployment,
+                client,
+                jhelper,
+                deployment.openstack_machines_model,
+                Networks.MANAGEMENT,
+                deployment.internal_ip_pool,
             ),
         ]
     )
@@ -1090,6 +1099,16 @@ def join(
             AddK8SUnitsStep(client, name, jhelper, deployment.openstack_machines_model)
         )
         plan4.append(AddK8SCredentialStep(deployment, jhelper))
+        plan4.append(
+            EnsureL2AdvertisementByHostStep(
+                deployment,
+                client,
+                jhelper,
+                deployment.openstack_machines_model,
+                Networks.MANAGEMENT,
+                deployment.internal_ip_pool,
+            ),
+        )
 
     openstack_tfhelper = deployment.get_tfhelper("openstack-plan")
     plan4.append(TerraformInitStep(openstack_tfhelper))
@@ -1301,6 +1320,14 @@ def remove(ctx: click.Context, name: str, force: bool, show_hints: bool) -> None
         CordonK8SUnitStep(client, name, jhelper, deployment.openstack_machines_model),
         DrainK8SUnitStep(client, name, jhelper, deployment.openstack_machines_model),
         RemoveK8SUnitsStep(client, name, jhelper, deployment.openstack_machines_model),
+        EnsureL2AdvertisementByHostStep(
+            deployment,
+            client,
+            jhelper,
+            deployment.openstack_machines_model,
+            Networks.MANAGEMENT,
+            deployment.internal_ip_pool,
+        ),
         RemoveSunbeamMachineUnitsStep(
             client, name, jhelper, deployment.openstack_machines_model
         ),

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -44,6 +44,7 @@ from sunbeam.core.juju import (
     JujuAccountNotFound,
     JujuController,
 )
+from sunbeam.core.k8s import K8SHelper
 from sunbeam.core.questions import QuestionBank, load_answers, show_questions
 from sunbeam.provider.local.steps import local_hypervisor_questions
 from sunbeam.steps.clusterd import (
@@ -324,3 +325,8 @@ class LocalDeployment(Deployment):
         Local deployment only supports management space as of now.
         """
         return "management"
+
+    @property
+    def internal_ip_pool(self) -> str:
+        """Name of the internal IP pool."""
+        return K8SHelper().get_internal_pool_name()

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -27,6 +27,7 @@ from sunbeam.commands.configure import (
 )
 from sunbeam.commands.proxy import proxy_questions
 from sunbeam.core.deployment import PROXY_CONFIG_KEY, Deployment, Networks
+from sunbeam.core.k8s import K8SHelper
 from sunbeam.core.questions import Question, QuestionBank, load_answers, show_questions
 from sunbeam.steps.openstack import (
     REGION_CONFIG_KEY,
@@ -305,6 +306,16 @@ class MaasDeployment(Deployment):
         if space is None:
             raise ValueError(f"Space for network {network.value} not set.")
         return space
+
+    @property
+    def internal_ip_pool(self) -> str:
+        """Name of the internal IP pool."""
+        return K8SHelper().get_internal_pool_name()
+
+    @property
+    def public_ip_pool(self) -> str:
+        """Name of the public IP pool."""
+        return self.public_api_label
 
 
 def is_maas_deployment(deployment: Deployment) -> TypeGuard[MaasDeployment]:

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -1842,19 +1842,6 @@ class MaasDeployK8SApplicationStep(k8s.DeployK8SApplicationStep):
         """Return loadbalancer range from public space."""
         return self.ranges
 
-    def _get_loadbalancer_l2_interfaces(self) -> str | None:
-        """Return l2 interfaces to use for loadbalancer.
-
-        For maas mode, the interfaces are corresponding to infra,
-        internal and public spaces on any one of control nodes.
-        """
-        management_space = self.deployment.get_space(Networks.MANAGEMENT)
-        return maas_client.get_ifname_from_space(
-            self.maas_client,
-            management_space,
-            tags=maas_deployment.RoleTags.CONTROL.value,
-        )
-
     def is_skip(self, status: Status | None = None):
         """Determines if the step should be skipped or not."""
         public_space = self.deployment.get_space(Networks.PUBLIC)
@@ -2185,4 +2172,4 @@ class MaasCreateLoadBalancerIPPoolsStep(CreateLoadBalancerIPPoolsStep):
             public_ranges, self.deployment.public_api_label
         )
 
-        return {self.deployment.public_api_label: public_metallb_range}
+        return {self.deployment.public_ip_pool: public_metallb_range}

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -17,6 +17,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from lightkube import ApiError
 
 from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.core.common import ResultType
@@ -30,6 +31,7 @@ from sunbeam.steps.k8s import (
     K8S_CLOUD_SUFFIX,
     AddK8SCloudStep,
     AddK8SCredentialStep,
+    EnsureL2AdvertisementByHostStep,
     StoreK8SKubeConfigStep,
 )
 
@@ -195,6 +197,12 @@ users:
         }
         self.jhelper.run_action.return_value = action_result
         self.jhelper.get_leader_unit_machine.return_value = "0"
+        self.jhelper.get_machine_interfaces.return_value = {
+            "enp0s8": {
+                "ip-addresses": ["127.0.0.1"],
+                "space": "management",
+            }
+        }
 
         step = StoreK8SKubeConfigStep(
             self.deployment, self.client, self.jhelper, "test-model"
@@ -237,7 +245,12 @@ users:
         self.jhelper.run_action.side_effect = ActionFailedException("Action failed...")
         self.jhelper.get_leader_unit.return_value = "k8s/0"
         self.jhelper.get_leader_unit_machine.return_value = "0"
-
+        self.jhelper.get_machine_interfaces.return_value = {
+            "enp0s8": {
+                "ip-addresses": ["127.0.0.1"],
+                "space": "management",
+            }
+        }
         step = StoreK8SKubeConfigStep(
             self.deployment, self.client, self.jhelper, "test-model"
         )
@@ -247,3 +260,273 @@ users:
         self.jhelper.run_action.assert_called_once()
         assert result.result_type == ResultType.FAILED
         assert result.message == "Action failed..."
+
+
+class TestEnsureL2AdvertisementByHostStep(unittest.TestCase):
+    def __init__(self, methodName: str = "runTest") -> None:
+        super().__init__(methodName)
+
+    def setUp(self):
+        self.deployment = Mock()
+        self.control_nodes = [
+            {"name": "node1", "machineid": "1"},
+            {"name": "node2", "machineid": "2"},
+        ]
+        self.client = Mock(
+            cluster=Mock(
+                list_nodes_by_role=Mock(return_value=self.control_nodes),
+                get_config=Mock(return_value="{}"),
+            )
+        )
+        self.jhelper = AsyncMock()
+        self.model = "test-model"
+        self.network = Mock()
+        self.pool = "test-pool"
+        self.step = EnsureL2AdvertisementByHostStep(
+            self.deployment,
+            self.client,
+            self.jhelper,
+            self.model,
+            self.network,
+            self.pool,
+        )
+        self.step.kube = Mock()
+        self.step.kubeconfig = Mock()
+
+        self.kubeconfig_mocker = patch(
+            "sunbeam.steps.k8s.KubeConfig",
+            Mock(from_dict=Mock(return_value=self.step.kubeconfig)),
+        )
+        self.kubeconfig_mocker.start()
+        self.kube_mocker = patch(
+            "sunbeam.steps.k8s.KubeClient",
+            Mock(return_value=Mock(return_value=self.step.kube)),
+        )
+        self.kube_mocker.start()
+
+    def test_is_skip_no_outdated_or_deleted(self):
+        self.step._get_outdated_l2_advertisement = Mock(return_value=([], []))
+        result = self.step.is_skip()
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_is_skip_with_outdated(self):
+        self.step._get_outdated_l2_advertisement = Mock(return_value=(["node1"], []))
+        result = self.step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+        assert len(self.step.to_update) == 1
+
+    def test_is_skip_with_deleted(self):
+        self.step._get_outdated_l2_advertisement = Mock(return_value=([], ["node2"]))
+        result = self.step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+        assert len(self.step.to_delete) == 1
+
+    def test_run_update_and_delete(self):
+        self.step.to_update = [{"name": "node1", "machineid": "1"}]
+        self.step.to_delete = [{"name": "node2", "machineid": "2"}]
+        self.step._get_interface = Mock(return_value="eth0")
+        self.step.kube.apply = Mock()
+        self.step.kube.delete = Mock()
+
+        result = self.step.run(None)
+
+        self.step.kube.apply.assert_called_once()
+        self.step.kube.delete.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_update_failure(self):
+        self.step.to_update = [{"name": "node1", "machineid": "1"}]
+        self.step.to_delete = []
+        self.step._get_interface = Mock(return_value="eth0")
+        api_error = ApiError.__new__(ApiError)
+        api_error.status = Mock(code=500)
+        self.step.kube.apply = Mock(side_effect=api_error)
+
+        result = self.step.run(None)
+
+        self.step.kube.apply.assert_called_once()
+        assert result.result_type == ResultType.FAILED
+
+    def test_run_delete_failure(self):
+        self.step.to_update = []
+        self.step.to_delete = [{"name": "node2", "machineid": "2"}]
+        api_error = ApiError.__new__(ApiError)
+        api_error.status = Mock(code=500)
+        self.step.kube.delete = Mock(side_effect=api_error)
+
+        result = self.step.run(None)
+
+        self.step.kube.delete.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_get_interface_cached(self):
+        self.step._ifnames = {"node1": "eth0"}
+        result = self.step._get_interface({"name": "node1"}, self.network)
+        assert result == "eth0"
+
+    def test_get_interface_found(self):
+        self.jhelper.get_machine_interfaces.return_value = {
+            "eth0": {"space": "management"},
+            "eth1": {"space": "other-space"},
+        }
+        self.deployment.get_space.return_value = "management"
+        result = self.step._get_interface(
+            {"name": "node1", "machineid": "1"}, self.network
+        )
+        assert result == "eth0"
+        assert self.step._ifnames["node1"] == "eth0"
+
+    def test_get_interface_not_found(self):
+        self.jhelper.get_machine_interfaces.return_value = {
+            "eth0": {"space": "other-space"},
+            "eth1": {"space": "another-space"},
+        }
+        self.deployment.get_space.return_value = "management"
+        with self.assertRaises(EnsureL2AdvertisementByHostStep._L2AdvertisementError):
+            self.step._get_interface({"name": "node1", "machineid": "1"}, self.network)
+
+
+def _to_kube_object(metadata: dict, spec: dict | None) -> object:
+    """Convert a dictionary to a mock object."""
+    obj = Mock()
+    obj.metadata = Mock(**metadata)
+    obj.spec = spec
+    return obj
+
+
+_l2_outdated_testcases = {
+    "1-node-no-l2": ([{"name": "node1", "interface": "eth0"}], [], ["node1"], []),
+    "1-node-matching-l2": (
+        [{"name": "node1", "interface": "eth0"}],
+        [
+            _to_kube_object(
+                metadata={"labels": {"sunbeam/hostname": "node1"}},
+                spec={"ipAddressPools": ["test-pool"], "interfaces": ["eth0"]},
+            )
+        ],
+        [],
+        [],
+    ),
+    "1-node-wrong-pool-l2": (
+        [{"name": "node1", "interface": "eth0"}],
+        [
+            _to_kube_object(
+                metadata={"labels": {"sunbeam/hostname": "node1"}},
+                spec={"ipAddressPools": ["my-pool"], "interfaces": ["eth0"]},
+            )
+        ],
+        ["node1"],
+        [],
+    ),
+    "1-node-wrong-interface-l2": (
+        [{"name": "node1", "interface": "eth0"}],
+        [
+            _to_kube_object(
+                metadata={"labels": {"sunbeam/hostname": "node1"}},
+                spec={"ipAddressPools": ["test-pool"], "interfaces": ["eth1"]},
+            )
+        ],
+        ["node1"],
+        [],
+    ),
+    "0-node-l2-advertisement": (
+        [],
+        [
+            _to_kube_object(
+                metadata={"labels": {"sunbeam/hostname": "node1"}},
+                spec={"ipAddressPools": ["test-pool"], "interfaces": ["eth0"]},
+            )
+        ],
+        [],
+        ["node1"],
+    ),
+    "2-nodes-1-missing-l2-1-outdated-l2-1-l2-to-delete": (
+        [
+            {"name": "node2", "interface": "2"},
+            {"name": "node3", "interface": "3"},
+        ],
+        [
+            _to_kube_object(
+                metadata={"labels": {"sunbeam/hostname": "node1"}},
+                spec={"ipAddressPools": ["test-pool"], "interfaces": ["eth0"]},
+            ),
+            _to_kube_object(
+                metadata={"labels": {"sunbeam/hostname": "node2"}},
+                spec={"ipAddressPools": ["my-pool"], "interfaces": ["eth1"]},
+            ),
+        ],
+        ["node2", "node3"],
+        ["node1"],
+    ),
+    "missing-metadata": (
+        [{"name": "node1", "interface": "eth0"}],
+        [Mock(metadata=None)],
+        ["node1"],
+        [],
+    ),
+    "missing-labels": (
+        [{"name": "node1", "interface": "eth0"}],
+        [
+            _to_kube_object(
+                metadata={"labels": None},
+                spec={"ipAddressPools": ["test-pool"], "interfaces": ["eth0"]},
+            )
+        ],
+        ["node1"],
+        [],
+    ),
+    "missing-hostname-in-labels": (
+        [{"name": "node1", "interface": "eth0"}],
+        [
+            _to_kube_object(
+                metadata={"labels": {}},
+                spec={"ipAddressPools": ["test-pool"], "interfaces": ["eth0"]},
+            )
+        ],
+        ["node1"],
+        [],
+    ),
+    "missing-spec": (
+        [{"name": "node1", "interface": "eth0"}],
+        [
+            _to_kube_object(
+                metadata={"labels": {"sunbeam/hostname": "node1"}},
+                spec=None,
+            )
+        ],
+        ["node1"],
+        [],
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "nodes,list,outdated,deleted",
+    _l2_outdated_testcases.values(),
+    ids=_l2_outdated_testcases.keys(),
+)
+def test_get_outdated_l2_advertisement(
+    nodes: list[dict], list: list[object], outdated: list[str], deleted: list[str]
+):
+    kube = Mock(list=Mock(return_value=list))
+    step = EnsureL2AdvertisementByHostStep(
+        Mock(),
+        Mock(),
+        Mock(),
+        "test-model",
+        Mock(),
+        "test-pool",
+    )
+
+    def _get_interface(node, network):
+        for node_it in nodes:
+            if node_it["name"] == node["name"]:
+                return node_it["interface"]
+        raise EnsureL2AdvertisementByHostStep._L2AdvertisementError()
+
+    step._get_interface = Mock(side_effect=_get_interface)
+
+    outdated_res, deleted_res = step._get_outdated_l2_advertisement(nodes, kube)
+
+    assert outdated_res == outdated
+    assert deleted_res == deleted


### PR DESCRIPTION
Create an L2Advertisement resource per host that will reference the correct interface bound to given space.

Closes-Bug: 2104880


Example on a MAAS deployment:
```
kubectl get -n metallb-system L2advertisements
NAME                                        IPADDRESSPOOLS                             IPADDRESSPOOL SELECTORS   INTERFACES
internal-stg-reproducer-gboutry-compute-0   ["metallb-loadbalancer-ck-loadbalancer"]                             ["ens8"]
internal-stg-reproducer-gboutry-compute-1   ["metallb-loadbalancer-ck-loadbalancer"]                             ["ens5"]
internal-stg-reproducer-gboutry-compute-2   ["metallb-loadbalancer-ck-loadbalancer"]                             ["ens8"]
metallb-loadbalancer-ck-loadbalancer        ["metallb-loadbalancer-ck-loadbalancer"]                             
public-stg-reproducer-gboutry-compute-0     ["ps6-public-api"]                                                   ["ens3"]
public-stg-reproducer-gboutry-compute-1     ["ps6-public-api"]                                                   ["ens3"]
public-stg-reproducer-gboutry-compute-2     ["ps6-public-api"]                                                   ["ens3"]
```
```yaml
# kubectl get -n metallb-system L2advertisements -o yaml | yq '.items[] | {.metadata.name: .spec}'
internal-stg-reproducer-gboutry-compute-0:
  interfaces:
    - ens8
  ipAddressPools:
    - metallb-loadbalancer-ck-loadbalancer
  nodeSelectors:
    - matchLabels:
        kubernetes.io/hostname: stg-reproducer-gboutry-compute-0
internal-stg-reproducer-gboutry-compute-1:
  interfaces:
    - ens5
  ipAddressPools:
    - metallb-loadbalancer-ck-loadbalancer
  nodeSelectors:
    - matchLabels:
        kubernetes.io/hostname: stg-reproducer-gboutry-compute-1
internal-stg-reproducer-gboutry-compute-2:
  interfaces:
    - ens8
  ipAddressPools:
    - metallb-loadbalancer-ck-loadbalancer
  nodeSelectors:
    - matchLabels:
        kubernetes.io/hostname: stg-reproducer-gboutry-compute-2
metallb-loadbalancer-ck-loadbalancer:
  ipAddressPools:
    - metallb-loadbalancer-ck-loadbalancer
public-stg-reproducer-gboutry-compute-0:
  interfaces:
    - ens3
  ipAddressPools:
    - ps6-public-api
  nodeSelectors:
    - matchLabels:
        kubernetes.io/hostname: stg-reproducer-gboutry-compute-0
public-stg-reproducer-gboutry-compute-1:
  interfaces:
    - ens3
  ipAddressPools:
    - ps6-public-api
  nodeSelectors:
    - matchLabels:
        kubernetes.io/hostname: stg-reproducer-gboutry-compute-1
public-stg-reproducer-gboutry-compute-2:
  interfaces:
    - ens3
  ipAddressPools:
    - ps6-public-api
  nodeSelectors:
    - matchLabels:
        kubernetes.io/hostname: stg-reproducer-gboutry-compute-2
```