### PR TITLE
Retry terraform apply if remote state is locked

### DIFF
--- a/sunbeam-python/sunbeam/core/common.py
+++ b/sunbeam-python/sunbeam/core/common.py
@@ -16,6 +16,7 @@ from click import decorators
 from rich.console import Console
 from rich.status import Status
 from snaphelpers import Snap, UnknownConfigKey
+from tenacity import RetryCallState
 
 from sunbeam.clusterd.client import Client
 
@@ -543,3 +544,10 @@ def validate_ip_range(ip_range: str):
         ipaddress.ip_address(ips[1])
     else:
         raise ValueError("Invalid IP range, must be in the form of 'ip-ip'")
+
+
+def convert_retry_failure_as_result(retry_state: RetryCallState) -> Result:
+    if retry_state.outcome is not None:
+        return Result(ResultType.FAILED, str(retry_state.outcome.exception()))
+    else:
+        return Result(ResultType.FAILED)

--- a/sunbeam-python/sunbeam/core/terraform.py
+++ b/sunbeam-python/sunbeam/core/terraform.py
@@ -56,6 +56,18 @@ class TerraformException(Exception):
         return self.message
 
 
+class TerraformStateLockedException(Exception):
+    """Terraform Remote State Locked Exception."""
+
+    def __init__(self, message):
+        super().__init__()
+        self.message = message
+
+    def __str__(self) -> str:
+        """Stringify the exception."""
+        return self.message
+
+
 class TerraformHelper:
     """Helper for interaction with Terraform."""
 
@@ -207,7 +219,10 @@ class TerraformHelper:
         except subprocess.CalledProcessError as e:
             LOG.error(f"terraform apply failed: {e.output}")
             LOG.warning(e.stderr)
-            raise TerraformException(str(e))
+            if "remote state already locked" in e.stderr:
+                raise TerraformStateLockedException(str(e))
+            else:
+                raise TerraformException(str(e))
 
     def destroy(self):
         """Terraform destroy."""

