### PR TITLE
Configure proxy more aggressively

### DIFF
--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -70,6 +70,11 @@ EOF
     exit 1
 fi
 
+if grep -E -q 'HTTPS?_PROXY=' /etc/environment; then
+    echo "Loading in current shell environment variables from /etc/environment"
+    source /etc/environment
+fi
+
 # Ensure the localhost IPs are present in the no_proxy list
 # both on disk and in the environment
 if grep -E -q "NO_PROXY=" /etc/environment; then

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -80,7 +80,12 @@ fi
 if grep -E -q "NO_PROXY=" /etc/environment; then
     echo "Ensuring all localhost IPs are in the no_proxy list"
     for ip in $(hostname -I); do
-        export NO_PROXY="$NO_PROXY,$ip"
+        if [ -z "$NO_PROXY" ]; then
+            echo "NO_PROXY is not set in current shell"
+            export NO_PROXY="$ip"
+        else
+            export NO_PROXY="$NO_PROXY,$ip"
+        fi
         grep -E -q "NO_PROXY=.*$ip.*" /etc/environment \
             || sudo sed -E -i "s|^NO_PROXY=(.*)|NO_PROXY=\\1,$ip|" \
                     /etc/environment

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -168,10 +168,13 @@ profiles:
       type: disk
   name: default
 EOF
-    # Add the LXD bridge to the no_proxy list while we don't know the container final IP
-    cidr=$(sudo --user $USER lxc network list --format compact | grep sunbeambr0 | col4)
-    export NO_PROXY="$NO_PROXY,$cidr"
 fi
+
+# Add the LXD bridges to the no_proxy list while we don't know the container final IP
+cidr=$(sudo --user $USER lxc network list --format compact | grep YES | col4 | \
+    tr '\\n' ',')
+export NO_PROXY="$(echo $NO_PROXY,$cidr | sed -e 's|^,||' -e 's|,$||')"
+
 # Bootstrap juju onto LXD
 echo 'Bootstrapping Juju onto LXD'
 sudo --user $USER juju show-controller 2>/dev/null

--- a/sunbeam-python/sunbeam/commands/prepare_node.py
+++ b/sunbeam-python/sunbeam/commands/prepare_node.py
@@ -172,10 +172,12 @@ profiles:
 EOF
 fi
 
-# Add the LXD bridges to the no_proxy list while we don't know the container final IP
-cidr=$(sudo --user $USER lxc network list --format compact | grep YES | col4 | \
-    tr '\\n' ',')
-export NO_PROXY="$(echo $NO_PROXY,$cidr | sed -e 's|^,||' -e 's|,$||')"
+# Add the LXD bridges to the no_proxy list while we don't know the container IP
+if grep -E -q 'HTTPS?_PROXY=' /etc/environment; then
+    cidr=$(sudo --user $USER lxc network list --format compact | grep YES | col4 | \
+        tr '\\n' ',')
+    export NO_PROXY="$(echo $NO_PROXY,$cidr | sed -e 's|^,||' -e 's|,$||')"
+fi
 
 # Bootstrap juju onto LXD
 echo 'Bootstrapping Juju onto LXD'

--- a/sunbeam-python/sunbeam/core/proxy.py
+++ b/sunbeam-python/sunbeam/core/proxy.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ipaddress
+import logging
+import os
+import typing
+from collections.abc import Iterable
+
+LOG = logging.getLogger(__name__)
+
+
+def patch_process_env(proxies: dict[str, str]) -> None:
+    """Patch current env with proxies.
+
+    This function will patch the current process environment
+    variables with the given proxies if any proxy is set.
+    """
+    if not proxies:
+        return
+    db_http_proxy = proxies.get("HTTP_PROXY")
+    db_https_proxy = proxies.get("HTTPS_PROXY")
+    db_no_proxy = proxies.get("NO_PROXY", "").strip()
+    if db_http_proxy is None and db_https_proxy is None:
+        LOG.debug("Proxy provided but no http(s)_proxy found")
+        return
+
+    if db_https_proxy is None:
+        db_https_proxy = db_http_proxy
+    if db_http_proxy is None:
+        db_http_proxy = db_https_proxy
+
+    db_http_proxy = typing.cast(str, db_http_proxy).strip()
+    db_https_proxy = typing.cast(str, db_https_proxy).strip()
+
+    new_env = {}
+
+    new_env["http_proxy"] = db_http_proxy
+    new_env["https_proxy"] = db_https_proxy
+    new_env["HTTP_PROXY"] = db_http_proxy
+    new_env["HTTPS_PROXY"] = db_https_proxy
+    new_env["no_proxy"] = db_no_proxy
+    new_env["NO_PROXY"] = db_no_proxy
+    LOG.debug("Patching process env with proxy settings")
+    os.environ.update(new_env)
+
+
+def should_bypass(no_proxies: Iterable[str], endpoint: str) -> bool:
+    """Check if the endpoint should be bypassed.
+
+    This function will check if the endpoint is in the no_proxy
+    list. If no_proxy is empty, it will return False.
+    """
+    if not no_proxies:
+        return False
+
+    host = endpoint.rsplit(":", 1)[0]
+    host_ip = None
+
+    try:
+        host_ip = ipaddress.ip_address(host)
+    except ValueError:
+        # Not an IP address, continue
+        pass
+    for no_proxy in no_proxies:
+        if (
+            endpoint == no_proxy
+            or (no_proxy.startswith("*") and endpoint.endswith(no_proxy[1:]))
+            or (no_proxy.startswith(".") and endpoint.endswith(no_proxy))
+        ):
+            return True
+        if host_ip:
+            try:
+                no_proxy_net = ipaddress.ip_network(no_proxy, strict=False)
+                if host_ip in no_proxy_net:
+                    return True
+            except ValueError:
+                # Not an IP address, continue
+                pass
+    return False

