### PR TITLE
Bump timeout on k8s add unit

### DIFF
--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -92,7 +92,7 @@ K8S_ADDONS_CONFIG_KEY = "TerraformVarsK8SAddons"
 APPLICATION = "k8s"
 K8S_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
 K8S_DESTROY_TIMEOUT = 900
-K8S_UNIT_TIMEOUT = 1200  # 20 minutes, adding / removing units can take a long time
+K8S_UNIT_TIMEOUT = 1800  # 30 minutes, adding / removing units can take a long time
 K8S_ENABLE_ADDONS_TIMEOUT = 180  # 3 minutes
 K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
 


### PR DESCRIPTION
When joining multiple k8s units at the same, it can take longer for individual units to become ready.