### PR TITLE
Mute default L2Advertisement

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -138,6 +138,7 @@ from sunbeam.steps.k8s import (
     CordonK8SUnitStep,
     DeployK8SApplicationStep,
     DrainK8SUnitStep,
+    EnsureDefaultL2AdvertisementMutedStep,
     EnsureL2AdvertisementByHostStep,
     MigrateK8SKubeconfigStep,
     RemoveK8SUnitsStep,
@@ -272,6 +273,7 @@ def get_k8s_plans(
             StoreK8SKubeConfigStep(
                 deployment, client, jhelper, deployment.openstack_machines_model
             ),
+            EnsureDefaultL2AdvertisementMutedStep(deployment, client, jhelper),
             EnsureL2AdvertisementByHostStep(
                 deployment,
                 client,
@@ -1086,7 +1088,7 @@ def join(
         plan4.append(
             AddK8SUnitsStep(client, name, jhelper, deployment.openstack_machines_model)
         )
-        plan4.append(AddK8SCredentialStep(deployment, jhelper))
+        plan4.append(EnsureDefaultL2AdvertisementMutedStep(deployment, client, jhelper))
         plan4.append(
             EnsureL2AdvertisementByHostStep(
                 deployment,
@@ -1097,6 +1099,7 @@ def join(
                 deployment.internal_ip_pool,
             ),
         )
+        plan4.append(AddK8SCredentialStep(deployment, jhelper))
 
     openstack_tfhelper = deployment.get_tfhelper("openstack-plan")
     plan4.append(TerraformInitStep(openstack_tfhelper))

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -151,6 +151,7 @@ from sunbeam.steps.k8s import (
     CordonK8SUnitStep,
     DestroyK8SApplicationStep,
     DrainK8SUnitStep,
+    EnsureDefaultL2AdvertisementMutedStep,
     EnsureL2AdvertisementByHostStep,
     MigrateK8SKubeconfigStep,
     RemoveK8SUnitsStep,
@@ -660,6 +661,7 @@ def deploy(
             deployment, client, jhelper, deployment.openstack_machines_model
         )
     )
+    plan2.append(EnsureDefaultL2AdvertisementMutedStep(deployment, client, jhelper))
     plan2.append(MaasCreateLoadBalancerIPPoolsStep(deployment, client, maas_client))
     plan2.append(
         EnsureL2AdvertisementByHostStep(


### PR DESCRIPTION
Default L2 advertisement can cause issues when joining a new unit as there's a window where there's no l2 targeting the new node, therefore, metallb will broadcast arp on all interfaces of the new node.