### PR TITLE
Auto scale coredns pods

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -143,6 +143,7 @@ from sunbeam.steps.k8s import (
     EnsureK8SUnitsTaggedStep,
     EnsureL2AdvertisementByHostStep,
     MigrateK8SKubeconfigStep,
+    PatchCoreDNSStep,
     RemoveK8SUnitsStep,
     StoreK8SKubeConfigStep,
     UpdateK8SCloudStep,
@@ -292,6 +293,7 @@ def get_k8s_plans(
                 fqdn,
             ),
             EnsureDefaultL2AdvertisementMutedStep(deployment, client, jhelper),
+            PatchCoreDNSStep(deployment, jhelper),
         ]
     )
 

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -155,6 +155,7 @@ from sunbeam.steps.k8s import (
     EnsureK8SUnitsTaggedStep,
     EnsureL2AdvertisementByHostStep,
     MigrateK8SKubeconfigStep,
+    PatchCoreDNSStep,
     RemoveK8SUnitsStep,
     StoreK8SKubeConfigStep,
     UpdateK8SCloudStep,
@@ -690,6 +691,7 @@ def deploy(
         )
     )
     plan2.append(AddK8SCloudStep(deployment, jhelper))
+    plan2.append(PatchCoreDNSStep(deployment, jhelper))
 
     plan2.append(TerraformInitStep(tfhelper_microceph))
     plan2.append(


### PR DESCRIPTION
Currently k8s canonical only deploys 1 coredns and not scaled. Bug raised on canonical k8s [1].
    
Add a workaround in sunbeam until [1] is fixed.
Logic is to use hpa to scale between 1 to 5 pods based on 80% cpu utilization.
Also increase the resource limits and requests for coredns pod.
Increase cpu requests/limits to 500m, memory requests/limits to 128Mi
    
[1] https://github.com/canonical/k8s-operator/issues/504
    
Related-Bug: https://bugs.launchpad.net/snap-openstack/+bug/2112396