--- a/sunbeam-python/sunbeam/features/caas/feature.py
+++ b/sunbeam-python/sunbeam/features/caas/feature.py
@@ -27,6 +27,7 @@ from sunbeam.core.terraform import (
     TerraformException,
     TerraformHelper,
     TerraformInitStep,
+    TerraformStateLockedException,
 )
 from sunbeam.features.interface.v1.base import FeatureRequirement
 from sunbeam.features.interface.v1.openstack import (
@@ -101,7 +102,7 @@ class CaasConfigureStep(BaseStep):
             self.tfhelper.update_tfvars_and_apply_tf(
                 self.client, self.manifest, override_tfvars=override_tfvars
             )
-        except TerraformException as e:
+        except (TerraformException, TerraformStateLockedException) as e:
             LOG.exception("Error configuring Container as a Service feature.")
             return Result(ResultType.FAILED, str(e))
 

--- a/sunbeam-python/sunbeam/features/instance_recovery/consul.py
+++ b/sunbeam-python/sunbeam/features/instance_recovery/consul.py
@@ -36,6 +36,7 @@ from sunbeam.core.manifest import (
 from sunbeam.core.terraform import (
     TerraformException,
     TerraformHelper,
+    TerraformStateLockedException,
 )
 from sunbeam.features.interface.v1.openstack import (
     APPLICATION_DEPLOY_TIMEOUT,
@@ -179,7 +180,7 @@ class DeployConsulClientStep(BaseStep):
                 tfvar_config=self._CONFIG,
                 override_tfvars=extra_tfvars,
             )
-        except TerraformException as e:
+        except (TerraformException, TerraformStateLockedException) as e:
             LOG.exception("Error deploying consul client")
             return Result(ResultType.FAILED, str(e))
 

--- a/sunbeam-python/sunbeam/features/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/openstack.py
@@ -40,6 +40,7 @@ from sunbeam.core.terraform import (
     TerraformException,
     TerraformHelper,
     TerraformInitStep,
+    TerraformStateLockedException,
 )
 from sunbeam.features.interface.v1.base import ConfigType, EnableDisableFeature
 from sunbeam.steps.openstack import (
@@ -411,8 +412,7 @@ class OpenStackControlPlaneFeature(EnableDisableFeature, typing.Generic[ConfigTy
         # care during control plane refresh
         if (
             not upgrade_release
-            or self.tf_plan_location  # noqa W503
-            == TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO  # noqa: W503
+            or self.tf_plan_location == TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO
         ):
             LOG.debug(
                 f"Ignore upgrade_hook for feature {self.name}, the corresponding apps"
@@ -569,7 +569,7 @@ class EnableOpenStackApplicationStep(
                 tfvar_config=config_key,
                 override_tfvars=extra_tfvars,
             )
-        except TerraformException as e:
+        except (TerraformException, TerraformStateLockedException) as e:
             return Result(ResultType.FAILED, str(e))
 
         apps = self.feature.set_application_names(self.deployment)
@@ -668,7 +668,7 @@ class DisableOpenStackApplicationStep(
                     tfvar_config=config_key,
                     override_tfvars=extra_tfvars,
                 )
-        except TerraformException as e:
+        except (TerraformException, TerraformStateLockedException) as e:
             return Result(ResultType.FAILED, str(e))
 
         apps = self.feature.set_application_names(self.deployment)

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -63,6 +63,7 @@ from sunbeam.core.terraform import (
     TerraformException,
     TerraformHelper,
     TerraformInitStep,
+    TerraformStateLockedException,
 )
 from sunbeam.features.interface.v1.base import (
     BaseFeatureGroup,
@@ -146,7 +147,7 @@ class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
                 tfvar_config=self._CONFIG,
                 override_tfvars=extra_tfvars,
             )
-        except TerraformException as e:
+        except (TerraformException, TerraformStateLockedException) as e:
             LOG.exception("Error deploying Observability Stack")
             return Result(ResultType.FAILED, str(e))
 
@@ -216,7 +217,7 @@ class UpdateObservabilityModelConfigStep(BaseStep, JujuStepHelper):
                 override_tfvars=extra_tfvars,
                 tf_apply_extra_args=["-target=juju_model.cos"],
             )
-        except TerraformException as e:
+        except (TerraformException, TerraformStateLockedException) as e:
             LOG.exception("Error updating Observability Model config")
             return Result(ResultType.FAILED, str(e))
 
@@ -268,7 +269,7 @@ class DeployGrafanaAgentStep(BaseStep, JujuStepHelper):
                 tfvar_config=self._CONFIG,
                 override_tfvars=extra_tfvars,
             )
-        except TerraformException as e:
+        except (TerraformException, TerraformStateLockedException) as e:
             LOG.exception("Error deploying grafana agent")
             return Result(ResultType.FAILED, str(e))
 

--- a/sunbeam-python/sunbeam/features/pro/feature.py
+++ b/sunbeam-python/sunbeam/features/pro/feature.py
@@ -28,6 +28,7 @@ from sunbeam.core.terraform import (
     TerraformException,
     TerraformHelper,
     TerraformInitStep,
+    TerraformStateLockedException,
 )
 from sunbeam.features.interface.v1.base import EnableDisableFeature
 from sunbeam.utils import (
@@ -91,7 +92,7 @@ class EnableUbuntuProApplicationStep(BaseStep, JujuStepHelper):
                 tfvar_config=None,
                 override_tfvars=extra_tfvars,
             )
-        except TerraformException as e:
+        except (TerraformException, TerraformStateLockedException) as e:
             return Result(ResultType.FAILED, str(e))
 
         # Note(gboutry): application is in state unknown when it's deployed

--- a/sunbeam-python/sunbeam/features/validation/feature.py
+++ b/sunbeam-python/sunbeam/features/validation/feature.py
@@ -34,6 +34,7 @@ from sunbeam.core.terraform import (
     TerraformException,
     TerraformHelper,
     TerraformInitStep,
+    TerraformStateLockedException,
 )
 from sunbeam.feature_manager import FeatureManager
 from sunbeam.features.interface.v1.openstack import (
@@ -219,8 +220,8 @@ class ConfigureValidationStep(BaseStep):
                 tfvar_config=self.tfvar_config,
                 override_tfvars=override_tfvars,
             )
-        except TerraformException as e:
-            LOG.exception("Error configuring validation featureg.")
+        except (TerraformException, TerraformStateLockedException) as e:
+            LOG.exception("Error configuring validation feature.")
             return Result(ResultType.FAILED, str(e))
 
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/tests/unit/sunbeam/core/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_steps.py
@@ -5,6 +5,7 @@ import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import tenacity
 
 from sunbeam.core.common import ResultType
 from sunbeam.core.juju import ApplicationNotFoundException, TimeoutException
@@ -204,6 +205,7 @@ class TestDeployMachineApplicationStep:
             "app1",
             "model1",
         )
+        step.run.retry.wait = tenacity.wait_none()
         result = step.run()
 
         tfhelper.update_tfvars_and_apply_tf.assert_called()


### PR DESCRIPTION
Running multiple join commands at same time can invoke same terraform plan from multiple nodes at the same time resulting in one of the terraform plan failure as the remote state is locked by other node.

Add retry logic if terraform remote state is locked when terraform is applied.

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2103499