### PR TITLE
Prime juju model cache before copying Tempest container file

### DIFF
--- a/sunbeam-python/sunbeam/features/validation/feature.py
+++ b/sunbeam-python/sunbeam/features/validation/feature.py
@@ -390,6 +390,17 @@ class ValidationFeature(OpenStackControlPlaneFeature):
             f"to {destination} ..."
         )
         with console.status(progress_message):
+            # Note: this is a workaround to cache the model in the juju client
+            try:
+                subprocess.run(
+                    ["juju", "show-model", model_name],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=True,
+                    timeout=30,
+                )
+            except subprocess.TimeoutExpired:
+                raise click.ClickException("Timed out while priming Juju model cache")
             # Note: this is a workaround to run command to payload container
             # since python-libjuju does not support such feature. See related
             # bug: https://github.com/juju/python-libjuju/issues/1029


### PR DESCRIPTION
This change makes a dummy call to 'prime' the juju model cache before Tempest copies the test results file from the container. Previously, if the cache did not exist Juju would error with a "model not found" error.

https://bugs.launchpad.net/snap-openstack/+bug/2100739