### PR TITLE
[stable/2024.1] Change sunbeam terraform branch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -144,6 +144,7 @@ parts:
     after: [terraform]
     plugin: dump
     source: https://github.com/canonical/sunbeam-terraform
+    source-branch: stable/2024.1
     source-depth: 1
     source-type: git
     organize:


### PR DESCRIPTION
Change sunbeam terraform branch in snapcraft to
point to stable/2024.1 branch