### PR TITLE
Allow passing initial model configuration

### DIFF
--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -53,6 +53,16 @@ class JujuManifest(pydantic.BaseModel):
     destroy_args: list[str] = Field(
         default=[], description="Extra args for juju destroy-controller"
     )
+    bootstrap_model_configs: dict[str, dict[str, Any]] = Field(
+        default={},
+        description="""Mapping of model to model configuration.
+
+        This model configuration are guaranteed to be applied at model creation
+        only. Only, and only if, they are not overriden by Sunbeam.
+        This is offered as a convenience to allow users an easy way to
+        pass initial model configuration.
+        """,
+    )
 
 
 class CharmManifest(pydantic.BaseModel):

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -129,9 +129,17 @@ class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
 
     def run(self, status: Status | None = None) -> Result:
         """Execute configuration using terraform."""
+        f_manifest = self.manifest.get_feature(self.feature.name.split(".")[-1])
+        if f_manifest is not None:
+            model_config = f_manifest.software.juju.bootstrap_model_configs.get(
+                OBSERVABILITY_MODEL, {}
+            )
+        else:
+            model_config = {}
         proxy_settings = self.deployment.get_proxy_settings()
-        model_config = convert_proxy_to_model_configs(proxy_settings)
+        model_config.update(convert_proxy_to_model_configs(proxy_settings))
         model_config.update({"workload-storage": K8SHelper.get_default_storageclass()})
+
         extra_tfvars = {
             "model": self.model,
             "cloud": self.cloud,

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -344,20 +344,24 @@ def get_juju_model_machine_plans(
     jhelper: JujuHelper,
     local_management_ip: str,
     credential_name: str | None,
+    manifest: Manifest,
 ) -> list[BaseStep]:
     """Get Juju model and machine related plans."""
     proxy_settings = deployment.get_proxy_settings()
+    model = deployment.openstack_machines_model
+    bootstrap_model_config = manifest.core.software.juju.bootstrap_model_configs.get(
+        model
+    )
     return [
         AddJujuModelStep(
             jhelper,
-            deployment.openstack_machines_model,
+            model,
             deployment.name,
             credential_name,
             proxy_settings,
+            bootstrap_model_config,
         ),
-        AddJujuMachineStep(
-            local_management_ip, deployment.openstack_machines_model, jhelper
-        ),
+        AddJujuMachineStep(local_management_ip, model, jhelper),
     ]
 
 
@@ -511,7 +515,7 @@ def deploy_and_migrate_juju_controller(
     jhelper = JujuHelper(deployment.get_connected_controller())
 
     plan2 = get_juju_model_machine_plans(
-        deployment, jhelper, local_management_ip, "empty-creds"
+        deployment, jhelper, local_management_ip, "empty-creds", manifest
     )
     run_plan(plan2, console, show_hints)
 
@@ -712,7 +716,7 @@ def bootstrap(
         jhelper = JujuHelper(deployment.get_connected_controller())
 
         plan12 = get_juju_model_machine_plans(
-            deployment, jhelper, local_management_ip, None
+            deployment, jhelper, local_management_ip, None, manifest
         )
         run_plan(plan12, console, show_hints)
 

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -430,6 +430,9 @@ def bootstrap(
             deployment.name,
             deployment.name,
             proxy_settings,
+            manifest.core.software.juju.bootstrap_model_configs.get(
+                deployment.infra_model
+            ),
         )
     )
     plan2.append(
@@ -589,6 +592,9 @@ def deploy(
             deployment.name,
             deployment.name,
             proxy_settings,
+            manifest.core.software.juju.bootstrap_model_configs.get(
+                deployment.openstack_machines_model
+            ),
         )
     )
     plan.append(MaasAddMachinesToClusterdStep(client, maas_client))

--- a/sunbeam-python/sunbeam/steps/juju.py
+++ b/sunbeam-python/sunbeam/steps/juju.py
@@ -1485,6 +1485,7 @@ class AddJujuModelStep(BaseStep):
         cloud: str,
         credential: str | None = None,
         proxy_settings: dict | None = None,
+        model_config: dict | None = None,
     ):
         super().__init__(f"Add model {model}", f"Adding model {model}")
         self.jhelper = jhelper
@@ -1492,6 +1493,7 @@ class AddJujuModelStep(BaseStep):
         self.cloud = cloud
         self.credential = credential
         self.proxy_settings = proxy_settings or {}
+        self.model_config = model_config or {}
 
     def is_skip(self, status: Status | None = None) -> Result:
         """Determines if the step should be skipped or not."""
@@ -1503,13 +1505,16 @@ class AddJujuModelStep(BaseStep):
     def run(self, status: Status | None = None) -> Result:
         """Add model with configs."""
         try:
-            model_config = convert_proxy_to_model_configs(self.proxy_settings)
+            self.model_config.update(
+                convert_proxy_to_model_configs(self.proxy_settings)
+            )
+            LOG.debug(f"Adding model {self.model} with config: {self.model_config}")
             model = run_sync(
                 self.jhelper.add_model(
                     self.model,
                     cloud=self.cloud,
                     credential=self.credential,
-                    config=model_config,
+                    config=self.model_config,
                 )
             )
             run_sync(model.disconnect())


### PR DESCRIPTION
For the model created by Sunbeam, allow passing initial model configuration. The only guarantee made is that, at creation time, the parameter will be given to juju, and only if Sunbeam does not override them. Sunbeam will not perform any checks to see wheter or not these config options are valid parameter.

Closes-Bug: #2065490