### PR TITLE
Increase patch ip pool step timeout

### DIFF
--- a/sunbeam-python/sunbeam/core/steps.py
+++ b/sunbeam-python/sunbeam/core/steps.py
@@ -730,7 +730,7 @@ class PatchLoadBalancerServicesIPPoolStep(BaseStep, abc.ABC):
 
     @tenacity.retry(
         wait=tenacity.wait_fixed(10),
-        stop=tenacity.stop_after_delay(120),
+        stop=tenacity.stop_after_delay(300),
         retry=tenacity.retry_if_exception_type(ValueError),
         reraise=True,
     )


### PR DESCRIPTION
On some system, patching the ip pool takes a bit more time before the address is actually allocated. Increase the timeout to 5 minutes, in lines with other timeouts of the same nature.