### PR TITLE
Add Sunbeam TLS Vault Feature

### DIFF
--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -220,6 +220,9 @@ class CoreConfig(pydantic.BaseModel):
     region: str | None = None
     addons: _Addons | None = None
     k8s_addons: _K8sAddons | None = pydantic.Field(default=None, alias="k8s-addons")
+    traefik_endpoints: dict[str, str] | None = pydantic.Field(
+        default=None, alias="traefik-endpoints"
+    )
     user: _User | None = None
     external_network: _ExternalNetwork | None = None
     microceph_config: pydantic.RootModel[dict[str, _HostMicroCephConfig]] | None = None

--- a/sunbeam-python/sunbeam/features/tls/README.md
+++ b/sunbeam-python/sunbeam/features/tls/README.md
@@ -1,47 +1,10 @@
-# TLS CA feature (Manual TLS Certificate Operator)
+# Sunbeam TLS Feature
 
 This feature enables user to provide TLS certificates obtained through manual process. The certificates can be applied on public and internal traefik instances.
 
 ## Installation
 
-To enable the TLS CA feature, you need an already bootstraped Sunbeam instance. Then, you can install the feature with:
+Sunbeam supports 2 different methods to enable TLS CA:
 
-```bash
-sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain>
-```
-
-By default the TLS Certificate charm integrates with public traefik instances.
-To integrate with internal traefik instances as well, install the feature with:
-
-```bash
-sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal
-```
-
-To integrate with internal and rgw traefik instances as well, install the feature with:
-
-```bash
-sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal --endpoint rgw
-```
-
-## Configure
-
-To apply tls certificate on the traefik instances, run the following command:
-
-```bash
-sunbeam tls ca unit_certs
-```
-
-The above command will prompt the user for TLS Certificate for each traefik unit.
-
-## Contents
-
-This feature will install the following services:
-- Manual TLS Certificate operator: [charm](https://github.com/canonical/manual-tls-certificates-operator)
-
-## Removal
-
-To remove the feature, run:
-
-```bash
-sunbeam disable tls ca
-```
+- [TLS CA via Manual TLS Certificate Operator](./VaultTLS.md)
+- [Vault TLS](./VaultTLS.md)

--- a/sunbeam-python/sunbeam/features/tls/TLSCA.md
+++ b/sunbeam-python/sunbeam/features/tls/TLSCA.md
@@ -1,0 +1,47 @@
+# TLS CA feature (Manual TLS Certificate Operator)
+
+This feature enables user to provide TLS certificates obtained through manual process. The certificates can be applied on public and internal traefik instances.
+
+## Installation
+
+To enable the TLS CA feature, you need an already bootstraped Sunbeam instance. Then, you can install the feature with:
+
+```bash
+sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain>
+```
+
+By default the TLS Certificate charm integrates with public traefik instances.
+To integrate with internal traefik instances as well, install the feature with:
+
+```bash
+sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal
+```
+
+To integrate with internal and rgw traefik instances as well, install the feature with:
+
+```bash
+sunbeam enable tls ca --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal --endpoint rgw
+```
+
+## Configure
+
+To apply tls certificate on the traefik instances, run the following command:
+
+```bash
+sunbeam tls ca unit_certs
+```
+
+The above command will prompt the user for TLS Certificate for each traefik unit.
+
+## Contents
+
+This feature will install the following services:
+- Manual TLS Certificate operator: [charm](https://github.com/canonical/manual-tls-certificates-operator)
+
+## Removal
+
+To remove the feature, run:
+
+```bash
+sunbeam disable tls ca
+```

--- a/sunbeam-python/sunbeam/features/tls/VaultTLS.md
+++ b/sunbeam-python/sunbeam/features/tls/VaultTLS.md
@@ -1,0 +1,53 @@
+# TLS Vault feature
+
+This feature enables user to provide TLS certificates obtained through manual process. The certificates can be applied on public and internal traefik instances.
+
+## Prerequisites
+
+This feature requires the Vault feature enabled in sunbeam. For this, follow this [guide](https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/features/vault/).
+
+## Installation
+
+To enable the TLS Vault feature, you need an already bootstraped Sunbeam instance. Then, you can install the feature with:
+
+```bash
+sunbeam enable tls vault --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain>
+```
+
+**NOTE**: The certificate needs to be created as a CA certificate. This can be done by adding to the certificate the `x509 Extension -> CA:TRUE`.
+
+By default the TLS Certificate charm integrates with public traefik instances.
+To integrate with internal traefik instances as well, install the feature with:
+
+```bash
+sunbeam enable tls vault --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal
+```
+
+To integrate with internal and rgw traefik instances as well, install the feature with:
+
+```bash
+sunbeam enable tls vault --ca=<Base64 encoded CA cert> --ca-chain=<Base64 encoded CA Chain> --endpoint public --endpoint internal --endpoint rgw
+```
+
+## Configure
+
+To apply tls certificate on the traefik instances, run the following command:
+
+```bash
+sunbeam tls vault unit_certs
+```
+
+The above command will prompt the user for TLS Certificate for each traefik unit.
+
+## Contents
+
+This feature will require the following services:
+- Vault-K8s: [charm](https://github.com/canonical/vault-k8s-operator)
+
+## Removal
+
+To remove the feature, run:
+
+```bash
+sunbeam disable tls vault
+```

--- a/sunbeam-python/sunbeam/features/tls/common.py
+++ b/sunbeam-python/sunbeam/features/tls/common.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.status import Status
 
 from sunbeam.clusterd.service import ConfigItemNotFoundException
+from sunbeam.core import questions
 from sunbeam.core.common import (
     BaseStep,
     Result,
@@ -24,7 +25,11 @@ from sunbeam.core.juju import (
     JujuHelper,
     LeaderNotFoundException,
 )
-from sunbeam.core.manifest import FeatureConfig
+from sunbeam.core.manifest import (
+    CharmManifest,
+    FeatureConfig,
+    SoftwareConfig,
+)
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.features.interface.v1.base import BaseFeatureGroup
 from sunbeam.features.interface.v1.openstack import (
@@ -79,6 +84,34 @@ class TlsFeature(OpenStackControlPlaneFeature):
     @click.group()
     def disable_tls(self) -> None:
         """Disable TLS group."""
+
+    @click.group()
+    def tls_group(self):
+        """Manage TLS."""
+
+    def default_software_overrides(self) -> SoftwareConfig:
+        """Feature software configuration."""
+        return SoftwareConfig(
+            charms={
+                "manual-tls-certificates": CharmManifest(
+                    channel="latest/stable",
+                )
+            }
+        )
+
+    def manifest_attributes_tfvar_map(self) -> dict:
+        """Manifest attributes terraformvars map."""
+        return {
+            self.tfplan: {
+                "charms": {
+                    "manual-tls-certificates": {
+                        "channel": "manual-tls-certificates-channel",
+                        "revision": "manual-tls-certificates-revision",
+                        "config": "manual-tls-certificates-config",
+                    }
+                }
+            }
+        }
 
     def provider_config(self, deployment: Deployment) -> dict:
         """Return stored provider configuration."""
@@ -305,3 +338,25 @@ class RemoveCACertsFromKeystoneStep(BaseStep):
         LOG.debug(f"Result from action {action_cmd}: {action_result}")
 
         return Result(ResultType.COMPLETED)
+
+
+def certificate_questions(unit: str, subject: str):
+    return {
+        "certificate": questions.PromptQuestion(
+            f"Base64 encoded Certificate for {unit} CSR Unique ID: {subject}",
+        ),
+    }
+
+
+def get_outstanding_certificate_requests(
+    app: str, model: str, jhelper: JujuHelper
+) -> dict:
+    """Get outstanding certificate requests from manual-tls-certificate operator.
+
+    Returns the result from the action get-outstanding-certificate-requests.
+    Raises LeaderNotFoundException, ActionFailedException.
+    """
+    action_cmd = "get-outstanding-certificate-requests"
+    unit = jhelper.get_leader_unit(app, model)
+    action_result = jhelper.run_action(unit, model, action_cmd)
+    return action_result

--- a/sunbeam-python/sunbeam/features/tls/feature.py
+++ b/sunbeam-python/sunbeam/features/tls/feature.py
@@ -1,3 +1,4 @@
 # SPDX-FileCopyrightText: 2024 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 from .ca import CaTlsFeature  # noqa: F401
+from .vault import VaultTlsFeature  # noqa: F401

--- a/sunbeam-python/sunbeam/features/tls/vault.py
+++ b/sunbeam-python/sunbeam/features/tls/vault.py
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: 2024 - Canonical Ltd
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
 import json
 import logging
+import typing
 from pathlib import Path
 
 import click
@@ -14,9 +15,7 @@ from rich.status import Status
 from rich.table import Table
 
 from sunbeam.clusterd.client import Client
-from sunbeam.clusterd.service import (
-    ConfigItemNotFoundException,
-)
+from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.core import questions
 from sunbeam.core.common import (
     FORMAT_TABLE,
@@ -24,6 +23,7 @@ from sunbeam.core.common import (
     BaseStep,
     Result,
     ResultType,
+    SunbeamException,
     read_config,
     run_plan,
     str_presenter,
@@ -31,13 +31,11 @@ from sunbeam.core.common import (
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import (
     ActionFailedException,
+    JujuException,
     JujuHelper,
     LeaderNotFoundException,
 )
-from sunbeam.core.manifest import (
-    AddManifestStep,
-    FeatureConfig,
-)
+from sunbeam.core.manifest import AddManifestStep, FeatureConfig
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.features.interface.utils import (
     encode_base64_as_string,
@@ -57,23 +55,26 @@ from sunbeam.features.tls.common import (
     certificate_questions,
     get_outstanding_certificate_requests,
 )
+from sunbeam.features.vault.feature import VaultCommandFailedException, VaultHelper
+from sunbeam.steps.k8s import TRAEFIK_CONFIG_KEY
 from sunbeam.utils import click_option_show_hints, pass_method_obj
 
 CERTIFICATE_FEATURE_KEY = "TlsProvider"
-CA_APP_NAME = "manual-tls-certificates"
+CA_APP_NAME = "vault"
 LOG = logging.getLogger(__name__)
 console = Console()
+ConfigType = typing.TypeVar("ConfigType", bound=FeatureConfig)
 
 
 class _Certificate(pydantic.BaseModel):
     certificate: str
 
 
-class CaTlsFeatureConfig(TlsFeatureConfig):
+class VaultTlsFeatureConfig(TlsFeatureConfig):
     certificates: dict[str, _Certificate] = {}
 
 
-class ConfigureCAStep(BaseStep):
+class ConfigureVaultCAStep(BaseStep):
     """Configure CA certificates."""
 
     _CONFIG = "FeatureCACertificatesConfig"
@@ -92,7 +93,7 @@ class ConfigureCAStep(BaseStep):
         self.ca_cert = ca_cert
         self.ca_chain = ca_chain
         self.preseed = deployment_preseed or {}
-        self.app = CA_APP_NAME
+        self.app = "manual-tls-certificates"
         self.model = OPENSTACK_MODEL
         self.process_certs: dict = {}
 
@@ -116,7 +117,7 @@ class ConfigureCAStep(BaseStep):
         # let exception propagate, since they are SunbeamException
         # they will be caught cleanly
         action_result = get_outstanding_certificate_requests(
-            self.app, self.model, self.jhelper
+            self.app, OPENSTACK_MODEL, self.jhelper
         )
 
         LOG.debug(f"Result from action {action_cmd}: {action_result}")
@@ -139,6 +140,8 @@ class ConfigureCAStep(BaseStep):
             csr = record.get("csr")
             app = record.get("application_name")
             relation_id = record.get("relation_id")
+            if not unit_name:
+                unit_name = str(relation_id)
 
             # Each unit can have multiple CSRs
             subject = get_subject_from_csr(csr)
@@ -181,7 +184,7 @@ class ConfigureCAStep(BaseStep):
         """Run configure steps."""
         action_cmd = "provide-certificate"
         try:
-            unit = self.jhelper.get_leader_unit(self.app, self.model)
+            unit = self.jhelper.get_leader_unit(self.app, OPENSTACK_MODEL)
         except LeaderNotFoundException as e:
             LOG.debug(f"Unable to get {self.app} leader")
             return Result(ResultType.FAILED, str(e))
@@ -194,21 +197,19 @@ class ConfigureCAStep(BaseStep):
                 return Result(ResultType.FAILED)
 
             action_params = {
-                "relation-id": request.get("relation_id"),
                 "certificate": request.get("certificate"),
-                "ca-chain": self.ca_chain,
+                "ca-chain": self.ca_cert,
                 "ca-certificate": self.ca_cert,
                 "certificate-signing-request": str(csr),
-                "unit-name": request.get("unit"),
             }
 
-            LOG.debug(f"Running action {action_cmd} with params {action_params}")
+            LOG.debug(f"Running action {action_cmd}")
             try:
                 action_result = self.jhelper.run_action(
-                    unit, self.model, action_cmd, action_params
+                    unit, OPENSTACK_MODEL, action_cmd, action_params
                 )
             except ActionFailedException as e:
-                LOG.debug(f"Running action {action_cmd} on {unit} failed")
+                LOG.debug(f"Running action {action_cmd} on {unit}")
                 return Result(ResultType.FAILED, str(e))
 
             LOG.debug(f"Result from action {action_cmd}: {action_result}")
@@ -220,15 +221,19 @@ class ConfigureCAStep(BaseStep):
         return Result(ResultType.COMPLETED)
 
 
-class CaTlsFeature(TlsFeature):
+class VaultTlsFeature(TlsFeature):
     version = Version("0.0.1")
 
-    name = "tls.ca"
+    name = "tls.vault"
     tf_plan_location = TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO
+
+    @click.group()
+    def vault_group(self) -> None:
+        """Manage CA (HashiCorp Vault)."""
 
     def config_type(self) -> type | None:
         """Return the config type for the feature."""
-        return CaTlsFeatureConfig
+        return VaultTlsFeatureConfig
 
     def preseed_questions_content(self) -> list:
         """Generate preseed manifest content."""
@@ -244,7 +249,69 @@ class CaTlsFeature(TlsFeature):
             section_description="TLS Certificates",
             comment_out=True,
         )
-        return content
+        return [content]
+
+    def _build_tls_config_maps(
+        self,
+        jhelper: JujuHelper,
+        endpoints: list[str],
+    ) -> dict[str, dict[str, str]]:
+        """Get the TLS config maps for specified endpoints."""
+        external: dict[str, str] = {}
+        missing: list[str] = []
+
+        try:
+            traefik_vars = read_config(self.client, TRAEFIK_CONFIG_KEY)
+            traefik_endpoints = traefik_vars.get("traefik-endpoints", {})
+        except ConfigItemNotFoundException:
+            raise click.ClickException(
+                "Traefik endpoint hostnames are not configured in Sunbeam. "
+                "Please configure them before proceeding."
+            )
+
+        endpoint_key_map = {
+            "public": "traefik-public",
+            "internal": "traefik",
+            "rgw": "traefik-rgw",
+        }
+
+        for ep in endpoints:
+            endpoint_key = endpoint_key_map[ep]
+            hostname = traefik_endpoints.get(endpoint_key)
+            if hostname:
+                external[ep] = hostname
+            else:
+                missing.append(ep)
+
+        if missing:
+            raise click.ClickException(
+                "TLS Vault cannot be enabled because the following endpoints "
+                f"are missing external hostnames: {', '.join(missing)}. "
+                "Please configure these hostnames using Sunbeam bootstrap."
+            )
+
+        maps: dict[str, dict[str, str]] = {}
+        domains = set()
+        for hostname in external.values():
+            if "." in hostname:
+                domains.add(hostname.split(".", 1)[1])
+        if len(domains) != 1:
+            raise click.ClickException(
+                "Traefik endpoints must share one common domain; found multiple: "
+                f"{', '.join(domains)}"
+            )
+
+        common_domain = domains.pop()
+        maps["vault-config"] = {"common_name": common_domain}
+
+        if "public" in external:
+            maps["traefik-public-config"] = {"external_hostname": external["public"]}
+        if "internal" in external:
+            maps["traefik-config"] = {"external_hostname": external["internal"]}
+        if "rgw" in external:
+            maps["traefik-rgw-config"] = {"external_hostname": external["rgw"]}
+
+        return maps
 
     @click.command()
     @click.option(
@@ -253,7 +320,7 @@ class CaTlsFeature(TlsFeature):
         multiple=True,
         default=["public"],
         type=click.Choice(["public", "internal", "rgw"], case_sensitive=False),
-        help="Specify endpoints to apply tls.",
+        help="Specify which endpoints to apply TLS for.",
     )
     @click.option(
         "--ca-chain",
@@ -279,62 +346,54 @@ class CaTlsFeature(TlsFeature):
         endpoints: list[str],
         show_hints: bool,
     ):
-        """Enable CA feature."""
-        self.enable_feature(
-            deployment,
-            CaTlsFeatureConfig(ca=ca, ca_chain=ca_chain, endpoints=endpoints),
-            show_hints,
+        """Enable TLS Vault feature."""
+        self.client = deployment.get_client()
+
+        config = VaultTlsFeatureConfig(
+            ca=ca,
+            ca_chain=ca_chain,
+            endpoints=endpoints,
         )
+        self.enable_feature(deployment, config, show_hints)
 
     @click.command()
     @click_option_show_hints
     @pass_method_obj
     def disable_cmd(self, deployment: Deployment, show_hints: bool):
-        """Disable CA feature."""
+        """Disable TLS Vault feature."""
         self.disable_feature(deployment, show_hints)
-        console.print("CA feature disabled")
+        console.print("TLS Vault feature disabled")
 
     def set_application_names(self, deployment: Deployment) -> list:
         """Application names handled by the terraform plan."""
         return ["manual-tls-certificates"]
 
     def set_tfvars_on_enable(
-        self, deployment: Deployment, config: CaTlsFeatureConfig
+        self, deployment: Deployment, config: VaultTlsFeatureConfig
     ) -> dict:
         """Set terraform variables to enable the application."""
-        tfvars: dict[str, str | bool] = {"traefik-to-tls-provider": CA_APP_NAME}
-        if "public" in config.endpoints:
-            tfvars.update({"enable-tls-for-public-endpoint": True})
-        if "internal" in config.endpoints:
-            tfvars.update({"enable-tls-for-internal-endpoint": True})
-        if "rgw" in config.endpoints:
-            tfvars.update({"enable-tls-for-rgw-endpoint": True})
-
+        tfvars: dict[str, typing.Any] = {
+            "traefik-to-tls-provider": CA_APP_NAME,
+            "manual-tls-certificates-channel": "1/stable",
+        }
+        jhelper = JujuHelper(deployment.juju_controller)
+        tfvars.update(self._build_tls_config_maps(jhelper, config.endpoints))
+        tfvars["enable-tls-for-public-endpoint"] = "public" in config.endpoints
+        tfvars["enable-tls-for-internal-endpoint"] = "internal" in config.endpoints
+        tfvars["enable-tls-for-rgw-endpoint"] = "rgw" in config.endpoints
         return tfvars
 
     def set_tfvars_on_disable(self, deployment: Deployment) -> dict:
         """Set terraform variables to disable the application."""
-        tfvars: dict[str, None | str | bool] = {"traefik-to-tls-provider": None}
-        provider_config = self.provider_config(deployment)
-        endpoints = provider_config.get("endpoints", [])
-        if "public" in endpoints:
-            tfvars.update({"enable-tls-for-public-endpoint": False})
-        if "internal" in endpoints:
-            tfvars.update({"enable-tls-for-internal-endpoint": False})
-        if "rgw" in endpoints:
-            tfvars.update({"enable-tls-for-rgw-endpoint": False})
-
-        return tfvars
+        return {
+            "traefik-to-tls-provider": None,
+        }
 
     def set_tfvars_on_resize(
         self, deployment: Deployment, config: FeatureConfig
     ) -> dict:
         """Set terraform variables to resize the application."""
         return {}
-
-    @click.group()
-    def ca_group(self) -> None:
-        """Manage CA."""
 
     @click.command()
     @click.option(
@@ -346,7 +405,7 @@ class CaTlsFeature(TlsFeature):
     @pass_method_obj
     def list_outstanding_csrs(self, deployment: Deployment, format: str) -> None:
         """List outstanding CSRs."""
-        app = CA_APP_NAME
+        app = "manual-tls-certificates"
         model = OPENSTACK_MODEL
         action_cmd = "get-outstanding-certificate-requests"
         jhelper = JujuHelper(deployment.juju_controller)
@@ -367,17 +426,18 @@ class CaTlsFeature(TlsFeature):
 
         certs_to_process = json.loads(action_result.get("result", "[]"))
         csrs = {
-            unit: csr
+            relation: csr
             for record in certs_to_process
-            if (unit := record.get("unit_name")) and (csr := record.get("csr"))
+            if (relation := str(record.get("relation_id")))
+            and (csr := record.get("csr"))
         }
 
         if format == FORMAT_TABLE:
             table = Table()
-            table.add_column("Unit name")
+            table.add_column("Relation ID")
             table.add_column("CSR")
-            for unit, csr in csrs.items():
-                table.add_row(unit, csr)
+            for relation, csr in csrs.items():
+                table.add_row(relation, csr)
             console.print(table)
         elif format == FORMAT_YAML:
             yaml.add_representer(str, str_presenter)
@@ -406,9 +466,7 @@ class CaTlsFeature(TlsFeature):
         if (ca := manifest.get_feature(self.name.split(".")[-1])) and ca.config:
             preseed = ca.config.model_dump(by_alias=True)
         model = OPENSTACK_MODEL
-        apps_to_monitor = ["traefik", "traefik-public", "keystone"]
-        if client.cluster.list_nodes_by_role("storage"):
-            apps_to_monitor.append("traefik-rgw")
+        apps_to_monitor = [CA_APP_NAME]
 
         try:
             config = read_config(client, CERTIFICATE_FEATURE_KEY)
@@ -423,7 +481,7 @@ class CaTlsFeature(TlsFeature):
         jhelper = JujuHelper(deployment.juju_controller)
         plan = [
             AddManifestStep(client, manifest_path),
-            ConfigureCAStep(
+            ConfigureVaultCAStep(
                 client,
                 jhelper,
                 ca,
@@ -447,8 +505,8 @@ class CaTlsFeature(TlsFeature):
         """
         return {
             "init": [{"name": self.group.name, "command": self.tls_group}],
-            "init.tls": [{"name": "ca", "command": self.ca_group}],
-            "init.tls.ca": [
+            "init.tls": [{"name": "vault", "command": self.vault_group}],
+            "init.tls.vault": [
                 {"name": "unit_certs", "command": self.configure},
                 {
                     "name": "list_outstanding_csrs",
@@ -456,3 +514,131 @@ class CaTlsFeature(TlsFeature):
                 },
             ],
         }
+
+    def is_vault_application_active(self, jhelper: JujuHelper) -> bool:
+        """Check if Vault is deployed, initialized, and authorized."""
+        try:
+            leader = jhelper.get_leader_unit(CA_APP_NAME, OPENSTACK_MODEL)
+        except SunbeamException:
+            raise click.ClickException(
+                "Cannot enable TLS Vault because Vault is not deployed. "
+                "Please deploy Vault first."
+            )
+
+        app_status = jhelper.get_application(CA_APP_NAME, OPENSTACK_MODEL)
+        raw_units: typing.Any = app_status.units
+        if hasattr(raw_units, "items"):
+            unit_items = raw_units.items()
+        else:
+            unit_items = enumerate(raw_units)
+        units = list(unit_items)
+        if not units:
+            raise click.ClickException(
+                "Vault application has no units. Please deploy Vault first."
+            )
+        _, unit_stat = units[0]
+
+        status = unit_stat.workload_status.current
+        message = unit_stat.workload_status.message
+
+        if status == "active":
+            return True
+
+        vhelper = VaultHelper(jhelper)
+        try:
+            vault_status = vhelper.get_vault_status(leader)
+        except VaultCommandFailedException as e:
+            raise click.ClickException(f"Error querying Vault status: {e}")
+        except (TimeoutError, JujuException) as e:
+            raise click.ClickException(f"Unable to contact Vault: {e}")
+
+        if not vault_status.get("initialized", False):
+            raise click.ClickException(
+                "Vault is deployed but uninitialized. "
+                "Please run `sunbeam vault init` first."
+            )
+        if vault_status.get("sealed", True):
+            raise click.ClickException(
+                "Vault is initialized but still sealed. "
+                "Please unseal Vault before proceeding."
+            )
+
+        # There is a case where after vault unseal, the vault
+        # application is still in blocked state, but shows the message
+        # "Please initialize Vault or integrate
+        # with an auto-unseal provider"
+        if "authorize" in message.lower() or "initialize" in message.lower():
+            raise click.ClickException(
+                "Vault is not authorized. Please run `sunbeam vault authorize-charm`"
+                "first."
+            )
+
+        if status == "blocked":
+            raise click.ClickException(f"Vault is blocked: {message}")
+        return True
+
+    def pre_enable(
+        self,
+        deployment: Deployment,
+        config: TlsFeatureConfig,
+        show_hints: bool,
+    ) -> None:
+        """Handler to perform tasks before enabling the feature."""
+        super().pre_enable(deployment, config, show_hints)
+
+        jhelper = JujuHelper(deployment.juju_controller)
+        if not self.is_vault_application_active(jhelper):
+            raise click.ClickException(
+                "Cannot enable TLS Vault as Vault is not enabled. Enable Vault first."
+            )
+
+        try:
+            tfvars = read_config(self.client, TRAEFIK_CONFIG_KEY)
+            saved = tfvars.get("traefik-endpoints", {})
+        except ConfigItemNotFoundException:
+            raise click.ClickException(
+                "Traefik endpoint hostnames are not configured in Sunbeam. "
+                "Please configure them using the bootstrap prompts."
+            )
+
+        key_map = {
+            "public": "traefik-public",
+            "internal": "traefik",
+            "rgw": "traefik-rgw",
+        }
+        external: dict[str, str] = {}
+        missing: list[str] = []
+        for ep in config.endpoints:
+            k = key_map[ep]
+            h = saved.get(k, "").strip()
+            if h:
+                external[ep] = h
+            else:
+                missing.append(ep)
+
+        if missing:
+            raise click.ClickException(
+                "TLS Vault cannot be enabled because no hostname was provided for: "
+                f"{', '.join(missing)}"
+            )
+
+        domains = set()
+        for hostname in external.values():
+            if "." in hostname:
+                domains.add(hostname.split(".", 1)[1])
+        if len(domains) != 1:
+            raise click.ClickException(
+                f"Traefik endpoints must share one domain; \
+                found: {', '.join(external.values())}"
+            )
+        common_domain = domains.pop()
+
+        with jhelper._model(OPENSTACK_MODEL):
+            jhelper.cli(
+                "config",
+                CA_APP_NAME,
+                f"common_name={common_domain}",
+                include_controller=False,
+                json_format=False,
+            )
+        console.print(f"Set {CA_APP_NAME}.common_name = {common_domain}")

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -93,6 +93,7 @@ else:
 LOG = logging.getLogger(__name__)
 K8S_CONFIG_KEY = "TerraformVarsK8S"
 K8S_ADDONS_CONFIG_KEY = "TerraformVarsK8SAddons"
+TRAEFIK_CONFIG_KEY = "TerraformVarsTraefikEndpoints"
 APPLICATION = "k8s"
 K8S_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
 K8S_DESTROY_TIMEOUT = 900
@@ -144,6 +145,23 @@ def k8s_addons_questions():
     }
 
 
+def endpoint_questions():
+    return {
+        "traefik": PromptQuestion(
+            "Hostname for Traefik internal endpoint",
+            default_value="",
+        ),
+        "traefik-public": PromptQuestion(
+            "Hostname for Traefik public endpoint",
+            default_value="",
+        ),
+        "traefik-rgw": PromptQuestion(
+            "Hostname for Traefik RGW endpoint",
+            default_value="",
+        ),
+    }
+
+
 class KubeClientError(K8SError):
     pass
 
@@ -171,6 +189,7 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
     """Deploy K8S application using Terraform."""
 
     _ADDONS_CONFIG = K8S_ADDONS_CONFIG_KEY
+    _TRAEFIK_CONFIG_KEY = TRAEFIK_CONFIG_KEY
 
     def __init__(
         self,
@@ -199,7 +218,7 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
 
         self.accept_defaults = accept_defaults
         self.variables: dict = {}
-        self.ranges: str | None = None
+        self.traefik_variables: dict = {}
 
     def prompt(
         self,
@@ -230,9 +249,29 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
         self.variables["k8s-addons"]["loadbalancer"] = (
             k8s_addons_bank.loadbalancer.ask()
         )
-
-        LOG.debug(self.variables)
         write_answers(self.client, self._ADDONS_CONFIG, self.variables)
+
+        # Traefik endpoints prompt
+        self.traefik_variables = load_answers(self.client, self._TRAEFIK_CONFIG_KEY)
+        self.traefik_variables.setdefault("traefik-endpoints", {})
+
+        preseed = getattr(self.manifest.core.config, "traefik_endpoints", {}) or {}
+
+        endpoint_bank = QuestionBank(
+            questions=endpoint_questions(),
+            console=console,
+            preseed=preseed,
+            previous_answers=self.traefik_variables["traefik-endpoints"],
+            accept_defaults=self.accept_defaults,
+            show_hint=show_hint,
+        )
+
+        for key in endpoint_questions():
+            answer = endpoint_bank.questions[key].ask()
+            if answer:
+                self.traefik_variables.setdefault("traefik-endpoints", {})[key] = answer
+
+        write_answers(self.client, self._TRAEFIK_CONFIG_KEY, self.traefik_variables)
 
     def has_prompts(self) -> bool:
         """Returns true if the step has prompts that it can ask the user.
@@ -277,14 +316,50 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
 
         return config_tfvars
 
+    def _get_traefik_endpoint_tfvars(self) -> dict:
+        """Prepare Traefik endpoint terraform variables."""
+        traefik_vars = load_answers(self.client, self._TRAEFIK_CONFIG_KEY).get(
+            "traefik-endpoints", {}
+        )
+
+        return {
+            "traefik-config": {
+                # Use underscore in key to match charm config
+                "external_hostname": traefik_vars.get("traefik"),
+            },
+            "traefik-public-config": {
+                "external_hostname": traefik_vars.get("traefik-public"),
+            },
+            "traefik-rgw-config": {
+                "external_hostname": traefik_vars.get("traefik-rgw"),
+            },
+        }
+
     def extra_tfvars(self) -> dict:
         """Extra terraform vars to pass to terraform apply."""
-        return {
+        tfvars = {
             "endpoint_bindings": [
                 {"space": self.deployment.get_space(Networks.MANAGEMENT)},
             ],
             "k8s_config": self._get_k8s_config_tfvars(),
         }
+        traefik_vars = load_answers(self.client, self._TRAEFIK_CONFIG_KEY).get(
+            "traefik-endpoints", {}
+        )
+
+        tfvars.update(
+            {
+                "traefik-config": {"external_hostname": traefik_vars.get("traefik")},
+                "traefik-public-config": {
+                    "external_hostname": traefik_vars.get("traefik-public")
+                },
+                "traefik-rgw-config": {
+                    "external_hostname": traefik_vars.get("traefik-rgw")
+                },
+            }
+        )
+
+        return tfvars
 
 
 class AddK8SUnitsStep(AddMachineUnitsStep):

--- a/sunbeam-python/tests/unit/sunbeam/features/test_tls.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_tls.py
@@ -11,6 +11,7 @@ import sunbeam.core.questions
 import sunbeam.features.interface.utils
 import sunbeam.features.tls.ca as ca
 import sunbeam.features.tls.common as tls
+import sunbeam.features.tls.vault as vault
 from sunbeam.core.common import ResultType
 from sunbeam.core.juju import ActionFailedException, LeaderNotFoundException
 
@@ -52,6 +53,29 @@ def get_subject_from_csr():
 @pytest.fixture()
 def is_certificate_valid():
     with patch.object(ca, "is_certificate_valid") as p:
+        yield p
+
+
+@pytest.fixture()
+def get_outstanding():
+    with patch.object(
+        vault,
+        "get_outstanding_certificate_requests",
+    ) as p:
+        yield p
+
+
+@pytest.fixture()
+def vault_get_subject_from_csr():
+    """Patch the Vault version of get_subject_from_csr."""
+    with patch.object(vault, "get_subject_from_csr") as p:
+        yield p
+
+
+@pytest.fixture()
+def vault_is_certificate_valid():
+    """Patch the Vault version of is_certificate_valid."""
+    with patch.object(vault, "is_certificate_valid") as p:
         yield p
 
 
@@ -453,3 +477,239 @@ class TestConfigureCAStep:
         jhelper.run_action.assert_not_called()
         assert result.result_type == ResultType.FAILED
         assert result.message == "not able to get leader..."
+
+
+class TestConfigureVaultCAStepPrompt:
+    def test_prompt_normal(
+        self,
+        cclient,
+        jhelper,
+        load_answers,
+        write_answers,
+        question_bank,
+        vault_get_subject_from_csr,
+        vault_is_certificate_valid,
+        get_outstanding,
+    ):
+        # one outstanding CSR
+        rec = {"unit_name": "app/0", "csr": "fake-csr", "relation_id": 42}
+        get_outstanding.return_value = {"return-code": 0, "result": json.dumps([rec])}
+
+        vault_get_subject_from_csr.return_value = "subj"
+        vault_is_certificate_valid.return_value = True
+
+        step = vault.ConfigureVaultCAStep(cclient, jhelper, "fake-ca", "fake-chain")
+        step.prompt()
+
+        get_outstanding.assert_called_once_with(step.app, step.model, step.jhelper)
+        load_answers.assert_called_once_with(cclient, step._CONFIG)
+        write_answers.assert_called_once()
+
+    def test_prompt_no_certs(
+        self, cclient, jhelper, load_answers, write_answers, get_outstanding
+    ):
+        get_outstanding.return_value = {"return-code": 0, "result": "[]"}
+        step = vault.ConfigureVaultCAStep(cclient, jhelper, "fake-ca", "fake-chain")
+        step.prompt()
+        load_answers.assert_not_called()
+        write_answers.assert_not_called()
+
+    def test_prompt_invalid_csr(
+        self,
+        cclient,
+        jhelper,
+        load_answers,
+        write_answers,
+        get_subject_from_csr,
+        get_outstanding,
+    ):
+        rec = {"unit_name": "app/0", "csr": "bad", "relation_id": 1}
+        get_outstanding.return_value = {"return-code": 0, "result": json.dumps([rec])}
+        get_subject_from_csr.return_value = None
+
+        step = vault.ConfigureVaultCAStep(cclient, jhelper, "fake-ca", "fake-chain")
+        with pytest.raises(click.ClickException) as exc:
+            step.prompt()
+        assert "Not a valid CSR" in str(exc.value)
+
+        write_answers.assert_not_called()
+
+    def test_prompt_invalid_cert(
+        self,
+        cclient,
+        jhelper,
+        load_answers,
+        write_answers,
+        question_bank,
+        vault_get_subject_from_csr,
+        vault_is_certificate_valid,
+        get_outstanding,
+    ):
+        rec = {"unit_name": "app/0", "csr": "fake", "relation_id": 1}
+        get_outstanding.return_value = {"return-code": 0, "result": json.dumps([rec])}
+        vault_get_subject_from_csr.return_value = "subj"
+
+        question_bank.return_value.certificate.ask.return_value = "invalid-cert"
+        vault_is_certificate_valid.return_value = False
+
+        step = vault.ConfigureVaultCAStep(cclient, jhelper, "fake-ca", "fake-chain")
+        with pytest.raises(click.ClickException) as exc:
+            step.prompt()
+
+        assert "Not a valid certificate" in str(exc.value)
+        write_answers.assert_not_called()
+
+    def test_prompt_error_return_code(
+        self, cclient, jhelper, load_answers, write_answers, get_outstanding
+    ):
+        get_outstanding.return_value = {"return-code": 2}
+        step = vault.ConfigureVaultCAStep(cclient, jhelper, "fake-ca", "fake-chain")
+        with pytest.raises(click.ClickException):
+            step.prompt()
+
+        load_answers.assert_not_called()
+
+    def test_prompt_action_failed(
+        self, cclient, jhelper, load_answers, write_answers, get_outstanding
+    ):
+        get_outstanding.side_effect = ActionFailedException("juju oops")
+        step = vault.ConfigureVaultCAStep(cclient, jhelper, "fake-ca", "fake-chain")
+        with pytest.raises(ActionFailedException):
+            step.prompt()
+
+    def test_prompt_leader_not_found(
+        self, cclient, jhelper, load_answers, write_answers, get_outstanding
+    ):
+        get_outstanding.side_effect = LeaderNotFoundException("no leader")
+        step = vault.ConfigureVaultCAStep(cclient, jhelper, "fake-ca", "fake-chain")
+        with pytest.raises(LeaderNotFoundException):
+            step.prompt()
+
+
+class TestConfigureVaultCAStepRun:
+    def test_run_normal(self, jhelper):
+        jhelper.get_leader_unit.return_value = "lead"
+        jhelper.run_action.return_value = {"return-code": 0}
+        step = vault.ConfigureVaultCAStep(None, jhelper, "fake-ca", "fake-chain")
+        step.process_certs = {
+            "subj": {
+                "csr": "csr",
+                "certificate": "cert",
+            }
+        }
+
+        result = step.run()
+        assert result.result_type == ResultType.COMPLETED
+        jhelper.get_leader_unit.assert_called_once()
+        jhelper.run_action.assert_called_once()
+
+    def test_run_no_certs(self, jhelper):
+        jhelper.get_leader_unit.return_value = "lead"
+        step = vault.ConfigureVaultCAStep(None, jhelper, "fake-ca", "fake-chain")
+        result = step.run()
+        assert result.result_type == ResultType.COMPLETED
+        jhelper.run_action.assert_not_called()
+
+    def test_run_action_error_code(self, jhelper):
+        jhelper.get_leader_unit.return_value = "lead"
+        jhelper.run_action.return_value = {"return-code": 2}
+        step = vault.ConfigureVaultCAStep(None, jhelper, "fake-ca", "fake-chain")
+        step.process_certs = {"s": {"csr": "csr", "certificate": "cert"}}
+
+        result = step.run()
+        assert result.result_type == ResultType.FAILED
+
+    def test_run_action_failed_exception(self, jhelper):
+        jhelper.get_leader_unit.return_value = "lead"
+        jhelper.run_action.side_effect = ActionFailedException("run oops")
+        step = vault.ConfigureVaultCAStep(None, jhelper, "fake-ca", "fake-chain")
+        step.process_certs = {"s": {"csr": "csr", "certificate": "cert"}}
+
+        result = step.run()
+        assert result.result_type == ResultType.FAILED
+        assert "run oops" in result.message
+
+    def test_run_leader_not_found(self, jhelper):
+        jhelper.get_leader_unit.side_effect = LeaderNotFoundException("no leader")
+        step = vault.ConfigureVaultCAStep(None, jhelper, "fake-ca", "fake-chain")
+        step.process_certs = {"s": {"csr": "csr", "certificate": "cert"}}
+
+        result = step.run()
+        assert result.result_type == ResultType.FAILED
+        assert "no leader" in result.message
+
+
+class FakeUnit:
+    def __init__(self, status, message):
+        class WorkloadStatus:
+            def __init__(self, current, message):
+                self.current = current
+                self.message = message
+
+        self.workload_status = WorkloadStatus(status, message)
+        self.workload_status_message = message
+
+
+class FakeApp:
+    def __init__(self, units):
+        if isinstance(units, list):
+            self.units = dict(enumerate(units))
+        else:
+            self.units = units
+
+
+class TestVaultTlsFeatureIsActive:
+    @patch(
+        "sunbeam.features.tls.vault.VaultHelper.get_vault_status",
+        return_value={"initialized": True, "sealed": False},
+    )
+    def test_active_status_short_circuits(self, mock_status):
+        jhelper = Mock()
+        jhelper.get_model_status.return_value = Mock()
+        jhelper.get_leader_unit.return_value = "vault/0"
+
+        unit = FakeUnit(status="active", message="all good")
+        app = FakeApp(units=[unit])
+        jhelper.get_application.return_value = app
+
+        feature = vault.VaultTlsFeature()
+        assert feature.is_vault_application_active(jhelper) is True
+
+    def test_no_units_raises(self):
+        jhelper = Mock()
+        jhelper.get_model_status.return_value = Mock()
+        jhelper.get_leader_unit.return_value = "vault/0"
+        jhelper.get_application.return_value = FakeApp(units=[])
+
+        feature = vault.VaultTlsFeature()
+        with pytest.raises(click.ClickException) as exc:
+            feature.is_vault_application_active(jhelper)
+        assert "has no units" in str(exc.value)
+
+    @patch("sunbeam.features.tls.vault.VaultHelper.get_vault_status")
+    def test_uninitialized_vault_raises(self, mock_status):
+        jhelper = Mock()
+        jhelper.get_model_status.return_value = Mock()
+        jhelper.get_leader_unit.return_value = "vault/0"
+        fake_unit = FakeUnit(status="blocked", message="blocked…")
+        jhelper.get_application.return_value = FakeApp(units=[fake_unit])
+        mock_status.return_value = {"initialized": False, "sealed": False}
+
+        feature = vault.VaultTlsFeature()
+        with pytest.raises(click.ClickException) as exc:
+            feature.is_vault_application_active(jhelper)
+        assert "uninitialized" in str(exc.value)
+
+    @patch("sunbeam.features.tls.vault.VaultHelper.get_vault_status")
+    def test_sealed_vault_raises(self, mock_status):
+        jhelper = Mock()
+        jhelper.get_model_status.return_value = Mock()
+        jhelper.get_leader_unit.return_value = "vault/0"
+        fake_unit = FakeUnit(status="blocked", message="blocked…")
+        jhelper.get_application.return_value = FakeApp(units=[fake_unit])
+        mock_status.return_value = {"initialized": True, "sealed": True}
+
+        feature = vault.VaultTlsFeature()
+        with pytest.raises(click.ClickException) as exc:
+            feature.is_vault_application_active(jhelper)
+        assert "sealed" in str(exc.value)

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -1273,6 +1273,7 @@ class TestMaasDeployK8SApplicationStep:
             "test-model",
         )
         step.ranges = "10.0.0.0/28"
+        step.client.cluster.get_config.return_value = "{}"
         expected_tfvars = {
             "endpoint_bindings": [{"space": "data"}],
             "k8s_config": {
@@ -1281,7 +1282,17 @@ class TestMaasDeployK8SApplicationStep:
                 "load-balancer-l2-mode": True,
                 "node-labels": "sunbeam/deployment=test_deployment",
             },
+            "traefik-config": {
+                "external_hostname": None,
+            },
+            "traefik-public-config": {
+                "external_hostname": None,
+            },
+            "traefik-rgw-config": {
+                "external_hostname": None,
+            },
         }
+
         assert step.extra_tfvars() == expected_tfvars
 
     def test_is_skip_with_public_ranges_error(self, mocker, deployment_k8s):


### PR DESCRIPTION
This PR introduces the TLS Vault feature, which allows the operator to configure Vault (Vault-k8s charm) as an Intermediary CA.

*NOTE:* This PR should not be merged until the following steps are finished:
- Manual-TLS-Certificates has a new stable release with the features from `1/edge`
- The `common_name` configuration for Vault and `external_hostname` for Traefik endpoints are properly defined

*NOTE 2*: This PR adds breaking changes unless the [PR](https://github.com/canonical/sunbeam-terraform/pull/108) from sunbeam-terraform is merge
**NOTE 3**: This PR requires the following [PR](https://github.com/canonical/sunbeam-terraform/pull/113) to be merged inside sunbeam-terraform for keeping 3 different tfvars for traefik endpoints