--- a/sunbeam-python/tests/unit/sunbeam/core/test_proxy.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_proxy.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from sunbeam.core.proxy import patch_process_env, should_bypass
+
+
+def test_patch_process_env_no_proxies():
+    """Test patch_process_env with no proxies provided."""
+    with patch.dict(os.environ, {}, clear=True):
+        patch_process_env({})
+        assert os.environ == {}
+
+
+def test_patch_process_env_with_proxies():
+    """Test patch_process_env with valid proxies."""
+    proxies = {
+        "HTTP_PROXY": "http://proxy.example.com:8080",
+        "HTTPS_PROXY": "https://proxy.example.com:8443",
+        "NO_PROXY": "localhost,127.0.0.1",
+    }
+    with patch.dict(os.environ, {}, clear=True):
+        patch_process_env(proxies)
+        assert os.environ["http_proxy"] == "http://proxy.example.com:8080"
+        assert os.environ["https_proxy"] == "https://proxy.example.com:8443"
+        assert os.environ["HTTP_PROXY"] == "http://proxy.example.com:8080"
+        assert os.environ["HTTPS_PROXY"] == "https://proxy.example.com:8443"
+        assert os.environ["no_proxy"] == "localhost,127.0.0.1"
+        assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
+
+
+def test_patch_process_env_missing_https_proxy():
+    """Test patch_process_env when HTTPS_PROXY is missing."""
+    proxies = {
+        "HTTP_PROXY": "http://proxy.example.com:8080",
+        "NO_PROXY": "localhost,127.0.0.1",
+    }
+    with patch.dict(os.environ, {}, clear=True):
+        patch_process_env(proxies)
+        assert os.environ["http_proxy"] == "http://proxy.example.com:8080"
+        assert os.environ["https_proxy"] == "http://proxy.example.com:8080"
+        assert os.environ["HTTP_PROXY"] == "http://proxy.example.com:8080"
+        assert os.environ["HTTPS_PROXY"] == "http://proxy.example.com:8080"
+        assert os.environ["no_proxy"] == "localhost,127.0.0.1"
+        assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
+
+
+def test_patch_process_env_missing_http_proxy():
+    """Test patch_process_env when HTTP_PROXY is missing."""
+    proxies = {
+        "HTTPS_PROXY": "https://proxy.example.com:8443",
+        "NO_PROXY": "localhost,127.0.0.1",
+    }
+    with patch.dict(os.environ, {}, clear=True):
+        patch_process_env(proxies)
+        assert os.environ["http_proxy"] == "https://proxy.example.com:8443"
+        assert os.environ["https_proxy"] == "https://proxy.example.com:8443"
+        assert os.environ["HTTP_PROXY"] == "https://proxy.example.com:8443"
+        assert os.environ["HTTPS_PROXY"] == "https://proxy.example.com:8443"
+        assert os.environ["no_proxy"] == "localhost,127.0.0.1"
+        assert os.environ["NO_PROXY"] == "localhost,127.0.0.1"
+
+
+def test_patch_process_env_no_http_or_https_proxy():
+    """Test patch_process_env when neither HTTP_PROXY nor HTTPS_PROXY is provided."""
+    proxies = {"NO_PROXY": "localhost,127.0.0.1"}
+    with patch.dict(os.environ, {}, clear=True):
+        patch_process_env(proxies)
+        assert os.environ == {}
+
+
+@pytest.mark.parametrize(
+    "no_proxies,endpoint,expected",
+    [
+        ([], "example.com", False),  # No proxies, should not bypass
+        (["example.com"], "example.com", True),  # Exact match
+        (["*.example.com"], "sub.example.com", True),  # Wildcard match
+        (["192.168.1.0/24"], "192.168.1.5", True),  # IP in subnet
+        (["192.168.1.0/24"], "192.168.2.5", False),  # IP not in subnet
+        (["example.com"], "other.com", False),  # No match
+        (["*.example.com"], "example.com", False),  # Wildcard no match
+        (["192.168.1.0/24"], "not-an-ip", False),  # Invalid IP
+        (["*example.com"], "myexample.com", True),  # Ends with match
+        (["*example.com"], "example.com", True),  # Ends with match exact
+        ([".example.com"], "sub.example.com", True),  # Allow all subdomains
+        ([".example.com"], "example.com", False),  # Only subdomains allowed
+        (["example.com"], "192.168.1.5", False),  # IP not in no_proxy
+    ],
+)
+def test_should_bypass(no_proxies, endpoint, expected):
+    assert should_bypass(no_proxies, endpoint) == expected


### PR DESCRIPTION
Ensure during prepare-node-script current host is part of no_proxy, also, lxd network is temporarily added to no_proxy to allow reaching the controller during the bootstrap command. Once the bootstrap command succeeds, add LXD controller to /etc/environment.

When fetching a connected controller, on proxy failure, try to add juju controller endpoints to process environment if it should actually bypass the proxy.