### PR TITLE
Reopen tty when fetching secret from stdin

### DIFF
--- a/sunbeam-python/sunbeam/features/vault/feature.py
+++ b/sunbeam-python/sunbeam/features/vault/feature.py
@@ -54,6 +54,7 @@ from sunbeam.core.manifest import (
     SoftwareConfig,
 )
 from sunbeam.core.openstack import OPENSTACK_MODEL
+from sunbeam.core.questions import get_stdin_reopen_tty
 from sunbeam.core.terraform import TerraformInitStep
 from sunbeam.features.interface.v1.base import ConfigType
 from sunbeam.features.interface.v1.openstack import (
@@ -744,7 +745,7 @@ class VaultFeature(OpenStackControlPlaneFeature):
         Use `-` as unseal key to read from stdin.
         """
         if unseal_key == "-":
-            unseal_key = click.get_text_stream("stdin").readline().strip()
+            unseal_key = get_stdin_reopen_tty()
 
         jhelper = JujuHelper(deployment.get_connected_controller())
         plan = [VaultUnsealStep(jhelper, unseal_key)]
@@ -760,7 +761,7 @@ class VaultFeature(OpenStackControlPlaneFeature):
         Use "-" as root_token to read from stdin.
         """
         if root_token == "-":
-            root_token = click.get_text_stream("stdin").readline().strip()
+            root_token = get_stdin_reopen_tty()
 
         jhelper = JujuHelper(deployment.get_connected_controller())
         plan = [AuthorizeVaultCharmStep(jhelper, root_token)]

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -72,6 +72,7 @@ from sunbeam.core.juju import (
 from sunbeam.core.k8s import K8S_CLOUD_SUFFIX
 from sunbeam.core.manifest import AddManifestStep, Manifest
 from sunbeam.core.openstack import OPENSTACK_MODEL
+from sunbeam.core.questions import get_stdin_reopen_tty
 from sunbeam.core.terraform import TerraformInitStep
 from sunbeam.provider.base import ProviderBase
 from sunbeam.provider.local.deployment import LOCAL_TYPE, LocalDeployment
@@ -997,7 +998,7 @@ def join(
     Use `-` as token to read from stdin.
     """
     if token == "-":
-        token = click.get_text_stream("stdin").readline().strip()
+        token = get_stdin_reopen_tty()
     is_control_node = any(role.is_control_node() for role in roles)
     is_compute_node = any(role.is_compute_node() for role in roles)
     is_storage_node = any(role.is_storage_node() for role in roles)


### PR DESCRIPTION
In most Sunbeam docs, we advise to pass secrets via stdin using the special value `-` as arguments. In case where user still requires prompts to answer deployment questions, such as joining a new node, it mades prompts unable to get answers from the user. Re-open the tty once we've fetch the secret from stdin.

Closes-Bug: #2111431