### PR TITLE
Update metallb annotations

### DIFF
--- a/sunbeam-python/sunbeam/core/k8s.py
+++ b/sunbeam-python/sunbeam/core/k8s.py
@@ -33,9 +33,9 @@ K8S_KUBECONFIG_KEY = "K8SKubeConfig"
 SERVICE_LB_ANNOTATION = "io.cilium/lb-ipam-ips"
 
 # --- Metallb specific
-METALLB_IP_ANNOTATION = "metallb.universe.tf/loadBalancerIPs"
-METALLB_ADDRESS_POOL_ANNOTATION = "metallb.universe.tf/address-pool"
-METALLB_ALLOCATED_POOL_ANNOTATION = "metallb.universe.tf/ip-allocated-from-pool"
+METALLB_IP_ANNOTATION = "metallb.io/loadBalancerIPs"
+METALLB_ADDRESS_POOL_ANNOTATION = "metallb.io/address-pool"
+METALLB_ALLOCATED_POOL_ANNOTATION = "metallb.io/ip-allocated-from-pool"
 METALLB_INTERNAL_POOL_NAME = "metallb-loadbalancer-ck-loadbalancer"
 
 CREDENTIAL_SUFFIX = "-creds"

--- a/sunbeam-python/sunbeam/core/steps.py
+++ b/sunbeam-python/sunbeam/core/steps.py
@@ -698,7 +698,7 @@ class PatchLoadBalancerServicesIPPoolStep(BaseStep, abc.ABC):
     def _wait_for_ip_allocated_from_pool_annotation_update(
         self, service_name: str, pool_name: str
     ):
-        """Wait until metallb.universe.tf/ip-allocated-from-pool is updated.
+        """Wait until metallb.io/ip-allocated-from-pool is updated.
 
         Wait until the ip-allocated-from-pool annotation is updated to pool_name
         for the service

--- a/sunbeam-python/sunbeam/feature_manager.py
+++ b/sunbeam-python/sunbeam/feature_manager.py
@@ -238,17 +238,14 @@ class FeatureManager:
         :param deployment: Deployment instance.
         :param upgrade_release: Upgrade release flag.
         """
-        for name, feature in self.features().items():
-            if (
-                hasattr(feature, "enabled")
-                and feature.enabled
-                and hasattr(feature, "upgrade_hook")
-            ):
+        for feature in self.enabled_features(deployment):
+            if hasattr(feature, "upgrade_hook"):
                 LOG.debug(f"Upgrading feature {feature.name}")
                 try:
                     feature.upgrade_hook(deployment, upgrade_release=upgrade_release)
                 except TypeError:
                     LOG.debug(
-                        f"Feature {name} does not support upgrades between channels"
+                        f"Feature {feature.name} does not support upgrades between "
+                        "channels"
                     )
                     feature.upgrade_hook(deployment)

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -783,6 +783,18 @@ class ObservabilityFeature(OpenStackControlPlaneFeature):
     def observability_group(self):
         """Manage Observability."""
 
+    def upgrade_hook(
+        self,
+        deployment: Deployment,
+        upgrade_release: bool = False,
+        show_hints: bool = False,
+    ):
+        """Run upgrade.
+
+        :param upgrade_release: Whether to upgrade release
+        """
+        self.run_enable_plans(deployment, FeatureConfig(), show_hints)
+
 
 class EmbeddedObservabilityFeature(ObservabilityFeature):
     name = "observability.embedded"


### PR DESCRIPTION
metallb annotation prefix metallb.universe.tf is
deprecated. Modify to use annotation prefix as
metallb.io

Run PatchLoadBalancer*Steps in refresh command