### PR TITLE
Fix cluster refresh

### DIFF
--- a/sunbeam-python/sunbeam/features/interface/v1/base.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/base.py
@@ -17,10 +17,9 @@ from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.core.common import RiskLevel, SunbeamException, read_config, update_config
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.manifest import FeatureConfig, Manifest, SoftwareConfig
-
-# from sunbeam.feature_manager import FeatureManager
 from sunbeam.features.interface import utils
 from sunbeam.provider.maas.deployment import MAAS_TYPE
+from sunbeam.versions import VarMap
 
 LOG = logging.getLogger(__name__)
 _GROUPS: dict[str, Type["BaseFeatureGroup"]] = {}
@@ -456,7 +455,7 @@ class BaseFeature(BaseRegisterable, Generic[ConfigType]):
         """
         return SoftwareConfig()
 
-    def manifest_attributes_tfvar_map(self) -> dict:
+    def manifest_attributes_tfvar_map(self) -> dict[str, VarMap]:
         """Return terraform var map for the manifest attributes.
 
         Map terraform variable for each manifest attribute.

--- a/sunbeam-python/sunbeam/steps/upgrades/base.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/base.py
@@ -11,7 +11,6 @@ from sunbeam.core.common import BaseStep, Result, ResultType, run_plan
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import JujuHelper
 from sunbeam.core.manifest import Manifest
-from sunbeam.feature_manager import FeatureManager
 
 LOG = logging.getLogger(__name__)
 console = Console()
@@ -34,7 +33,7 @@ class UpgradeFeatures(BaseStep):
 
     def run(self, status: Status | None = None) -> Result:
         """Upgrade features."""
-        FeatureManager.update_features(
+        self.deployment.get_feature_manager().update_features(
             self.deployment, upgrade_release=self.upgrade_release
         )
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/tests/unit/sunbeam/core/test_terraform.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_terraform.py
@@ -85,6 +85,7 @@ class TestTerraformHelper:
             "neutron-channel": "2023.1/stable",
             "neutron-revision": 123,
             "ldap-apps": {"dom1": {"domain-name": "dom1"}},
+            "mysql-config": {"debug": True},
         }
         mocker.patch.object(deployment_mod, "Snap", return_value=snap)
         mocker.patch.object(manifest_mod, "Snap", return_value=snap)
@@ -134,3 +135,7 @@ class TestTerraformHelper:
         # Below are asserts for charm config parameters
         # Assert config values coming from extra_tfvars and in manifest
         assert applied_tfvars.get("glance-config") == {"ceph-osd-replication-count": 5}
+
+        # While mysql-config is not in the manifest, it is in config db,
+        # and mysql-config is one of the preserve vars of the OpenStack plan
+        assert applied_tfvars.get("mysql-config") == {"debug": True}


### PR DESCRIPTION
update_tfvars_and_apply_tf removes from tf vars variables that are in
config db but not in manifest, which is fine for most variables as they
are not direct mapping from manifest to tf plan. But it is not the case
for MySQl variables, which are either: computed by sunbeam (not in
manifest) or in manifest, but are used as same name in the config db.
Introduce concept of preserved variable in a tf plan varmap.

Fix feature manager update features instanciation.
    
Use model from deployment instead of hardcoded names.