### PR TITLE
Determine Coredns replica based on number of control nodes

### DIFF
--- a/sunbeam-python/sunbeam/commands/resize.py
+++ b/sunbeam-python/sunbeam/commands/resize.py
@@ -13,6 +13,7 @@ from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import JujuHelper
 from sunbeam.core.terraform import TerraformInitStep
 from sunbeam.steps.cinder_volume import DeployCinderVolumeApplicationStep
+from sunbeam.steps.k8s import PatchCoreDNSStep
 from sunbeam.steps.microceph import (
     DeployMicrocephApplicationStep,
     SetCephMgrPoolSizeStep,
@@ -81,6 +82,7 @@ def resize(
 
     plan.extend(
         [
+            PatchCoreDNSStep(deployment, jhelper),
             TerraformInitStep(openstack_tfhelper),
             DeployControlPlaneStep(
                 deployment,


### PR DESCRIPTION
Currently the HPA applied on coredns has minReplica as 1. This means in case of multi node deployment, the number of codedns pods is 1 if there is no load on coredns.

The ideal situation is to have 3 coredns in case of multi node deployment irrespective of the load. Determine the number of replicas for coredns based on number of control nodes.
Apply the determined replica during deploy command in mass mode and resize command in manual mode.