### PR TITLE
Make external-network shared to be visible to Tempest

### DIFF
--- a/cloud/etc/demo-setup/main.tf
+++ b/cloud/etc/demo-setup/main.tf
@@ -73,6 +73,7 @@ resource "openstack_networking_network_v2" "external_network" {
   name           = "external-network"
   admin_state_up = true
   external       = true
+  shared         = true
   segments {
     physical_network = var.external_network.physical_network
     network_type     = var.external_network.network_type


### PR DESCRIPTION
Previously, `sunbeam validation run smoke` would fail network tests due to Tempest auto-config not discovering Sunbeam external-network and missing the [network] stanza in tempest.conf. Marking external-network as shared exposes it to Tempest auto-config.

https://bugs.launchpad.net/snap-openstack/+bug/2109630