### PR TITLE
Support upgrade release for observability feature

### DIFF
--- a/sunbeam-python/sunbeam/core/terraform.py
+++ b/sunbeam-python/sunbeam/core/terraform.py
@@ -431,7 +431,7 @@ class TerraformHelper:
                 # Exclude all default tfvar keys from the previous terraform
                 # vars applied to the plan. Ignore the keys that should
                 # be preserved.
-                _tfvar_names = set(self._get_tfvar_names()).difference(
+                _tfvar_names = set(self._get_tfvar_names(charms)).difference(
                     self.tfvar_map.get("preserve", [])
                 )
                 updated_tfvars = {

--- a/sunbeam-python/sunbeam/features/dns/feature.py
+++ b/sunbeam-python/sunbeam/features/dns/feature.py
@@ -250,6 +250,10 @@ class DnsFeature(OpenStackControlPlaneFeature):
 
         :param upgrade_release: Whether to upgrade release
         """
+        if upgrade_release:
+            LOG.debug(f"Release upgrade not supported for feature {self.name}")
+            return
+
         super().upgrade_hook(deployment, upgrade_release, show_hints)
         plan: list[BaseStep] = []
         if is_maas_deployment(deployment):

--- a/sunbeam-python/sunbeam/features/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/openstack.py
@@ -408,12 +408,13 @@ class OpenStackControlPlaneFeature(EnableDisableFeature, typing.Generic[ConfigTy
 
         :param upgrade_release: Whether to upgrade release
         """
+        if upgrade_release:
+            LOG.debug(f"Release upgrade not supported for feature {self.name}")
+            return
+
         # Nothig to do if the plan is openstack-plan as it is taken
         # care during control plane refresh
-        if (
-            not upgrade_release
-            or self.tf_plan_location == TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO
-        ):
+        if self.tf_plan_location == TerraformPlanLocation.SUNBEAM_TERRAFORM_REPO:
             LOG.debug(
                 f"Ignore upgrade_hook for feature {self.name}, the corresponding apps"
                 f" will be refreshed as part of Control plane refresh"

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -807,6 +807,8 @@ class ObservabilityFeature(OpenStackControlPlaneFeature):
 
         :param upgrade_release: Whether to upgrade release
         """
+        # Supports --upgrade-release, so no condition required
+        # based on upgrade_release flag
         self.run_enable_plans(deployment, FeatureConfig(), show_hints)
 
 

--- a/sunbeam-python/sunbeam/steps/upgrades/inter_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/inter_channel.py
@@ -24,7 +24,6 @@ from sunbeam.core.juju import (
     run_sync,
 )
 from sunbeam.core.manifest import Manifest
-from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.terraform import TerraformException, TerraformHelper
 from sunbeam.steps.cinder_volume import CONFIG_KEY as CINDER_VOLUME_CONFIG_KEY
 from sunbeam.steps.hypervisor import CONFIG_KEY as HYPERVISOR_CONFIG_KEY
@@ -435,6 +434,16 @@ class ChannelUpgradeCoordinator(UpgradeCoordinator):
 
         Return the steps to complete this upgrade.
         """
+        plan: list[BaseStep] = [UpgradeFeatures(self.deployment, upgrade_release=True)]
+        return plan
+
+        # --release-upgrade implementation is not proper and so the
+        # option is hidden. Bug [1] requires to support the flag,
+        # however to avoid any upgrades on other charms, this is
+        # supported only for charms involved in observability
+        # and rest of the code is commented out.
+        # https://bugs.launchpad.net/snap-openstack/+bug/2115169
+        """
         get_tf = self.deployment.get_tfhelper
         plan = [
             ValidationCheck(self.jhelper, self.manifest),
@@ -490,7 +499,7 @@ class ChannelUpgradeCoordinator(UpgradeCoordinator):
                 UpgradeFeatures(self.deployment, upgrade_release=True),
             ]
         )
-        return plan
+        """
 
     def run_plan(self, show_hints: bool = False) -> None:
         """Execute the upgrade plan."""


### PR DESCRIPTION
Observability charms releaed 1/stable and removed
latest/stable tracks and so release upgrade is
required for observability.

Sunbeam refresh supports --upgrade-release option
which is hidden as it is not functioning properly. In case of --upgrade-release, skip upgrades of
control plane and data plane and all the features. Enable release upgrade only for observability
feature.

Users on observability with latest/stable can run
following command to upgrade observability charms

sunbeam cluster refresh --upgrade-release

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2115169 (cherry picked from commit ba89e9b018d43757271f4fe2eb60c2c8f5f653e0)