### PR TITLE
Fix step name for ClusterUpdateNodeStep

### DIFF
--- a/sunbeam-python/sunbeam/steps/clusterd.py
+++ b/sunbeam-python/sunbeam/steps/clusterd.py
@@ -374,14 +374,16 @@ class ClusterUpdateNodeStep(BaseStep):
     ):
         super().__init__("Update node info", "Updating node info in cluster database")
         self.client = client
-        self.name = name
+        self.node_name = name
         self.role = role
         self.machine_id = machine_id
 
     def run(self, status: Status | None = None) -> Result:
         """Update Node info."""
         try:
-            self.client.cluster.update_node_info(self.name, self.role, self.machine_id)
+            self.client.cluster.update_node_info(
+                self.node_name, self.role, self.machine_id
+            )
             return Result(result_type=ResultType.COMPLETED)
         except ClusterServiceUnavailableException as e:
             LOG.debug(e)


### PR DESCRIPTION
In ClusterUpdateNodeStep, self.name is updated to the node name. However self.name is used for step name. So the logs says 'Starting step <nodename>' instead of step name.

Use self.node_name to set node name instead of using self.name