### PR TITLE
Return a list of enabled plugins instead of name

### DIFF
--- a/sunbeam-python/sunbeam/feature_manager.py
+++ b/sunbeam-python/sunbeam/feature_manager.py
@@ -81,7 +81,7 @@ class FeatureManager:
         """Return a list of feature classes."""
         return list(all_features().values())
 
-    def enabled_features(self, deployment: Deployment) -> list:
+    def enabled_features(self, deployment: Deployment) -> list[EnableDisableFeature]:
         """Returns feature names that are enabled.
 
         :param deployment: Deployment instance.
@@ -92,9 +92,9 @@ class FeatureManager:
             if isinstance(feature, EnableDisableFeature) and feature.is_enabled(
                 deployment.get_client()
             ):
-                enabled_features.append(name)
+                enabled_features.append(feature)
 
-        LOG.debug(f"Enabled features: {enabled_features}")
+        LOG.debug("Enabled features: %s", ",".join(f.name for f in enabled_features))
         return enabled_features
 
     def get_all_feature_manifests(

--- a/sunbeam-python/sunbeam/features/validation/feature.py
+++ b/sunbeam-python/sunbeam/features/validation/feature.py
@@ -417,9 +417,12 @@ class ValidationFeature(OpenStackControlPlaneFeature):
     def _configure_preflight_check(self, deployment: Deployment) -> bool:
         """Preflight check for configure command."""
         enabled_features = FeatureManager().enabled_features(deployment)
-        if "observability" not in enabled_features:
-            return False
-        return True
+        for feature in enabled_features:
+            if (
+                group := getattr(feature, "group", None)
+            ) and group.name == "observability":
+                return True
+        return False
 
     @click.command()
     @click_option_show_hints

--- a/sunbeam-python/sunbeam/steps/features.py
+++ b/sunbeam-python/sunbeam/steps/features.py
@@ -73,6 +73,6 @@ class DisableEnabledFeatures(BaseStep):
             except SunbeamException as e:
                 return Result(
                     ResultType.FAILED,
-                    f"Failed to disable feature {feature}: {e}",
+                    f"Failed to disable feature {feature.name}: {e}",
                 )
         return Result(ResultType.COMPLETED, "Features disabled")


### PR DESCRIPTION
The enabled_plugins method returned a list of names instead of an instance of the plugin.