### PR TITLE
local: only configure current node l2 advertisement

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -288,6 +288,7 @@ def get_k8s_plans(
                 deployment.openstack_machines_model,
                 Networks.MANAGEMENT,
                 deployment.internal_ip_pool,
+                fqdn,
             ),
             EnsureDefaultL2AdvertisementMutedStep(deployment, client, jhelper),
         ]
@@ -1114,6 +1115,7 @@ def join(
                 deployment.openstack_machines_model,
                 Networks.MANAGEMENT,
                 deployment.internal_ip_pool,
+                name,
             ),
         )
         plan4.append(AddK8SCredentialStep(deployment, jhelper))


### PR DESCRIPTION
Configuring multiple nodes' L2 advertisement can fail when it happens while another control is getting added to Juju. Its id will be -1 until properly added to Juju.