### PR TITLE
Add SSO feature

### DIFF
--- a/sunbeam-python/sunbeam/commands/sso.py
+++ b/sunbeam-python/sunbeam/commands/sso.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+import click
+import yaml
+from rich.console import Console
+from rich.table import Table
+
+from sunbeam.clusterd.service import ConfigItemNotFoundException
+from sunbeam.core.common import (
+    FORMAT_TABLE,
+    FORMAT_YAML,
+    BaseStep,
+    read_config,
+    run_plan,
+    str_presenter,
+    update_config,
+)
+from sunbeam.core.deployment import Deployment
+from sunbeam.core.juju import (
+    ActionFailedException,
+    JujuHelper,
+    LeaderNotFoundException,
+)
+from sunbeam.core.openstack import OPENSTACK_MODEL
+from sunbeam.core.terraform import TerraformInitStep
+from sunbeam.steps.juju import RemoveSaasApplicationsStep
+from sunbeam.steps.sso import (
+    APPLICATION_REMOVE_TIMEOUT,
+    SSO_CONFIG_KEY,
+    AddCanonicalProviderStep,
+    AddEntraProviderStep,
+    AddGenericProviderStep,
+    AddGoogleProviderStep,
+    AddOktaProviderStep,
+    RemoveExternalProviderStep,
+    UpdateExternalProviderStep,
+)
+from sunbeam.utils import click_option_show_hints
+
+console = Console()
+
+
+@click.command(name="list")
+@click.pass_context
+@click_option_show_hints
+@click.option(
+    "--format",
+    type=click.Choice([FORMAT_TABLE, FORMAT_YAML]),
+    default=FORMAT_TABLE,
+    help="Output format",
+)
+def list_sso(
+    ctx: click.Context,
+    format: str,
+    show_hints: bool = False,
+) -> None:
+    """List identity providers."""
+    deployment: Deployment = ctx.obj
+    client = deployment.get_client()
+
+    try:
+        cfg = read_config(client, SSO_CONFIG_KEY)
+    except ConfigItemNotFoundException:
+        cfg = {}
+
+    results = {}
+    for k, v in cfg.items():
+        results[k] = {
+            "type": v.get("provider_type", "unknown"),
+            "protocol": v.get("provider_proto", "unknown"),
+            "issuer_url": v.get("config", {}).get("issuer_url", "unknown"),
+        }
+
+    if format == FORMAT_TABLE:
+        table = Table()
+        table.add_column("Name")
+        table.add_column("Provider")
+        table.add_column("Protocol")
+        table.add_row(
+            "Keystone Credentials",
+            "Built-in",
+            "keystone",
+        )
+        for provider, data in results.items():
+            table.add_row(
+                provider,
+                data["type"],
+                data["protocol"],
+            )
+        console.print(table)
+    elif format == FORMAT_YAML:
+        yaml.add_representer(str, str_presenter)
+        console.print(yaml.dump(results))
+
+
+@click.command(name="add")
+@click.argument(
+    "provider-type",
+    type=click.Choice(
+        ["canonical", "google", "entra", "okta", "generic"],
+        case_sensitive=False,
+    ),
+)
+@click.argument(
+    "provider-protocol",
+    type=click.Choice(
+        [
+            "openid",
+        ],
+        case_sensitive=False,
+    ),
+)
+@click.argument("name", type=str)
+@click.option(
+    "--config",
+    type=str,
+    required=False,
+    help="Identity provider configuration",
+)
+@click_option_show_hints
+@click.pass_context
+def add_sso(
+    ctx: click.Context,
+    provider_type: str,
+    provider_protocol: str,
+    name: str,
+    config: str,
+    show_hints: bool,
+) -> None:
+    """Add a new identity provider."""
+    deployment: Deployment = ctx.obj
+    client = deployment.get_client()
+    try:
+        cfg = read_config(client, SSO_CONFIG_KEY)
+    except ConfigItemNotFoundException:
+        cfg = {}
+
+    if name in cfg:
+        click.echo(f"{name} is already enabled.")
+        return
+
+    jhelper = JujuHelper(deployment.juju_controller)
+
+    step_map = {
+        "google": AddGoogleProviderStep,
+        "entra": AddEntraProviderStep,
+        "okta": AddOktaProviderStep,
+        "generic": AddGenericProviderStep,
+        "canonical": AddCanonicalProviderStep,
+    }
+
+    step_cls = step_map.get(provider_type)
+    if not step_cls:
+        raise click.ClickException(f"Cannot handle {provider_type}")
+
+    charm_config: dict[str, str] = {}
+    try:
+        with open(config) as fd:
+            charm_config = yaml.safe_load(fd)
+    except Exception as err:
+        raise click.ClickException(f"Invalid config supplied: {err}")
+
+    step = step_cls(
+        deployment,
+        jhelper,
+        provider_protocol,
+        name,
+        charm_config,
+    )
+
+    plan = [
+        TerraformInitStep(deployment.get_tfhelper("openstack-plan")),
+        step,
+    ]
+    run_plan(plan, console, show_hints)
+    click.echo(f"{name} added.")
+
+
+@click.command(name="remove")
+@click.argument("name", type=str)
+@click.option(
+    "--yes-i-mean-it",
+    is_flag=True,
+    help="Do not prompt for confirmation.",
+)
+@click_option_show_hints
+@click.pass_context
+def remove_sso(ctx: click.Context, name: str, yes_i_mean_it: bool, show_hints: bool):
+    """Remove an identity provider."""
+    deployment: Deployment = ctx.obj
+    client = deployment.get_client()
+    try:
+        cfg = read_config(client, SSO_CONFIG_KEY)
+    except ConfigItemNotFoundException:
+        cfg = {}
+
+    provider = cfg.get(name)
+    if not provider:
+        click.echo(f"{name} does not exist.")
+        return
+
+    if not yes_i_mean_it:
+        msg = f"This action will remove {name}. Are you sure?"
+        click.confirm(msg, abort=True)
+
+    jhelper = JujuHelper(deployment.juju_controller)
+    plan: list[BaseStep] = [
+        TerraformInitStep(deployment.get_tfhelper("openstack-plan")),
+    ]
+    prov_type = provider.get("provider_type", None)
+    if prov_type == "canonical":
+        plan.append(
+            RemoveSaasApplicationsStep(
+                jhelper,
+                OPENSTACK_MODEL,
+                saas_apps_to_delete=[name, f"{name}-cert"],
+                offering_interfaces=["oauth", "certificate_transfer"],
+                wait_timeout=APPLICATION_REMOVE_TIMEOUT,
+            )
+        )
+    else:
+        plan.append(
+            RemoveExternalProviderStep(
+                deployment=deployment,
+                jhelper=jhelper,
+                provider_name=name,
+            )
+        )
+
+    run_plan(plan, console, show_hints)
+    if prov_type == "canonical":
+        del cfg[name]
+        update_config(deployment.get_client(), SSO_CONFIG_KEY, cfg)
+    click.echo(f"{name} removed.")
+
+
+@click.command(name="update")
+@click.argument("name", type=str)
+@click.option(
+    "--secrets-file",
+    type=str,
+    required=True,
+    help="Secrets file containing client_id and client_secret",
+)
+@click_option_show_hints
+@click.pass_context
+def update_sso(ctx: click.Context, name: str, secrets_file: str, show_hints: bool):
+    """Update identity provider."""
+    deployment: Deployment = ctx.obj
+    client = deployment.get_client()
+    try:
+        cfg = read_config(client, SSO_CONFIG_KEY)
+    except ConfigItemNotFoundException:
+        cfg = {}
+
+    if name not in cfg:
+        click.echo(f"{name} does not exist.")
+        return
+
+    secrets: dict[str, str] = {}
+    try:
+        with open(secrets_file) as fd:
+            secrets = yaml.safe_load(fd)
+    except Exception as e:
+        raise click.ClickException(f"Invalid config supplied: {e}")
+
+    jhelper = JujuHelper(deployment.juju_controller)
+    plan = [
+        TerraformInitStep(deployment.get_tfhelper("openstack-plan")),
+        UpdateExternalProviderStep(
+            deployment=deployment,
+            jhelper=jhelper,
+            provider_name=name,
+            secrets=secrets,
+        ),
+    ]
+    run_plan(plan, console, show_hints)
+    click.echo(f"{name} updated.")
+
+
+@click.command(name="get-oidc-redirect-url")
+@click.pass_context
+def get_openid_redirect_uri(ctx: click.Context):
+    """Get the OpenID redirect URI."""
+    deployment: Deployment = ctx.obj
+    jhelper = JujuHelper(deployment.juju_controller)
+    app = "keystone"
+    action_cmd = "get-admin-account"
+
+    try:
+        unit = jhelper.get_leader_unit(app, OPENSTACK_MODEL)
+    except LeaderNotFoundException:
+        raise click.ClickException(f"Unable to get {app} leader")
+
+    try:
+        action_result = jhelper.run_action(unit, OPENSTACK_MODEL, action_cmd)
+    except ActionFailedException:
+        raise click.ClickException(
+            "Unable to retrieve admin account data from Keystone service"
+        )
+    public_url = action_result.get("public-endpoint", "").rstrip("/")
+    if not public_url:
+        raise click.ClickException("Could not determine keystone public URL")
+    redirect_uri = f"{public_url}/OS-FEDERATION/protocols/openid/redirect_uri"
+    click.echo(f"{redirect_uri}")
+
+
+@click.command(name="purge")
+@click_option_show_hints
+@click.option(
+    "--yes-i-mean-it",
+    is_flag=True,
+    help="Do not prompt for confirmation.",
+)
+@click.pass_context
+def purge_sso(
+    ctx: click.Context,
+    show_hints: bool,
+    yes_i_mean_it: bool,
+) -> None:
+    """Remove all identity providers."""
+    deployment: Deployment = ctx.obj
+    jhelper = JujuHelper(deployment.juju_controller)
+    client = deployment.get_client()
+    try:
+        config = read_config(client, SSO_CONFIG_KEY)
+    except ConfigItemNotFoundException:
+        config = {}
+
+    if not yes_i_mean_it and config:
+        msg = (
+            "You have one or more identity providers enabled. "
+            "This action will remove all of them. Are you sure?"
+        )
+        click.confirm(msg, abort=True)
+
+    tfhelper = deployment.get_tfhelper("openstack-plan")
+    remove_idp_plan: list[BaseStep] = [
+        TerraformInitStep(tfhelper),
+    ]
+    saas_to_remove = []
+    for provider, cfg in config.items():
+        if cfg.get("provider_type", None) == "canonical":
+            saas_to_remove.append(provider)
+            saas_to_remove.append(f"{provider}-cert")
+        else:
+            remove_idp_plan.append(
+                RemoveExternalProviderStep(
+                    deployment=deployment,
+                    jhelper=jhelper,
+                    provider_name=provider,
+                )
+            )
+
+    if saas_to_remove:
+        remove_idp_plan.append(
+            RemoveSaasApplicationsStep(
+                jhelper,
+                OPENSTACK_MODEL,
+                saas_apps_to_delete=saas_to_remove,
+                offering_interfaces=["oauth", "certificate_transfer"],
+                wait_timeout=APPLICATION_REMOVE_TIMEOUT,
+            ),
+        )
+    run_plan(remove_idp_plan, console, show_hints)
+    update_config(client, SSO_CONFIG_KEY, {})

