### PR TITLE
Configure Tempest with roles in cluster

### DIFF
--- a/sunbeam-python/sunbeam/features/validation/feature.py
+++ b/sunbeam-python/sunbeam/features/validation/feature.py
@@ -57,6 +57,7 @@ VALIDATION_FEATURE_DEPLOY_TIMEOUT = (
     60 * 60
 )  # 60 minutes in seconds, tempest can take some time to initialized
 SUPPORTED_TEMPEST_CONFIG = {"schedule"}
+SUPPORTED_ROLES = ("compute", "control", "storage", "network")
 
 
 class Profile(pydantic.BaseModel):
@@ -149,6 +150,17 @@ class Config(pydantic.BaseModel):
         return schedule
 
 
+def get_enabled_roles(deployment) -> str:
+    """Detect enabled roles in the cluster and return as comma-separated string."""
+    client = deployment.get_client()
+    roles = []
+    for role in SUPPORTED_ROLES:
+        nodes = client.cluster.list_nodes_by_role(role)
+        if nodes:
+            roles.append(role)
+    return ",".join(roles)
+
+
 def parse_config_args(args: list[str]) -> dict[str, str]:
     """Parse key=value args into a valid dictionary of key: values.
 
@@ -191,6 +203,7 @@ class ConfigureValidationStep(BaseStep):
         tfhelper: TerraformHelper,
         manifest: Manifest,
         tfvar_config: str,
+        deployment: Deployment | None = None,
     ):
         super().__init__(
             "Configure validation feature",
@@ -201,6 +214,7 @@ class ConfigureValidationStep(BaseStep):
         self.tfhelper = tfhelper
         self.manifest = manifest
         self.tfvar_config = tfvar_config
+        self.deployment = deployment
 
     def run(self, status: Status | None = None) -> Result:
         """Execute step using terraform."""
@@ -208,12 +222,17 @@ class ConfigureValidationStep(BaseStep):
             # See ValidationFeature.manifest_attributes_tfvar_map
             charms = self.tfhelper.tfvar_map["charms"]
             tempest_k8s_config_var = charms["tempest-k8s"]["config"]
-            if self.config_changes.schedule is None:
-                override_tfvars = {}
-            else:
-                override_tfvars = {
-                    tempest_k8s_config_var: {"schedule": self.config_changes.schedule}
-                }
+            roles = get_enabled_roles(self.deployment)
+            LOG.info(f"OpenStack roles enabled for Tempest: {roles}")
+            override_tfvars: dict[str, Any] = {}
+            if self.config_changes.schedule is not None or roles:
+                override_tfvars[tempest_k8s_config_var] = {}
+                if self.config_changes.schedule is not None:
+                    override_tfvars[tempest_k8s_config_var]["schedule"] = (
+                        self.config_changes.schedule
+                    )
+                if roles:
+                    override_tfvars[tempest_k8s_config_var]["roles"] = roles
             self.tfhelper.update_tfvars_and_apply_tf(
                 self.client,
                 self.manifest,
@@ -263,7 +282,11 @@ class ValidationFeature(OpenStackControlPlaneFeature):
         self, deployment: Deployment, config: FeatureConfig
     ) -> dict:
         """Set terraform variables to enable the application."""
-        return {"enable-validation": True}
+        roles = get_enabled_roles(deployment)
+        return {
+            "enable-validation": True,
+            "tempest-config": {"roles": roles},
+        }
 
     def set_tfvars_on_disable(self, deployment: Deployment) -> dict:
         """Set terraform variables to disable the application."""
@@ -496,6 +519,7 @@ class ValidationFeature(OpenStackControlPlaneFeature):
                     tfhelper,
                     self.manifest,
                     self.get_tfvar_config_key(),
+                    deployment,
                 ),
             ],
             console,

--- a/sunbeam-python/tests/unit/sunbeam/features/test_validation.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_validation.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: 2024 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import MagicMock
+
 import click
 import pytest
 
@@ -118,3 +120,29 @@ class TestValidatorFunction:
         # This is raise by `validated_config_args`
         with pytest.raises(click.ClickException):
             validation_feature.validated_config_args(input_args)
+
+    def test_get_enabled_roles_all(self):
+        deployment = MagicMock()
+        client = MagicMock()
+        deployment.get_client.return_value = client
+        client.cluster.list_nodes_by_role.side_effect = [
+            ["compute"],
+            ["control"],
+            ["storage"],
+            ["network"],
+        ]
+        roles = validation_feature.get_enabled_roles(deployment)
+        assert set(roles.split(",")) == {"compute", "control", "storage", "network"}
+
+    def test_get_enabled_roles_some(self):
+        deployment = MagicMock()
+        client = MagicMock()
+        deployment.get_client.return_value = client
+        client.cluster.list_nodes_by_role.side_effect = [
+            ["compute"],
+            ["control"],
+            [],
+            [],
+        ]
+        roles = validation_feature.get_enabled_roles(deployment)
+        assert set(roles.split(",")) == {"compute", "control"}


### PR DESCRIPTION
This commit will configure tempest-k8s with the roles currently deployed in the cluster. This change supports the 'network' role once available.