### PR TITLE
Fix to apply custom region for microceph (S3 and Swift) endpoints

### DIFF
--- a/docs/deploy-locally-built-snap.md
+++ b/docs/deploy-locally-built-snap.md
@@ -47,6 +47,7 @@ sudo snap connections openstack
 sudo snap connect openstack:juju-bin juju:juju-bin
 sudo snap connect openstack:dot-local-share-juju
 sudo snap connect openstack:dot-config-openstack
+sudo snap connect openstack:dot-local-share-openstack
 ```
 
 ## Continue deployment

--- a/sunbeam-python/sunbeam/core/openstack.py
+++ b/sunbeam-python/sunbeam/core/openstack.py
@@ -2,3 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 OPENSTACK_MODEL = "openstack"
+REGION_CONFIG_KEY = "Region"
+DEFAULT_REGION = "RegionOne"

--- a/sunbeam-python/sunbeam/core/watcher.py
+++ b/sunbeam-python/sunbeam/core/watcher.py
@@ -10,9 +10,9 @@ from rich.status import Status
 from sunbeam.core.common import BaseStep, SunbeamException, read_config
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import JujuHelper
+from sunbeam.core.openstack import REGION_CONFIG_KEY
 from sunbeam.core.openstack_api import get_admin_connection
 from sunbeam.lazy import LazyImport
-from sunbeam.steps.openstack import REGION_CONFIG_KEY
 
 if TYPE_CHECKING:
     from watcherclient import v1 as watcher

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -33,6 +33,7 @@ from sunbeam.core.juju import (
     JujuController,
 )
 from sunbeam.core.k8s import K8SHelper
+from sunbeam.core.openstack import REGION_CONFIG_KEY
 from sunbeam.core.questions import QuestionBank, load_answers, show_questions
 from sunbeam.provider.local.steps import local_hypervisor_questions
 from sunbeam.steps.clusterd import (
@@ -43,7 +44,6 @@ from sunbeam.steps.clusterd import (
 from sunbeam.steps.k8s import K8S_ADDONS_CONFIG_KEY, k8s_addons_questions
 from sunbeam.steps.microceph import CONFIG_DISKS_KEY, microceph_questions
 from sunbeam.steps.openstack import (
-    REGION_CONFIG_KEY,
     TOPOLOGY_KEY,
     database_topology_questions,
     region_questions,

--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -16,9 +16,9 @@ from sunbeam.commands.configure import (
 from sunbeam.commands.proxy import proxy_questions
 from sunbeam.core.deployment import PROXY_CONFIG_KEY, Deployment, Networks
 from sunbeam.core.k8s import K8SHelper
+from sunbeam.core.openstack import REGION_CONFIG_KEY
 from sunbeam.core.questions import Question, QuestionBank, load_answers, show_questions
 from sunbeam.steps.openstack import (
-    REGION_CONFIG_KEY,
     TOPOLOGY_KEY,
     database_topology_questions,
     region_questions,

--- a/sunbeam-python/sunbeam/steps/microceph.py
+++ b/sunbeam-python/sunbeam/steps/microceph.py
@@ -11,7 +11,14 @@ from rich.status import Status
 from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import NodeNotExistInClusterException
 from sunbeam.core import questions
-from sunbeam.core.common import BaseStep, Result, ResultType, Role, SunbeamException
+from sunbeam.core.common import (
+    BaseStep,
+    Result,
+    ResultType,
+    Role,
+    SunbeamException,
+    read_config,
+)
 from sunbeam.core.deployment import Deployment, Networks
 from sunbeam.core.juju import (
     ActionFailedException,
@@ -40,6 +47,8 @@ MICROCEPH_APP_TIMEOUT = 1200  # updating rgw configs can take some time
 MICROCEPH_UNIT_TIMEOUT = (
     1200  # 20 minutes, adding / removing units can take a long time
 )
+REGION_CONFIG_KEY = "Region"
+DEFAULT_REGION = "RegionOne"
 
 
 def microceph_questions():
@@ -156,6 +165,9 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
                 "enable-rgw": "*",
                 "namespace-projects": True,
                 "default-pool-size": ceph_replica_scale(len(storage_nodes)),
+                "region": read_config(self.client, REGION_CONFIG_KEY).get(
+                    "region", DEFAULT_REGION
+                ),
             },
         }
 

--- a/sunbeam-python/sunbeam/steps/microceph.py
+++ b/sunbeam-python/sunbeam/steps/microceph.py
@@ -29,6 +29,7 @@ from sunbeam.core.juju import (
     run_sync,
 )
 from sunbeam.core.manifest import Manifest
+from sunbeam.core.openstack import DEFAULT_REGION, REGION_CONFIG_KEY
 from sunbeam.core.steps import (
     AddMachineUnitsStep,
     DeployMachineApplicationStep,
@@ -47,8 +48,6 @@ MICROCEPH_APP_TIMEOUT = 1200  # updating rgw configs can take some time
 MICROCEPH_UNIT_TIMEOUT = (
     1200  # 20 minutes, adding / removing units can take a long time
 )
-REGION_CONFIG_KEY = "Region"
-DEFAULT_REGION = "RegionOne"
 
 
 def microceph_questions():

--- a/sunbeam-python/sunbeam/steps/openstack.py
+++ b/sunbeam-python/sunbeam/steps/openstack.py
@@ -38,7 +38,7 @@ from sunbeam.core.juju import (
 )
 from sunbeam.core.k8s import CREDENTIAL_SUFFIX, K8SHelper
 from sunbeam.core.manifest import Manifest
-from sunbeam.core.openstack import OPENSTACK_MODEL
+from sunbeam.core.openstack import DEFAULT_REGION, OPENSTACK_MODEL, REGION_CONFIG_KEY
 from sunbeam.core.questions import (
     PromptQuestion,
     QuestionBank,
@@ -63,8 +63,6 @@ CONFIG_KEY = "TerraformVarsOpenstack"
 TOPOLOGY_KEY = "Topology"
 DATABASE_MEMORY_KEY = "DatabaseMemory"
 DATABASE_STORAGE_KEY = "DatabaseStorage"
-REGION_CONFIG_KEY = "Region"
-DEFAULT_REGION = "RegionOne"
 DEFAULT_DATABASE_TOPOLOGY = "single"
 
 DATABASE_MAX_POOL_SIZE = 2

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
@@ -22,12 +22,12 @@ from sunbeam.core.k8s import (
     METALLB_IP_ANNOTATION,
 )
 from sunbeam.core.manifest import Manifest
+from sunbeam.core.openstack import REGION_CONFIG_KEY
 from sunbeam.core.terraform import TerraformException
 from sunbeam.steps.openstack import (
     DATABASE_MEMORY_KEY,
     DEFAULT_STORAGE_MULTI_DATABASE,
     DEFAULT_STORAGE_SINGLE_DATABASE,
-    REGION_CONFIG_KEY,
     DeployControlPlaneStep,
     OpenStackPatchLoadBalancerServicesIPPoolStep,
     OpenStackPatchLoadBalancerServicesIPStep,


### PR DESCRIPTION
This PR fixes a bug (https://bugs.launchpad.net/snap-openstack/+bug/2109812) where custom region names provided via the manifest file were not reflected in the S3 and Swift service endpoints, which defaulted to "RegionOne".

What was changed?
1. Imported read_config from sunbeam.core.common in microceph.py.
2. Defined constants (REGION_CONFIG_KEY, DEFAULT_REGION) in microceph.py.
3. Dynamically fetch the configured region for the RGW service in microceph.py.