--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -214,11 +214,20 @@ class CoreConfig(pydantic.BaseModel):
                 return v.split(",")
             return v
 
+    class _Identity(pydantic.BaseModel):
+        class _IdentityProfile(pydantic.BaseModel):
+            provider: str
+            protocol: str
+            config: dict[str, str]
+
+        profiles: dict[str, _IdentityProfile]
+
     proxy: _ProxyConfig | None = None
     bootstrap: _BootstrapConfig | None = None
     database: str | None = None
     region: str | None = None
     addons: _Addons | None = None
+    identity: _Identity | None = None
     k8s_addons: _K8sAddons | None = pydantic.Field(default=None, alias="k8s-addons")
     traefik_endpoints: dict[str, str] | None = pydantic.Field(
         default=None, alias="traefik-endpoints"

--- a/sunbeam-python/sunbeam/main.py
+++ b/sunbeam-python/sunbeam/main.py
@@ -19,6 +19,7 @@ from sunbeam.commands import openrc as openrc_cmds
 from sunbeam.commands import plans as plans_cmd
 from sunbeam.commands import prepare_node as prepare_node_cmds
 from sunbeam.commands import proxy as proxy_cmds
+from sunbeam.commands import sso as sso_cmd
 from sunbeam.commands import utils as utils_cmds
 from sunbeam.core import deployments as deployments_jobs
 from sunbeam.provider import commands as provider_cmds
@@ -42,6 +43,20 @@ def cli(ctx, quiet, verbose):
     with by initializing the local node. Once the local node has been initialized,
     run the bootstrap process to get a live cloud.
     """
+
+
+@click.group("identity", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
+@click.pass_context
+def identity_group(ctx):
+    """Manage identity settings."""
+    pass
+
+
+@identity_group.group("provider")
+@click.pass_context
+def provider_group(ctx):
+    """Manage identity providers."""
+    pass
 
 
 @click.group("manifest", context_settings=CONTEXT_SETTINGS, cls=CatchGroup)
@@ -98,6 +113,18 @@ def main():
     cli.add_command(launch_cmds.launch)
     cli.add_command(openrc_cmds.openrc)
     cli.add_command(dasboard_url_cmds.dashboard_url)
+
+    # Add identity group
+    cli.add_command(identity_group)
+
+    # Add identity group and commands
+    identity_group.add_command(provider_group)
+    provider_group.add_command(sso_cmd.list_sso)
+    provider_group.add_command(sso_cmd.add_sso)
+    provider_group.add_command(sso_cmd.remove_sso)
+    provider_group.add_command(sso_cmd.update_sso)
+    provider_group.add_command(sso_cmd.get_openid_redirect_uri)
+    provider_group.add_command(sso_cmd.purge_sso)
 
     # Cluster management
     provider_cmds.register_providers()

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -160,6 +160,10 @@ from sunbeam.steps.openstack import (
     PromptDatabaseTopologyStep,
     PromptRegionStep,
 )
+from sunbeam.steps.sso import (
+    DeployIdentityProvidersStep,
+    ValidateIdentityManifest,
+)
 from sunbeam.steps.sunbeam_machine import (
     AddSunbeamMachineUnitsStep,
     DeploySunbeamMachineApplicationStep,
@@ -692,6 +696,7 @@ def bootstrap(
     )
     plan.append(PromptDatabaseTopologyStep(client, manifest, accept_defaults))
     plan.append(PromptRegionStep(client, manifest, accept_defaults))
+    plan.append(ValidateIdentityManifest(client, manifest))
     run_plan(plan, console, show_hints)
 
     update_config(client, DEPLOYMENTS_CONFIG_KEY, deployments.get_minimal_info())
@@ -809,6 +814,14 @@ def bootstrap(
                 topology,
                 deployment.openstack_machines_model,
                 proxy_settings=proxy_settings,
+            )
+        )
+        plan1.append(
+            DeployIdentityProvidersStep(
+                deployment,
+                openstack_tfhelper,
+                jhelper,
+                manifest,
             )
         )
         # Redeploy of Microceph is required to fill terraform vars

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -175,6 +175,10 @@ from sunbeam.steps.openstack import (
     PromptDatabaseTopologyStep,
     PromptRegionStep,
 )
+from sunbeam.steps.sso import (
+    DeployIdentityProvidersStep,
+    ValidateIdentityManifest,
+)
 from sunbeam.steps.sunbeam_machine import (
     AddSunbeamMachineUnitsStep,
     DeploySunbeamMachineApplicationStep,
@@ -624,6 +628,7 @@ def deploy(
 
     plan2.append(PromptDatabaseTopologyStep(client, manifest, accept_defaults))
     plan2.append(PromptRegionStep(client, manifest, accept_defaults))
+    plan2.append(ValidateIdentityManifest(client, manifest))
     plan2.append(TerraformInitStep(tfhelper_sunbeam_machine))
     plan2.append(
         DeploySunbeamMachineApplicationStep(
@@ -748,6 +753,14 @@ def deploy(
             topology,
             deployment.openstack_machines_model,
             proxy_settings=proxy_settings,
+        )
+    )
+    plan2.append(
+        DeployIdentityProvidersStep(
+            deployment,
+            tfhelper_openstack_deploy,
+            jhelper,
+            manifest,
         )
     )
     plan2.append(

--- a/sunbeam-python/sunbeam/steps/sso.py
+++ b/sunbeam-python/sunbeam/steps/sso.py
@@ -1,0 +1,1012 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import logging
+import queue
+from typing import Any
+
+import click
+import requests
+from rich.console import Console
+from rich.status import Status
+
+from sunbeam.clusterd.client import Client
+from sunbeam.clusterd.service import (
+    ConfigItemNotFoundException,
+)
+from sunbeam.core import questions
+from sunbeam.core.common import (
+    BaseStep,
+    Result,
+    ResultType,
+    read_config,
+    update_config,
+    update_status_background,
+)
+from sunbeam.core.deployment import Deployment
+from sunbeam.core.juju import (
+    JujuHelper,
+    JujuStepHelper,
+    JujuWaitException,
+)
+from sunbeam.core.manifest import Manifest
+from sunbeam.core.openstack import OPENSTACK_MODEL
+from sunbeam.core.terraform import (
+    TerraformException,
+    TerraformHelper,
+)
+from sunbeam.steps.openstack import CONFIG_KEY
+
+LOG = logging.getLogger(__name__)
+_GOOGLE_ISSUER_URL = "https://accounts.google.com"
+_ENTRA_ISSUER_URL = "https://login.microsoftonline.com/%s/v2.0"
+_CONFIG = "FeatureSSOExternalIDPConfig-%s"
+SSO_CONFIG_KEY = "SSOFeatureConfigKey"
+_OKTA_ISSUER_URL = "https://%s.okta.com"
+APPLICATION_DEPLOY_TIMEOUT = 900  # 15 minutes
+APPLICATION_REMOVE_TIMEOUT = 300  # 5 minutes
+_BASE_QUESTIONS: dict[str, questions.Question] = {
+    "client_id": questions.PromptQuestion("OAuth client-id"),
+    "client_secret": questions.PasswordPromptQuestion(
+        "OAuth client-secret",
+        password=True,
+    ),
+    "label": questions.PromptQuestion("Label for this provider (optional)"),
+}
+_OKTA_QUESTIONS = _BASE_QUESTIONS | {
+    "okta_org": questions.PromptQuestion("Your Okta org (eg: dev-123456)")
+}
+
+_ENTRA_QUESTIONS = _BASE_QUESTIONS | {
+    "microsoft_tenant": questions.PromptQuestion("Microsoft tenant ID")
+}
+_GENERIC_PROVIDER_QUESTIONS = _BASE_QUESTIONS | {
+    "issuer_url": questions.PromptQuestion(
+        "OpenID Issuer URL",
+        description=(
+            "The issuer URL is a unique identifier for an "
+            "OpenID provider. The URL must be https, it "
+            "may have an optional path and is used when "
+            "the provider type is set to generic."
+        ),
+    )
+}
+
+_CANONICAL_IAM_QUESTIONS: dict[str, questions.Question] = {
+    "oauth_offer": questions.PromptQuestion(
+        "OAuth juju offer",
+        description=(
+            "This is a juju offer created in another juju "
+            "model. The offer must expose a relation which "
+            "implements the 'oauth' interface. This is "
+            "mandatory when the provider type is set to "
+            "'canonical' and is typically used to relate "
+            "to a hydra charm deployed by canonical identity "
+            "platform, but other chrms may implement the "
+            "same interface."
+        ),
+    ),
+    "cert_offer": questions.PromptQuestion(
+        "OAuth cert authority",
+        description=(
+            "When relating to a charm that implements the "
+            "'oauth' interface, you may need to also relate "
+            "to a certificate authority that implements the "
+            "send-cert interface"
+        ),
+    ),
+}
+
+console = Console()
+
+
+class _OIDCValidationMixin:
+    def _validate_oidc_config(self, name: str, idp: dict) -> None:
+        """Basic check for openid connect discovery document."""
+        issuer_url = idp.get("config", {}).get("issuer_url", None)
+        if not issuer_url:
+            raise ValueError(
+                f"could not find issuer_url for {name}",
+            )
+
+        issuer_url = issuer_url.rstrip("/")
+        discovery_ep = f"{issuer_url}/.well-known/openid-configuration"
+        cfg_req = requests.get(discovery_ep, timeout=10)
+        cfg_req.raise_for_status()
+        data = cfg_req.json()
+
+        # see: https://openid.net/specs/openid-connect-discovery-1_0.html
+        mandatory_openid_fields = [
+            "issuer",
+            "authorization_endpoint",
+            "token_endpoint",
+            "jwks_uri",
+            "response_types_supported",
+            "subject_types_supported",
+            "id_token_signing_alg_values_supported",
+        ]
+        missing = []
+        for required in mandatory_openid_fields:
+            if required not in data:
+                missing.append(required)
+
+        if missing:
+            raise ValueError(
+                (
+                    f"Missing required fields in OIDC discovery document: "
+                    f"{', '.join(missing)}"
+                ),
+            )
+
+
+class RemoveExternalProviderStep(BaseStep, JujuStepHelper):
+    def __init__(
+        self,
+        deployment: Deployment,
+        jhelper: JujuHelper,
+        provider_name,
+    ):
+        super().__init__(
+            "Remove external IDP",
+            f"Removing external IDP {provider_name}",
+        )
+        self.client = deployment.get_client()
+        self.jhelper = jhelper
+        self.deployment = deployment
+        self.tfhelper = deployment.get_tfhelper("openstack-plan")
+        self._provider_name = provider_name
+
+    def run(self, status: Status | None = None) -> Result:
+        """Apply terraform configuration to deploy openstack application."""
+        try:
+            tfvars = read_config(self.client, CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        try:
+            cfg = read_config(self.client, SSO_CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            cfg = {}
+
+        if self._provider_name in tfvars.get("sso-providers", {}):
+            del tfvars["sso-providers"][self._provider_name]
+            self.tfhelper.write_tfvars(tfvars)
+            update_config(self.client, CONFIG_KEY, tfvars)
+
+        if self._provider_name in cfg:
+            del cfg[self._provider_name]
+            update_config(self.client, SSO_CONFIG_KEY, cfg)
+
+        try:
+            self.tfhelper.apply()
+        except TerraformException as e:
+            return Result(ResultType.FAILED, str(e))
+
+        try:
+            self.jhelper.wait_application_gone(
+                [f"keystone-idp-{self._provider_name}"],
+                OPENSTACK_MODEL,
+                timeout=APPLICATION_REMOVE_TIMEOUT,
+            )
+            self.jhelper.wait_until_active(
+                OPENSTACK_MODEL,
+                ["keystone"],
+                timeout=APPLICATION_REMOVE_TIMEOUT,
+            )
+        except (JujuWaitException, TimeoutError) as e:
+            return Result(ResultType.FAILED, str(e))
+
+        # Clear answers on delete.
+        questions.write_answers(
+            self.client,
+            _CONFIG % self._provider_name,
+            {},
+        )
+        return Result(ResultType.COMPLETED)
+
+
+class UpdateExternalProviderStep(BaseStep, JujuStepHelper):
+    def __init__(
+        self,
+        deployment: Deployment,
+        jhelper: JujuHelper,
+        provider_name,
+        secrets: dict[str, str],
+    ):
+        super().__init__(
+            "Update external IDP",
+            f"Updating external IDP {provider_name}",
+        )
+        self.client = deployment.get_client()
+        self.jhelper = jhelper
+        self.deployment = deployment
+        self.tfhelper = deployment.get_tfhelper("openstack-plan")
+        self._provider_name = provider_name
+        self._secrets = self._validate_secrets(secrets)
+
+    def _validate_secrets(self, data: dict[str, str]):
+        if not data:
+            raise click.ClickException(
+                "Invalid config supplied. Config must contain key/value pairs"
+            )
+
+        required_configs: dict[str, str | None] = {
+            "client_id": None,
+            "client_secret": None,
+        }
+
+        for key, _ in required_configs.items():
+            val = data.get(
+                key,
+                data.get(
+                    key.replace("_", "-"),
+                    None,
+                ),
+            )
+            if not val:
+                raise click.ClickException(f"Missing {key} in secrets file")
+            required_configs[key] = val
+        return required_configs
+
+    def run(self, status: Status | None = None) -> Result:
+        """Apply terraform configuration to deploy openstack application."""
+        try:
+            tfvars = read_config(self.client, CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        try:
+            cfg = read_config(self.client, SSO_CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            cfg = {}
+
+        if self._provider_name not in cfg:
+            return Result(ResultType.FAILED, "Provider not found")
+
+        provider_type = cfg[self._provider_name].get("provider_type", None)
+        if not provider_type or provider_type == "canonical":
+            return Result(
+                ResultType.FAILED,
+                (
+                    f"Provider {self._provider_name} of type "
+                    "{provider_type} cannot be updated"
+                ),
+            )
+
+        if "config" not in cfg[self._provider_name]:
+            return Result(
+                ResultType.FAILED,
+                f"Provider {self._provider_name} is in an invalid state",
+            )
+
+        cfg[self._provider_name]["config"]["client_id"] = self._secrets["client_id"]
+        cfg[self._provider_name]["config"]["client_secret"] = self._secrets[
+            "client_secret"
+        ]
+        update_config(self.client, SSO_CONFIG_KEY, cfg)
+
+        if tfvars.get("sso-providers"):
+            tfvars["sso-providers"][self._provider_name] = cfg[self._provider_name][
+                "config"
+            ]
+        else:
+            tfvars["sso-providers"] = {
+                self._provider_name: cfg[self._provider_name]["config"]
+            }
+        self.tfhelper.write_tfvars(tfvars)
+        update_config(self.client, CONFIG_KEY, tfvars)
+        try:
+            self.tfhelper.apply()
+        except TerraformException as e:
+            return Result(ResultType.FAILED, str(e))
+
+        charm_name = "keystone-idp-{}".format(self._provider_name)
+        apps = ["keystone", "horizon", charm_name]
+        app_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        task = update_status_background(self, apps, app_queue, status)
+        try:
+            self.jhelper.wait_until_active(
+                OPENSTACK_MODEL,
+                apps,
+                timeout=APPLICATION_DEPLOY_TIMEOUT,
+                queue=app_queue,
+            )
+        except (JujuWaitException, TimeoutError) as e:
+            return Result(ResultType.FAILED, str(e))
+        finally:
+            task.stop()
+
+        return Result(ResultType.COMPLETED)
+
+
+class _BaseProviderStep(BaseStep, JujuStepHelper):
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        provider_type: str,
+        deployment: Deployment,
+        jhelper: JujuHelper,
+        provider_protocol: str,
+        provider_name: str,
+        charm_config: dict[str, str],
+    ):
+        super().__init__(name, description)
+        self.client = deployment.get_client()
+        self.jhelper = jhelper
+        self.deployment = deployment
+        self.tfhelper = deployment.get_tfhelper("openstack-plan")
+
+        self._provider_name = provider_name
+        self._provider_type = provider_type
+        self._provider_protocol = provider_protocol
+        self._questions: dict[str, questions.Question] = {}
+        self._preseed = self._compose_preseed_from_config(charm_config)
+
+    def _get_preseed_map(self):
+        raise NotImplementedError()
+
+    def _compose_preseed_from_config(self, data: dict[str, str]):
+        preseed = self._get_preseed_map()
+
+        if not data:
+            return preseed
+
+        for key, val in preseed.items():
+            preseed[key] = data.get(
+                key,
+                data.get(
+                    key.replace("_", "-"),
+                    None,
+                ),
+            )
+        return preseed
+
+    def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user."""
+        return True
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        return Result(ResultType.COMPLETED)
+
+    @property
+    def _charm_config(self):
+        raise NotImplementedError()
+
+    def _ask(self, q_bank: questions.QuestionBank, variables: dict):
+        raise NotImplementedError()
+
+    def prompt(
+        self,
+        console: Console | None = None,
+        show_hint: bool = False,
+    ) -> None:
+        """Prompt the user for any data not in the config.
+
+        Based on the provider type, prompt the user for any options
+        that are not specified in the config.
+
+        :param console: the console to prompt on
+        :type console: rich.console.Console (Optional)
+        """
+        variables = questions.load_answers(
+            self.client,
+            _CONFIG % self._provider_name,
+        )
+        sso_bank = questions.QuestionBank(
+            questions=self._questions,
+            console=console,
+            preseed=self._preseed,
+            previous_answers=variables,
+            show_hint=show_hint,
+        )
+        variables = self._ask(sso_bank, variables)
+        questions.write_answers(self.client, _CONFIG % self._provider_name, variables)
+
+
+class _BaseExternalProviderStep(_BaseProviderStep, _OIDCValidationMixin):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self._issuer_url = None
+        self._client_id = None
+        self._client_secret = None
+        self._label = None
+        self._questions = copy.deepcopy(_BASE_QUESTIONS)
+
+    def _get_preseed_map(self):
+        return {
+            "client_id": None,
+            "client_secret": None,
+            "label": None,
+        }
+
+    def _ask(self, q_bank: questions.QuestionBank, variables: dict):
+        self._client_id = q_bank.client_id.ask()
+        self._client_secret = q_bank.client_secret.ask()
+        self._label = q_bank.label.ask()
+
+        if not all([self._client_id, self._client_secret]):
+            raise click.ClickException("client_id and client_secret are mandatory")
+
+        if not self._label:
+            label_name = self._provider_name.capitalize()
+            self._label = f"Log in with {label_name}"
+
+        variables["label"] = self._label
+        variables["client_id"] = self._client_id
+        variables["client_secret"] = self._client_secret
+        return variables
+
+    @property
+    def _charm_config(self):
+        if not all(
+            [
+                self._issuer_url,
+                self._client_id,
+                self._client_secret,
+                self._label,
+                self._provider_name,
+            ]
+        ):
+            raise click.ClickException("invalid state for provider step")
+        return {
+            "provider": "generic",
+            "provider_id": self._provider_name,
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+            "label": self._label,
+            "issuer_url": self._issuer_url,
+        }
+
+    def run(self, status: Status | None = None) -> Result:
+        try:
+            tfvars = read_config(self.client, CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        try:
+            cfg = read_config(self.client, SSO_CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            cfg = {}
+
+        idp = cfg.get(self._provider_name)
+        if idp:
+            cfg[self._provider_name]["config"] = self._charm_config
+        else:
+            cfg[self._provider_name] = {
+                "config": self._charm_config,
+                "provider_type": self._provider_type,
+                "provider_proto": self._provider_protocol,
+            }
+        update_config(self.client, SSO_CONFIG_KEY, cfg)
+
+        try:
+            self._validate_oidc_config(self._provider_name, cfg[self._provider_name])
+        except Exception as e:
+            return Result(ResultType.FAILED, str(e))
+
+        for provider, data in cfg.items():
+            if data.get("provider_type", None) == "canonical":
+                continue
+            if tfvars.get("sso-providers"):
+                tfvars["sso-providers"][provider] = data["config"]
+            else:
+                tfvars["sso-providers"] = {provider: data["config"]}
+
+        self.tfhelper.write_tfvars(tfvars)
+        update_config(self.client, CONFIG_KEY, tfvars)
+
+        try:
+            self.tfhelper.apply()
+        except TerraformException as e:
+            return Result(ResultType.FAILED, str(e))
+
+        charm_name = f"keystone-idp-{self._provider_name}"
+        apps = ["keystone", "horizon", charm_name]
+        app_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        task = update_status_background(self, apps, app_queue, status)
+        try:
+            self.jhelper.wait_until_active(
+                OPENSTACK_MODEL,
+                apps,
+                timeout=APPLICATION_DEPLOY_TIMEOUT,
+                queue=app_queue,
+            )
+        except (JujuWaitException, TimeoutError) as e:
+            return Result(ResultType.FAILED, str(e))
+        finally:
+            task.stop()
+
+        return Result(ResultType.COMPLETED)
+
+
+class AddGoogleProviderStep(_BaseExternalProviderStep):
+    def __init__(self, *args, **kw):
+        super().__init__(
+            "Add google external IDP",
+            "Adding google external IDP",
+            "google",
+            *args,
+            **kw,
+        )
+        self._issuer_url = _GOOGLE_ISSUER_URL
+
+
+class AddOktaProviderStep(_BaseExternalProviderStep):
+    def __init__(self, *args, **kw):
+        super().__init__(
+            "Add okta external IDP",
+            "Adding okta external IDP",
+            "okta",
+            *args,
+            **kw,
+        )
+        self._questions = copy.deepcopy(_OKTA_QUESTIONS)
+
+    def _get_preseed_map(self):
+        preseed = super()._get_preseed_map()
+        preseed["okta_org"] = None
+        return preseed
+
+    def _ask(self, q_bank: questions.QuestionBank, variables: dict):
+        variables = super()._ask(q_bank, variables)
+        okta_org = q_bank.okta_org.ask()
+        if not okta_org:
+            raise click.ClickException("okta_org is mandatory")
+        self._issuer_url = _OKTA_ISSUER_URL % okta_org
+        variables["okta_org"] = okta_org
+        return variables
+
+
+class AddEntraProviderStep(_BaseExternalProviderStep):
+    def __init__(self, *args, **kw):
+        super().__init__(
+            "Add entra external IDP",
+            "Adding entra external IDP",
+            "entra",
+            *args,
+            **kw,
+        )
+        self._questions = copy.deepcopy(_ENTRA_QUESTIONS)
+
+    def _get_preseed_map(self):
+        preseed = super()._get_preseed_map()
+        preseed["microsoft_tenant"] = None
+        return preseed
+
+    def _ask(self, q_bank: questions.QuestionBank, variables: dict):
+        variables = super()._ask(q_bank, variables)
+        tenant_id = q_bank.microsoft_tenant.ask()
+        if not tenant_id:
+            raise click.ClickException("microsoft_tenant is mandatory")
+        self._issuer_url = _ENTRA_ISSUER_URL % tenant_id
+        variables["microsoft_tenant"] = tenant_id
+        return variables
+
+
+class AddGenericProviderStep(_BaseExternalProviderStep):
+    def __init__(self, *args, **kw):
+        super().__init__(
+            "Add generic external IDP",
+            "Adding generic external IDP",
+            "generic",
+            *args,
+            **kw,
+        )
+        self._questions = copy.deepcopy(_GENERIC_PROVIDER_QUESTIONS)
+
+    def _get_preseed_map(self):
+        preseed = super()._get_preseed_map()
+        preseed["issuer_url"] = None
+        return preseed
+
+    def _ask(self, q_bank: questions.QuestionBank, variables: dict):
+        variables = super()._ask(q_bank, variables)
+        issuer_url = q_bank.issuer_url.ask()
+        if not issuer_url:
+            raise click.ClickException("issuer_url is mandatory")
+        self._issuer_url = issuer_url
+        variables["issuer_url"] = issuer_url
+        return variables
+
+
+class AddCanonicalProviderStep(_BaseProviderStep):
+    def __init__(self, *args, **kw):
+        super().__init__(
+            "Add canonical IDP",
+            "Adding canonical IDP",
+            "canonical",
+            *args,
+            **kw,
+        )
+        self._oauth_offer = None
+        self._cert_offer = None
+        self._questions = copy.deepcopy(_CANONICAL_IAM_QUESTIONS)
+
+    def _get_preseed_map(self):
+        return {
+            "oauth_offer": None,
+            "cert_offer": None,
+        }
+
+    @property
+    def _charm_config(self):
+        if not self._oauth_offer:
+            raise click.ClickException("Missing oauth offer")
+        return {
+            "oauth_offer": self._oauth_offer,
+            "cert_offer": self._cert_offer,
+        }
+
+    def _ask(self, q_bank: questions.QuestionBank, variables: dict):
+        self._oauth_offer = q_bank.oauth_offer.ask()
+        self._cert_offer = q_bank.cert_offer.ask()
+
+        if not self._oauth_offer:
+            raise click.ClickException("oauth_offer is mandatory")
+
+        variables["oauth_offer"] = self._oauth_offer
+        variables["cert_offer"] = self._cert_offer
+        return variables
+
+    def run(self, status: Status | None = None) -> Result:
+        """Run configure steps."""
+        try:
+            cfg = read_config(self.client, SSO_CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            cfg = {}
+
+        idp = cfg.get(self._provider_name)
+        if idp:
+            cfg[self._provider_name]["config"] = self._charm_config
+        else:
+            cfg[self._provider_name] = {
+                "config": self._charm_config,
+                "provider_type": self._provider_type,
+                "provider_proto": self._provider_protocol,
+            }
+        update_config(self.client, SSO_CONFIG_KEY, cfg)
+
+        oauth_offer = cfg[self._provider_name]["config"]["oauth_offer"]
+        try:
+            self.jhelper.consume_offer(
+                OPENSTACK_MODEL,
+                oauth_offer,
+                self._provider_name,
+            )
+            self.integrate(
+                OPENSTACK_MODEL,
+                f"{self._provider_name}",
+                "keystone:oauth",
+            )
+        except Exception as e:
+            return Result(ResultType.FAILED, str(e))
+
+        cert_offer = cfg[self._provider_name]["config"].get("cert_offer")
+        cert_saas_name = f"{self._provider_name}-cert"
+        if cert_offer:
+            try:
+                self.jhelper.consume_offer(
+                    OPENSTACK_MODEL,
+                    cert_offer,
+                    cert_saas_name,
+                )
+                self.integrate(
+                    OPENSTACK_MODEL,
+                    f"{cert_saas_name}",
+                    "keystone:receive-ca-cert",
+                )
+            except Exception as e:
+                return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)
+
+
+class ValidateIdentityManifest(BaseStep, _OIDCValidationMixin):
+    _provider_question_map = {
+        "google": _BASE_QUESTIONS,
+        "okta": _OKTA_QUESTIONS,
+        "entra": _ENTRA_QUESTIONS,
+        "generic": _GENERIC_PROVIDER_QUESTIONS,
+    }
+
+    def __init__(
+        self,
+        client: Client,
+        manifest: Manifest | None = None,
+    ):
+        super().__init__("Identity manifest", "Validating identity manifest")
+        self.client = client
+        self.manifest = manifest
+        self.variables: dict = {}
+
+    def _issuer_url(self, provider: str, config: dict[str, str | None]):
+        if provider == "google":
+            return _GOOGLE_ISSUER_URL
+        if provider == "okta":
+            return _OKTA_ISSUER_URL % config["okta_org"]
+        if provider == "entra":
+            return _ENTRA_ISSUER_URL % config["microsoft_tenant"]
+        if provider == "generic":
+            return config["issuer_url"]
+        raise click.ClickException(
+            f"Cannot determine issuer_url for provider type {provider}"
+        )
+
+    def _charm_config(
+        self,
+        name: str,
+        provider: str,
+        protocol: str,
+        config: dict[str, str | None],
+    ):
+        if not config.get("label"):
+            config["label"] = f"Log in with {name}"
+        return {
+            "provider": "generic",
+            "provider_id": name,
+            "client_id": config["client_id"],
+            "client_secret": config["client_secret"],
+            "label": config["label"],
+            "issuer_url": self._issuer_url(provider, config),
+        }
+
+    def _canonical_charm_config(
+        self, name: str, provider: str, protocol: str, config: dict[str, str]
+    ):
+        oauth_offer = config.get(
+            "oauth_offer",
+            config.get("oauth-offer", None),
+        )
+        cert_offer = config.get(
+            "cert_offer",
+            config.get("cert-offer", None),
+        )
+        if not oauth_offer:
+            raise click.ClickException(f"Missing oauth_offer for {name}")
+        return {
+            "oauth_offer": oauth_offer,
+            "cert_offer": cert_offer,
+        }
+
+    def _external_charm_config(
+        self, name: str, provider: str, protocol: str, config: dict[str, str]
+    ) -> dict[str, Any]:
+        questions = self._provider_question_map.get(provider, None)
+        if not questions:
+            raise click.ClickException(f"Unknown provider type {provider} for {name}")
+
+        missing_keys = []
+        norm_config = {}
+        for key in questions:
+            norm_key = key.replace("-", "_")
+            cfg_val = config.get(
+                norm_key,
+                config.get(
+                    norm_key.replace("_", "-"),
+                    None,
+                ),
+            )
+            if not cfg_val:
+                missing_keys.append(key)
+            norm_config[norm_key] = cfg_val
+
+        if missing_keys:
+            raise click.ClickException(
+                f"Missing config for provider {name} ({provider}): "
+                f"{', '.join(missing_keys)}"
+            )
+
+        parsed_conf = self._charm_config(name, provider, protocol, norm_config)
+        self._validate_oidc_config(name, {"config": parsed_conf})
+        return parsed_conf
+
+    def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user.
+
+        :return: True if the step can ask the user for prompts,
+                 False otherwise
+        """
+        return False
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        if not self.manifest or not self.manifest.core.config.identity:
+            return Result(ResultType.SKIPPED)
+
+        if not self.manifest.core.config.identity.profiles:
+            return Result(ResultType.SKIPPED)
+
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Status | None) -> Result:
+        """Run the step to completion.
+
+        Invoked when the step is run and returns a ResultType to indicate
+        :return:
+        """
+        try:
+            cfg = read_config(self.client, SSO_CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            cfg = {}
+
+        if not self.manifest:
+            return Result(ResultType.COMPLETED)
+
+        if not self.manifest.core.config.identity:
+            return Result(ResultType.COMPLETED)
+
+        profiles = self.manifest.core.config.identity.profiles
+        if not profiles:
+            return Result(ResultType.COMPLETED)
+
+        try:
+            for name, config in profiles.items():
+                cfg[name] = {
+                    "provider_type": config.provider,
+                    "provider_proto": config.protocol,
+                }
+                if config.provider == "canonical":
+                    cfg[name]["config"] = self._canonical_charm_config(
+                        name,
+                        config.provider,
+                        config.protocol,
+                        config.config,
+                    )
+                else:
+                    cfg[name]["config"] = self._external_charm_config(
+                        name,
+                        config.provider,
+                        config.protocol,
+                        config.config,
+                    )
+            update_config(self.client, SSO_CONFIG_KEY, cfg)
+        except Exception as err:
+            return Result(ResultType.FAILED, str(err))
+
+        return Result(ResultType.COMPLETED)
+
+
+class DeployIdentityProvidersStep(BaseStep, JujuStepHelper):
+    """Deploy identity providers on bootstrap."""
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+    ):
+        super().__init__("Identity providers", "Deploying identity providers")
+        self.client = deployment.get_client()
+        self.manifest = manifest
+        self.tfhelper = tfhelper
+        self.jhelper = jhelper
+
+    def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user.
+
+        :return: True if the step can ask the user for prompts,
+                 False otherwise
+        """
+        return False
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        if not self.manifest or not self.manifest.core.config.identity:
+            return Result(ResultType.SKIPPED)
+
+        if not self.manifest.core.config.identity.profiles:
+            return Result(ResultType.SKIPPED)
+
+        try:
+            state = self.tfhelper.pull_state()
+            self._has_tf_resources = bool(state.get("resources"))
+        except TerraformException:
+            LOG.debug("Failed to pull state", exc_info=True)
+
+        self._has_juju_resources = self.jhelper.model_exists(OPENSTACK_MODEL)
+
+        if not self._has_tf_resources and not self._has_juju_resources:
+            return Result(ResultType.SKIPPED)
+
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Status | None) -> Result:
+        """Run the step to completion.
+
+        Invoked when the step is run and returns a ResultType to indicate
+        :return:
+        """
+        try:
+            tfvars = read_config(self.client, CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            tfvars = {}
+
+        try:
+            cfg = read_config(self.client, SSO_CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            cfg = {}
+
+        apps = ["keystone", "horizon"]
+        canonical_providers = {}
+        for provider, data in cfg.items():
+            if data.get("provider_type", None) == "canonical":
+                canonical_providers[provider] = data
+                continue
+            if tfvars.get("sso-providers"):
+                tfvars["sso-providers"][provider] = data["config"]
+            else:
+                tfvars["sso-providers"] = {provider: data["config"]}
+            apps.append(f"keystone-idp-{provider}")
+
+        self.tfhelper.write_tfvars(tfvars)
+        update_config(self.client, CONFIG_KEY, tfvars)
+
+        try:
+            self.tfhelper.apply()
+        except TerraformException as e:
+            return Result(ResultType.FAILED, str(e))
+
+        app_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        task = update_status_background(self, apps, app_queue, status)
+        try:
+            self.jhelper.wait_until_active(
+                OPENSTACK_MODEL,
+                apps,
+                timeout=APPLICATION_DEPLOY_TIMEOUT,
+                queue=app_queue,
+            )
+        except (JujuWaitException, TimeoutError) as e:
+            return Result(ResultType.FAILED, str(e))
+        finally:
+            task.stop()
+
+        for provider, data in canonical_providers.items():
+            oauth_offer = data["config"]["oauth_offer"]
+            try:
+                self.jhelper.consume_offer(
+                    OPENSTACK_MODEL,
+                    oauth_offer,
+                    provider,
+                )
+                self.integrate(
+                    OPENSTACK_MODEL,
+                    f"{provider}",
+                    "keystone:oauth",
+                )
+            except Exception as e:
+                return Result(ResultType.FAILED, str(e))
+
+            cert_offer = data["config"].get("cert_offer")
+            cert_saas_name = f"{provider}-cert"
+            if cert_offer:
+                try:
+                    self.jhelper.consume_offer(
+                        OPENSTACK_MODEL,
+                        cert_offer,
+                        cert_saas_name,
+                    )
+                    self.integrate(
+                        OPENSTACK_MODEL,
+                        f"{cert_saas_name}",
+                        "keystone:receive-ca-cert",
+                    )
+                except Exception as e:
+                    return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -158,6 +158,12 @@ DEPLOY_OPENSTACK_TFVAR_MAP: VarMap = {
     ],
 }
 
+# kratos-external-idp-integrator is used to enable external IDP integration.
+DEPLOY_OPENSTACK_TFVAR_MAP["charms"]["kratos-external-idp-integrator"] = {
+    "channel": "kratos-idp-channel",
+    "revision": "kratos-idp-revision",
+}
+
 # mysql-k8s supports a config map when deployed in many-mysql mode
 DEPLOY_OPENSTACK_TFVAR_MAP["charms"]["mysql-k8s"]["config-map"] = "mysql-config-map"
 # mysql-k8s supports a storage map when deployed in many-mysql mode

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_sso.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_sso.py
@@ -1,0 +1,315 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock, patch
+
+import click
+import pytest
+
+from sunbeam.clusterd.service import ConfigItemNotFoundException
+from sunbeam.core.common import ResultType
+from sunbeam.steps.sso import (
+    AddCanonicalProviderStep,
+    AddEntraProviderStep,
+    AddGenericProviderStep,
+    AddGoogleProviderStep,
+    AddOktaProviderStep,
+    RemoveExternalProviderStep,
+    UpdateExternalProviderStep,
+)
+
+
+@pytest.fixture()
+def config_store():
+    return {}
+
+
+@pytest.fixture()
+def read_config(config_store):
+    with patch("sunbeam.steps.sso.read_config") as mock_read:
+
+        def side_effect(client, key):
+            if key in config_store:
+                return config_store[key]
+            raise ConfigItemNotFoundException()
+
+        mock_read.side_effect = side_effect
+        yield mock_read
+
+
+@pytest.fixture()
+def update_config(config_store):
+    with patch("sunbeam.steps.sso.update_config") as mock_update:
+
+        def side_effect(client, key, value):
+            config_store[key] = value
+
+        mock_update.side_effect = side_effect
+        yield mock_update
+
+
+@pytest.fixture()
+def mock_requests_get():
+    response_data = {}
+
+    def _set_json(data):
+        response_data.clear()
+        response_data.update(data)
+
+    with patch("requests.get") as mock_get:
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.side_effect = lambda: response_data
+        mock_get.return_value = mock_response
+        yield _set_json, mock_get
+
+
+@pytest.fixture()
+def load_answers():
+    with patch("sunbeam.steps.sso.questions.load_answers") as p:
+        yield p
+
+
+@pytest.fixture()
+def write_answers():
+    with patch("sunbeam.steps.sso.questions.write_answers") as p:
+        yield p
+
+
+class BaseExternalProviderTest:
+    step_class = None
+    provider_name = "test-idp"
+    charm_config = {
+        "client-id": "test-client",
+        "client-secret": "test-secret",
+        "label": "Test Label",
+    }
+    fake_oidc_doc = {
+        "issuer": "https://example.com",
+        "authorization_endpoint": "https://example.com/auth",
+        "token_endpoint": "https://example.com/token",
+        "jwks_uri": "https://example.com/jwks",
+        "response_types_supported": ["code"],
+        "subject_types_supported": ["public"],
+        "id_token_signing_alg_values_supported": ["RS256"],
+    }
+
+    def setup_method(self):
+        self.deployment = Mock()
+        self.jhelper = Mock()
+
+    def _get_step(self):
+        return self.step_class(
+            self.deployment,
+            self.jhelper,
+            "openid",
+            self.provider_name,
+            self.charm_config,
+        )
+
+    def test_is_skip(self):
+        step = self._get_step()
+        result = step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_has_prompts(self):
+        step = self._get_step()
+        assert step.has_prompts()
+
+    def test_prompt_with_empty_answers(self, load_answers, write_answers):
+        load_answers.return_value = {}
+        step = self._get_step()
+
+        for k, v in list(step._questions.items()):
+            step._questions[k].ask = Mock(return_value="")
+        with pytest.raises(
+            click.ClickException, match="client_id and client_secret are mandatory"
+        ):
+            step.prompt()
+        # When all prompts are empty, we fail at the common questions, which are
+        # the client_id and client_secret.
+        step._questions["client_id"].ask.assert_called_once()
+        step._questions["client_secret"].ask.assert_called_once()
+
+    def test_run_success(
+        self, read_config, update_config, mock_requests_get, load_answers, write_answers
+    ):
+        set_json, mock_get = mock_requests_get
+        set_json(self.fake_oidc_doc)
+        load_answers.return_value = {}
+
+        step = self._get_step()
+        step.prompt()
+        result = step.run()
+
+        assert result.result_type == ResultType.COMPLETED
+        mock_get.assert_called_once()
+
+
+class TestGoogleProvider(BaseExternalProviderTest):
+    step_class = AddGoogleProviderStep
+
+
+class TestOktaProvider(BaseExternalProviderTest):
+    step_class = AddOktaProviderStep
+    charm_config = {
+        "client-id": "test-client",
+        "client-secret": "test-secret",
+        "label": "Test Label",
+        "okta_org": "test-org",
+    }
+
+    def test_missing_okta_org_asks_for_input(self, load_answers, write_answers):
+        load_answers.return_value = {}
+        step = self._get_step()
+
+        step._questions["okta_org"].ask = Mock(return_value="dummy")
+        step.prompt()
+        step._questions["okta_org"].ask.assert_called_once()
+
+    def test_missing_okta_org_will_err(self, load_answers, write_answers):
+        load_answers.return_value = {}
+        step = self._get_step()
+
+        step._questions["okta_org"].ask = Mock(return_value="")
+        with pytest.raises(click.ClickException, match="okta_org is mandatory"):
+            step.prompt()
+        step._questions["okta_org"].ask.assert_called_once()
+
+
+class TestEntraProvider(BaseExternalProviderTest):
+    step_class = AddEntraProviderStep
+    charm_config = {
+        "client-id": "test-client",
+        "client-secret": "test-secret",
+        "label": "Test Label",
+        "microsoft_tenant": "tenant-123",
+    }
+
+    def test_missing_tenant_asks_for_input(self, load_answers, write_answers):
+        load_answers.return_value = {}
+        step = self._get_step()
+
+        step._questions["microsoft_tenant"].ask = Mock(return_value="dummy")
+        step.prompt()
+        step._questions["microsoft_tenant"].ask.assert_called_once()
+
+    def test_missing_tenant_will_err(self, load_answers, write_answers):
+        load_answers.return_value = {}
+        step = self._get_step()
+
+        step._questions["microsoft_tenant"].ask = Mock(return_value="")
+        with pytest.raises(click.ClickException, match="microsoft_tenant is mandatory"):
+            step.prompt()
+        step._questions["microsoft_tenant"].ask.assert_called_once()
+
+
+class TestGenericProvider(BaseExternalProviderTest):
+    step_class = AddGenericProviderStep
+    charm_config = {
+        "client-id": "test-client",
+        "client-secret": "test-secret",
+        "label": "Test Label",
+        "issuer-url": "https://example.com",
+    }
+
+    def test_missing_issuer_url_asks_for_input(self, load_answers, write_answers):
+        load_answers.return_value = {}
+        step = self._get_step()
+
+        step._questions["issuer_url"].ask = Mock(return_value="dummy")
+        step.prompt()
+        step._questions["issuer_url"].ask.assert_called_once()
+
+    def test_missing_issuer_url_will_err(self, load_answers, write_answers):
+        load_answers.return_value = {}
+        step = self._get_step()
+
+        step._questions["issuer_url"].ask = Mock(return_value="")
+        with pytest.raises(click.ClickException, match="issuer_url is mandatory"):
+            step.prompt()
+        step._questions["issuer_url"].ask.assert_called_once()
+
+
+class TestCanonicalProvider:
+    def test_prompt_validation(self, load_answers, write_answers):
+        load_answers.return_value = {}
+        step = AddCanonicalProviderStep(Mock(), Mock(), "openid", "canon-idp", {})
+        step._questions["oauth_offer"].ask = Mock(return_value="")
+        step._questions["cert_offer"].ask = Mock(return_value="")
+        with pytest.raises(click.ClickException, match="oauth_offer is mandatory"):
+            step.prompt()
+
+
+class TestRemoveExternalProviderStep:
+    def test_remove_provider(self, read_config, update_config):
+        deployment = Mock()
+        mock_client = Mock()
+        mock_client.cluster.update_config = Mock()
+        deployment.get_client.return_value = mock_client
+        tfhelper = Mock()
+        deployment.get_tfhelper.return_value = tfhelper
+
+        config_store = {
+            "TerraformVarsOpenstack": {"sso-providers": {"test-idp": {}}},
+            "SSOFeatureConfigKey": {"test-idp": {}},
+        }
+
+        read_config.side_effect = lambda client, key: config_store[key]
+
+        step = RemoveExternalProviderStep(
+            deployment,
+            Mock(),
+            "test-idp",
+        )
+        step.tfhelper = tfhelper
+        result = step.run()
+        assert result.result_type == ResultType.COMPLETED
+        update_config.assert_any_call(mock_client, "SSOFeatureConfigKey", {})
+        update_config.assert_any_call(
+            mock_client,
+            "TerraformVarsOpenstack",
+            {"sso-providers": {}},
+        )
+
+
+class TestUpdateExternalProviderStep:
+    def test_update_provider(self, read_config, update_config):
+        deployment = Mock()
+        deployment.get_client.return_value = "client"
+        deployment.get_tfhelper.return_value = Mock()
+        provider_name = "test-idp"
+        secrets = {"client_id": "id", "client_secret": "secret"}
+
+        config_store = {
+            "TerraformVarsOpenstack": {},
+            "SSOFeatureConfigKey": {
+                provider_name: {
+                    "provider_type": "okta",
+                    "config": {"client_id": "old", "client_secret": "old"},
+                }
+            },
+        }
+
+        read_config.side_effect = lambda client, key: config_store[key]
+
+        step = UpdateExternalProviderStep(
+            deployment,
+            Mock(),
+            provider_name,
+            secrets,
+        )
+        step.tfhelper = Mock()
+        result = step.run()
+        assert result.result_type == ResultType.COMPLETED
+        update_config.assert_any_call(
+            "client",
+            "SSOFeatureConfigKey",
+            config_store["SSOFeatureConfigKey"],
+        )
+        update_config.assert_any_call(
+            "client",
+            "TerraformVarsOpenstack",
+            config_store["TerraformVarsOpenstack"],
+        )
+        step.tfhelper.apply.assert_called_once()


### PR DESCRIPTION
This change adds SSO enablement in the sunbeam command. There are two methods through which SSO enablement is done:

* The oauth interface
* The external_provider interface

The oauth interface is used to relate to canonical identity platform or any other suite that implements the same kind of functionality. The enablement of this type of integration, requires the consumption of an offer from an existing model, managed externally. Because we use the remote application name of these types of integration, to generate a label for this provider, changes have been made to allow the consumption of a remote offer, with an alias. Changes have also been made to wait for a SAAS app to be removed before returning from the existing remove SAAS step. This allows us to properly add and remove oauth based integrations.

The external_provider is used to integrate IDPs like Google, Okta, Entra or any other IDP that implements OpenID Connect such as Keycloak. This is done via an integrator charm that implements the external_provider provider interface. In this implementation we're reusing the kratos-external-integrator charm.

Depends-on: https://github.com/canonical/sunbeam-terraform/pull/112