### PR TITLE
Fix cluster remove

### DIFF
--- a/sunbeam-python/sunbeam/steps/clusterd.py
+++ b/sunbeam-python/sunbeam/steps/clusterd.py
@@ -408,10 +408,10 @@ class ClusterRemoveNodeStep(BaseStep):
             NodeNotExistInClusterException,
         ) as e:
             # Consider these exceptions as soft ones
-            LOG.warning(e)
+            LOG.debug(e)
             return Result(ResultType.COMPLETED)
         except (LastNodeRemovalFromClusterException, Exception) as e:
-            LOG.warning(e)
+            LOG.debug(e)
             return Result(ResultType.FAILED, str(e))
 
 

--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -251,7 +251,7 @@ class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
             "Remove openstack-hypervisor unit from machine",
         )
         self.client = client
-        self.name = name
+        self.node_name = name
         self.jhelper = jhelper
         self.model = model
         self.force = force
@@ -265,10 +265,10 @@ class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
                 ResultType.COMPLETED or ResultType.FAILED otherwise
         """
         try:
-            node = self.client.cluster.get_node_info(self.name)
+            node = self.client.cluster.get_node_info(self.node_name)
             self.machine_id = str(node.get("machineid"))
         except NodeNotExistInClusterException:
-            LOG.debug(f"Machine {self.name} does not exist, skipping.")
+            LOG.debug(f"Machine {self.node_name} does not exist, skipping.")
             return Result(ResultType.SKIPPED)
 
         try:
@@ -343,7 +343,7 @@ class RemoveHypervisorUnitStep(BaseStep, JujuStepHelper):
             LOG.warning(str(e))
             return Result(ResultType.FAILED, str(e))
         try:
-            remove_hypervisor(self.name, self.jhelper)
+            remove_hypervisor(self.node_name, self.jhelper)
         except openstack.exceptions.SDKException as e:
             LOG.error(
                 "Encountered error removing hypervisor references from control plane."

--- a/sunbeam-python/sunbeam/steps/juju.py
+++ b/sunbeam-python/sunbeam/steps/juju.py
@@ -1061,7 +1061,8 @@ class RemoveJujuMachineStep(BaseStep, JujuStepHelper):
             node = self.client.cluster.get_node_info(self.node_name)
             self.machine_id = node.get("machineid", -1)
         except NodeNotExistInClusterException as e:
-            return Result(ResultType.FAILED, str(e))
+            return Result(ResultType.SKIPPED, str(e))
+
         self.model_with_owner = self.get_model_name_with_owner(self.model)
         try:
             machines = self._juju_cmd("machines", "-m", self.model_with_owner)


### PR DESCRIPTION
Step that deals with removing machine from juju
fails when the machine id is not available in
cluster db node table.
The step should skip to make the command
idempotent.