### PR TITLE
Switch to 1/stable self-signed-certificates

### DIFF
--- a/sunbeam-python/sunbeam/steps/certificates.py
+++ b/sunbeam-python/sunbeam/steps/certificates.py
@@ -16,7 +16,7 @@ from sunbeam.versions import JUJU_BASE
 
 LOG = logging.getLogger(__name__)
 APPLICATION = "tls-operator"
-CHARM = "sunbeam-ssc"
+CHARM = "self-signed-certificates"
 CERTIFICATES_APP_TIMEOUT = 1200
 
 

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -14,8 +14,7 @@ SUNBEAM_MACHINE_CHANNEL = "2024.1/stable"
 SUNBEAM_CLUSTERD_CHANNEL = "2024.1/stable"
 SNAP_SUNBEAM_CLUSTERD_CHANNEL = "2024.1/stable"
 MYSQL_CHANNEL = "8.0/stable"
-CERT_AUTH_CHANNEL = "latest/beta"
-SUNBEAM_SSC_CHANNEL = "latest/beta"
+CERT_AUTH_CHANNEL = "1/stable"
 BIND_CHANNEL = "9/stable"
 VAULT_CHANNEL = "1.16/stable"
 CONSUL_CHANNEL = "1.19/edge"
@@ -52,7 +51,7 @@ MACHINE_CHARMS = {
     "openstack-hypervisor": OPENSTACK_CHANNEL,
     "sunbeam-machine": SUNBEAM_MACHINE_CHANNEL,
     "sunbeam-clusterd": SUNBEAM_CLUSTERD_CHANNEL,
-    "sunbeam-ssc": SUNBEAM_SSC_CHANNEL,
+    "self-signed-certificates": CERT_AUTH_CHANNEL,
     "cinder-volume": OPENSTACK_CHANNEL,
     "cinder-volume-ceph": OPENSTACK_CHANNEL,
 }


### PR DESCRIPTION
Switch from sunbeam-ssc to self-signed-certificates stable version in MAAS deployments.