### PR TITLE
[validation] Raise click exception on test failures

### DIFF
--- a/sunbeam-python/sunbeam/features/validation/feature.py
+++ b/sunbeam-python/sunbeam/features/validation/feature.py
@@ -544,7 +544,10 @@ class ValidationFeature(OpenStackControlPlaneFeature):
             )
 
         if failed > 0 or unexpected_success > 0:
-            click.Abort()
+            raise click.ClickException(
+                f"Validation tests: failed {failed}, unexpected_success: "
+                f"{unexpected_success}"
+            )
 
     @click.command()
     def list_profiles(self) -> None:


### PR DESCRIPTION
Currently when tests are failed click.Abort() is used but the expcetion is not raised. Raise Abort or ClickException in failure cases.

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2093175