### PR TITLE
Support control role maintenance mode

### DIFF
--- a/sunbeam-python/sunbeam/features/maintenance/checks.py
+++ b/sunbeam-python/sunbeam/features/maintenance/checks.py
@@ -2,18 +2,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import Any
+import typing
+from collections.abc import Mapping
 
 from rich.console import Console
 
 from sunbeam.clusterd.client import Client
 from sunbeam.core.checks import Check
+from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import (
     ActionFailedException,
     ApplicationNotFoundException,
+    ExecFailedException,
     JujuActionHelper,
+    JujuException,
     JujuHelper,
     UnitNotFoundException,
+)
+from sunbeam.core.k8s import (
+    K8S_APP_NAME,
+    K8S_DATASTORE_CONFIG,
+    K8S_DEFAULT_JUJU_CONTROLLER_NAMESPACE,
+    K8S_DQLITE_SVC_NAME,
+    fetch_pods,
+    find_node,
 )
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.openstack_api import (
@@ -21,10 +33,24 @@ from sunbeam.core.openstack_api import (
     guests_on_hypervisor,
 )
 from sunbeam.core.watcher import WATCHER_APPLICATION
+from sunbeam.lazy import LazyImport
+from sunbeam.provider.maas.deployment import is_maas_deployment
+from sunbeam.steps.k8s import (
+    K8SError,
+    K8SNodeNotFoundError,
+    KubeClientError,
+    get_kube_client,
+)
+
+if typing.TYPE_CHECKING:
+    import lightkube.core.client as l_client
+else:
+    l_client = LazyImport("lightkube.core.client")
 from sunbeam.steps.microceph import APPLICATION as _MICROCEPH_APPLICATION
 
 console = Console()
 LOG = logging.getLogger(__name__)
+COMMAND_TIMEOUT = 60
 
 
 class InstancesStatusCheck(Check):
@@ -191,7 +217,7 @@ class MicroCephMaintenancePreflightCheck(Check):
         jhelper: JujuHelper,
         model: str,
         node: str,
-        action_params: dict[str, Any],
+        action_params: dict[str, typing.Any],
         force: bool,
     ):
         super().__init__(
@@ -271,3 +297,374 @@ class WatcherApplicationExistsCheck(Check):
             )
             return False
         return True
+
+
+class NodeExistCheck(Check):
+    """Check if the node is in the cluster."""
+
+    def __init__(self, node: str, cluster_status: dict[str, typing.Any]):
+        super().__init__(
+            "Check if the node is in the cluster.",
+            "Checking if the node is in the cluster.",
+        )
+        self.node = node
+        self.cluster_status = cluster_status
+
+    def run(self) -> bool:
+        """Check if the node is in the cluster."""
+        if not self.cluster_status.get(self.node):
+            self.message = f"'{self.node}' does not exist in cluster."
+            return False
+        return True
+
+
+class NoLastNodeCheck(Check):
+    """Check if the cluster has more than one node."""
+
+    def __init__(self, cluster_status: dict[str, typing.Any], force: bool = False):
+        super().__init__(
+            "Check if the cluster has more than one node.",
+            "Checking if the cluster has more than one node.",
+        )
+        self.force = force
+        self.cluster_status = cluster_status
+
+    def run(self) -> bool:
+        """Check if the cluster has more than one node."""
+        if len(self.cluster_status) > 1:
+            return True
+
+        if self.force:
+            LOG.debug("Ignore issue: only one node error")
+            return True
+
+        self.message = (
+            "cannot enable maintenance mode because there is only one node in the"
+            " cluster."
+        )
+        return False
+
+
+class NoLastControlRoleCheck(Check):
+    """Check if the cluster has more than one node with active control role."""
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        cluster_status: dict[str, typing.Any],
+        force: bool = False,
+    ):
+        super().__init__(
+            "Check if the cluster has more than one node with active control role.",
+            "Checking if the cluster has more than one node with active control role.",
+        )
+        self.force = force
+        self.deployment = deployment
+        self.cluster_status = cluster_status
+
+    def run(self) -> bool:
+        """Check if the cluster has only one active control role."""
+        try:
+            kube_client = get_kube_client(self.deployment.get_client())
+        except KubeClientError:
+            self.message = "failed to get k8s client"
+            return False
+
+        num_active_control_roles = 0
+        for node, status in self.cluster_status.items():
+            if "control" not in status:
+                LOG.debug("%s is not an control role node", node)
+                continue
+            if not self._is_active_control_role_node(node, kube_client):
+                LOG.debug("%s is not an active control role node", node)
+                continue
+            LOG.debug("%s is an active control role node", node)
+            num_active_control_roles += 1
+
+        if num_active_control_roles > 1:
+            return True
+
+        if self.force:
+            LOG.debug("Ignore issue: only one active control role error")
+            return True
+
+        self.message = (
+            "cannot enable maintenance mode because there is only one node with"
+            " active control role in the cluster."
+        )
+        return False
+
+    def _is_active_control_role_node(
+        self, name: str, kube_client: "l_client.Client"
+    ) -> bool:
+        """Check if the node is a node with active control role.
+
+        Current, a node with "active" control role is defined as a node with control
+        role (or a k8s node) and is uncordoned (or not unschedulable).
+        """
+        try:
+            node = find_node(kube_client, name)
+        except (K8SNodeNotFoundError, K8SError):
+            return False
+        if node.spec and not node.spec.unschedulable:
+            return True
+        return False
+
+
+class K8sDqliteRedundancyCheck(Check):
+    """Check if the k8s dqlite has enough redundancy."""
+
+    def __init__(
+        self,
+        node: str,
+        jhelper: JujuHelper,
+        deployment: Deployment,
+        force: bool = False,
+    ):
+        super().__init__(
+            "Check if the k8s dqlite has enough redundancy.",
+            "Checking if the k8s dqlite has enough redundancy.",
+        )
+        self.node = node
+        self.force = force
+        self.jhelper = jhelper
+        self.deployment = deployment
+
+    def run(self) -> bool:
+        """Check if the k8s dqlite has enough redundancy."""
+        datastore = self._get_k8s_configs().get(K8S_DATASTORE_CONFIG, "")
+        if datastore != "dqlite":
+            LOG.debug(
+                "Skipped checking %s redundancy: %s bootstrap datastore is not dqlte",
+                K8S_DQLITE_SVC_NAME,
+                K8S_APP_NAME,
+            )
+            return True
+
+        this_k8s_unit_name = self._get_this_k8s_unit_name(self.node)
+
+        total_k8s_dqlite_svcs = 0
+        remaining_active_k8s_dqlite_svcs = 0
+        for k8s_unit_name in self._get_k8s_unit_names():
+            total_k8s_dqlite_svcs += 1
+            if this_k8s_unit_name == k8s_unit_name:
+                continue  # don't count this node
+            if self._has_active_k8s_dqlite_svc(k8s_unit_name):
+                remaining_active_k8s_dqlite_svcs += 1
+
+        min_k8s_dqlite_svcs = total_k8s_dqlite_svcs // 2 + 1
+
+        if remaining_active_k8s_dqlite_svcs >= min_k8s_dqlite_svcs:
+            return True
+
+        if self.force:
+            LOG.debug("Ignore issue: not enough %s error", K8S_DQLITE_SVC_NAME)
+            return True
+
+        self.message = (
+            "cannot enable maintenance mode because there is not enough"
+            f" {K8S_DQLITE_SVC_NAME} in the cluster to maintain quorom"
+            f" (want {min_k8s_dqlite_svcs} for a {total_k8s_dqlite_svcs} node k8s"
+            f" cluster, but will have {remaining_active_k8s_dqlite_svcs} left after"
+            " enabling maintenance mode for this node)."
+        )
+
+        return False
+
+    def _get_k8s_configs(self) -> Mapping:
+        """Return the config of all k8s app."""
+        try:
+            config = self.jhelper.get_app_config(
+                K8S_APP_NAME, self.deployment.openstack_machines_model
+            )
+            LOG.debug("Got config %s for %s", config, K8S_APP_NAME)
+        except (ApplicationNotFoundException, JujuException) as e:
+            LOG.debug("%s", str(e))
+            return {}
+        return config
+
+    def _get_k8s_unit_names(self) -> list[str]:
+        """Return the names of all k8s units."""
+        try:
+            k8s_application = self.jhelper.get_application(
+                K8S_APP_NAME, self.deployment.openstack_machines_model
+            )
+            LOG.debug("Got %s application", k8s_application)
+        except ApplicationNotFoundException as e:
+            LOG.debug("%s", str(e))
+            return []
+        return list(k8s_application.units.keys())
+
+    def _get_this_k8s_unit_name(self, node: str) -> str:
+        """Return the name of the k8s unit in this node."""
+        try:
+            return JujuActionHelper.get_unit(
+                self.deployment.get_client(),
+                self.jhelper,
+                self.deployment.openstack_machines_model,
+                node,
+                K8S_APP_NAME,
+            )
+        except UnitNotFoundException:
+            LOG.debug("cannot find %s unit in '%s'", K8S_APP_NAME, node)
+            return ""
+
+    def _has_active_k8s_dqlite_svc(self, k8s_unit_name: str) -> bool:
+        """Check if the k8s unit has active k8s dqlite svc."""
+        try:
+            result = self.jhelper.run_cmd_on_machine_unit_payload(
+                k8s_unit_name,
+                self.deployment.openstack_machines_model,
+                f"snap services {K8S_DQLITE_SVC_NAME} | grep active",
+                timeout=COMMAND_TIMEOUT,
+            )
+            LOG.debug(result)
+            status = result.stdout.split()[2]
+        except (ExecFailedException, IndexError) as e:
+            LOG.debug("%s", str(e))
+            return False
+        return "active" == status
+
+
+class NoJujuControllerPodCheck(Check):
+    """Check if the node has juju controller pods."""
+
+    def __init__(self, node: str, deployment: Deployment):
+        super().__init__(
+            "Check if there are juju contoller pods in the node.",
+            "Checking if there are juju contoller pods in the node.",
+        )
+        self.node = node
+        self.deployment = deployment
+
+    def run(self) -> bool:
+        """Check if the node has juju controller pods."""
+        if is_maas_deployment(self.deployment):
+            LOG.debug(
+                "Skipped checking juju controller pods. MAAS deployment have"
+                " juju-controller role instead of control role."
+            )
+            return True
+
+        juju_controller = self.deployment.juju_controller
+        if juju_controller and juju_controller.is_external:
+            LOG.debug(
+                "Skipped checking juju controller pods. Juju controller pod is not"
+                " managed by Sunbeam for manual bare metal provider with an external."
+            )
+            return True
+
+        try:
+            juju_controller_pods = self._fetch_juju_controller_pods()
+        except KubeClientError:
+            self.message = "Failed to get k8s client"
+            return False
+
+        has_juju_controller_pods = False
+        for pod in juju_controller_pods:
+            # Found juju controller pod in this node
+            if pod.spec and pod.spec.nodeName == self.node:
+                LOG.debug(
+                    "Found juju controller pod '%s' in '%s'",
+                    pod.metadata.name,
+                    self.node,
+                )
+                has_juju_controller_pods = True
+
+        if not has_juju_controller_pods:
+            return True
+
+        self.message = (
+            f"cannot enable maintenance mode for '{self.node}' because this"
+            " node hosts juju controller pods."
+        )
+        return False
+
+    def _is_juju_controller_pod(self, pod) -> bool:
+        """Check if the pod is a juju controller pod or not."""
+        return "controller" in pod.metadata.name
+
+    def _fetch_juju_controller_pods(self) -> list:
+        """Fetch juju controller pods in the default k8s juju controller namespace."""
+        kube_client = get_kube_client(
+            self.deployment.get_client(),
+            K8S_DEFAULT_JUJU_CONTROLLER_NAMESPACE,
+        )
+        pods = fetch_pods(kube_client, K8S_DEFAULT_JUJU_CONTROLLER_NAMESPACE)
+        return list(filter(self._is_juju_controller_pod, pods))
+
+
+class ControlRoleNodeCordonedCheck(Check):
+    """Check if the node is cordoned."""
+
+    def __init__(self, node: str, deployment: Deployment, force: bool = False):
+        super().__init__(
+            "Check if the node is cordoned.",
+            "Checking if the node is cordoned.",
+        )
+        self.node = node
+        self.force = force
+        self.deployment = deployment
+
+    def run(self) -> bool:
+        """Check if the node is cordoned."""
+        try:
+            kube_client = get_kube_client(self.deployment.get_client())
+        except KubeClientError:
+            self.message = "failed to get k8s client"
+            return False
+
+        try:
+            node = find_node(kube_client, self.node)
+        except (K8SNodeNotFoundError, K8SError):
+            self.message = f"failed to get k8s node: '{self.node}'"
+            return False
+
+        if node.spec and node.spec.unschedulable:
+            return True
+
+        if self.force:
+            LOG.debug("Ignore issue: node is not cordoned.")
+            return True
+
+        self.message = "node is not cordoned."
+
+        return False
+
+
+class ControlRoleNodeUncordonedCheck(Check):
+    """Check if the node is uncordoned."""
+
+    def __init__(self, node: str, deployment: Deployment, force: bool = False):
+        super().__init__(
+            "Check if the node is uncordoned.",
+            "Checking if the node is uncordoned.",
+        )
+        self.node = node
+        self.force = force
+        self.deployment = deployment
+
+    def run(self) -> bool:
+        """Check if the node is uncordoned."""
+        try:
+            kube_client = get_kube_client(self.deployment.get_client())
+        except KubeClientError:
+            self.message = "failed to get k8s client"
+            return False
+
+        try:
+            node = find_node(kube_client, self.node)
+        except (K8SNodeNotFoundError, K8SError):
+            self.message = f"failed to get k8s node: '{self.node}'"
+            return False
+
+        if node.spec and not node.spec.unschedulable:
+            return True
+
+        if self.force:
+            LOG.debug("Ignore issue: node is not uncordoned.")
+            return True
+
+        self.message = "node is not uncordoned."
+
+        return False

--- a/sunbeam-python/sunbeam/features/maintenance/commands.py
+++ b/sunbeam-python/sunbeam/features/maintenance/commands.py
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
+import abc
 import logging
+from typing import Any
 
 import click
 from rich.console import Console
@@ -18,19 +20,524 @@ from sunbeam.features.maintenance import checks
 from sunbeam.features.maintenance.utils import (
     OperationGoal,
     OperationViewer,
-    get_node_status,
+    get_cluster_status,
 )
 from sunbeam.steps.hypervisor import EnableHypervisorStep
 from sunbeam.steps.maintenance import (
+    CordonControlRoleNodeStep,
     CreateWatcherHostMaintenanceAuditStep,
     CreateWatcherWorkloadBalancingAuditStep,
+    DrainControlRoleNodeStep,
     MicroCephActionStep,
     RunWatcherAuditStep,
+    UncordonControlRoleNodeStep,
 )
 from sunbeam.utils import click_option_show_hints, pass_method_obj
 
 console = Console()
 LOG = logging.getLogger(__name__)
+
+
+class CommandCancelledError(Exception):
+    """Command cancelled error."""
+
+
+class MaintenanceCommand(abc.ABC):
+    """Base class for any maintenance mode command.
+
+    The maintenance mode command should follow check-apply-verify pattern for consistent
+    behaviors. This base class only provides the overall pattern.
+
+    Check: Run the pre-flight checks before running any the core commands.
+    Apply: Run the core commands related to maintenance mode operations.
+    Verify: Run the verification steps to ensure that the cloud reaches expected state.
+    """
+
+    @abc.abstractmethod
+    def check(self, console: Console) -> None:
+        """Run pre-flight checks."""
+
+    @abc.abstractmethod
+    def apply(self, console: Console, show_hints: bool, plan_results: dict) -> None:
+        """Run the core commands."""
+
+    @abc.abstractmethod
+    def verify(self, console: Console) -> None:
+        """Run verification steps."""
+
+    @abc.abstractmethod
+    def dry_run(self, console: Console, show_hints: bool) -> dict:
+        """Dry run command steps."""
+
+    def __call__(self, console: Console, show_hints: bool, dry_run: bool) -> None:
+        """Run the commands following check-apply-verify order."""
+        try:
+            self.check(console)
+        except click.ClickException as e:
+            err_message = e.message
+            help_message = (
+                "Pre-flight checks failed, please consult the documentation to"
+                " understand what are the pre-flight checks and how to address"
+                " those failures before enabling maintenance mode:"
+                " https://canonical-openstack.readthedocs-hosted.com/en/latest"
+                "/explanation/maintenance-mode/"
+            )
+            raise click.ClickException(f"{err_message}\n{help_message}") from e
+
+        plan_results = self.dry_run(console, show_hints)
+        if dry_run:
+            return
+
+        try:
+            self.apply(console, show_hints, plan_results)
+        except CommandCancelledError as e:
+            console.print(str(e))
+        except click.ClickException as e:
+            raise e
+        else:
+            self.verify(console)
+
+
+class EnableMaintenance(MaintenanceCommand):
+    """Command to enable maintenance mode."""
+
+    def __init__(
+        self,
+        node: str,
+        deployment: Deployment,
+        cluster_status: dict[str, Any],
+        force: bool = False,
+        stop_osds: bool = False,
+        enable_ceph_crush_rebalancing: bool = False,
+    ):
+        self.node = node
+        self.deployment = deployment
+        self.cluster_status = cluster_status
+        self.force = force
+        self.stop_osds = stop_osds
+        self.enable_ceph_crush_rebalancing = enable_ceph_crush_rebalancing
+
+        self.model = deployment.openstack_machines_model
+        self.client = deployment.get_client()
+        self.jhelper = JujuHelper(deployment.juju_controller)
+        self.ops_viewer = OperationViewer(self.node, OperationGoal.EnableMaintenance)
+
+    def check(self, console: Console) -> None:
+        """Run pre-flight checks."""
+        node_status = self.cluster_status.get(self.node, "")
+
+        preflight_checks: list[Check] = [
+            checks.NodeExistCheck(self.node, self.cluster_status),
+            checks.NoLastNodeCheck(self.cluster_status, force=self.force),
+        ]
+
+        if "compute" in node_status:
+            preflight_checks += [
+                checks.WatcherApplicationExistsCheck(self.jhelper),
+                checks.InstancesStatusCheck(
+                    jhelper=self.jhelper, node=self.node, force=self.force
+                ),
+                checks.NoEphemeralDiskCheck(
+                    jhelper=self.jhelper, node=self.node, force=self.force
+                ),
+            ]
+
+        if "storage" in node_status:
+            preflight_checks += [
+                checks.MicroCephMaintenancePreflightCheck(
+                    client=self.client,
+                    jhelper=self.jhelper,
+                    node=self.node,
+                    model=self.model,
+                    force=self.force,
+                    action_params={
+                        "name": self.node,
+                        "stop-osds": self.stop_osds,
+                        "set-noout": not self.enable_ceph_crush_rebalancing,
+                    },
+                )
+            ]
+
+        if "control" in node_status:
+            preflight_checks += [
+                checks.NoLastControlRoleCheck(
+                    self.deployment,
+                    self.cluster_status,
+                    force=self.force,
+                ),
+                checks.K8sDqliteRedundancyCheck(
+                    self.node,
+                    self.jhelper,
+                    self.deployment,
+                    force=self.force,
+                ),
+                checks.NoJujuControllerPodCheck(
+                    self.node,
+                    self.deployment,
+                ),
+            ]
+
+        run_preflight_checks(preflight_checks, console)
+
+    def apply(self, console: Console, show_hints: bool, plan_results: dict) -> None:
+        """Run the core commands."""
+        node_status = self.cluster_status.get(self.node, "")
+
+        confirm = self.ops_viewer.prompt()
+        if not confirm:
+            raise CommandCancelledError("Operation Cancelled!")
+
+        operation_plan: list[BaseStep] = []
+
+        if "compute" in node_status:
+            audit_info = get_step_message(
+                plan_results, CreateWatcherHostMaintenanceAuditStep
+            )
+            operation_plan.append(
+                RunWatcherAuditStep(
+                    deployment=self.deployment,
+                    node=self.node,
+                    audit=audit_info["audit"],
+                )
+            )
+
+        if "storage" in node_status:
+            operation_plan.append(
+                MicroCephActionStep(
+                    client=self.client,
+                    node=self.node,
+                    jhelper=self.jhelper,
+                    model=self.model,
+                    action_name="enter-maintenance",
+                    action_params={
+                        "name": self.node,
+                        "set-noout": not self.enable_ceph_crush_rebalancing,
+                        "stop-osds": self.stop_osds,
+                        "dry-run": False,
+                        "ignore-check": True,
+                    },
+                )
+            )
+
+        if "control" in node_status:
+            operation_plan += [
+                CordonControlRoleNodeStep(
+                    self.node,
+                    self.client,
+                    self.jhelper,
+                    self.model,
+                    dry_run=False,
+                ),
+                DrainControlRoleNodeStep(
+                    self.node,
+                    self.client,
+                    self.jhelper,
+                    self.model,
+                    dry_run=False,
+                ),
+            ]
+
+        operation_plan_results = run_plan(operation_plan, console, show_hints, True)
+
+        self.ops_viewer.check_operation_succeeded(operation_plan_results)
+
+    def verify(self, console: Console) -> None:
+        """Run verification steps."""
+        node_status = self.cluster_status.get(self.node, "")
+
+        post_checks: list[Check] = []
+
+        if "compute" in node_status:
+            post_checks += [
+                checks.NovaInDisableStatusCheck(
+                    jhelper=self.jhelper, node=self.node, force=self.force
+                ),
+                checks.NoInstancesOnNodeCheck(
+                    jhelper=self.jhelper, node=self.node, force=self.force
+                ),
+            ]
+
+        if "control" in node_status:
+            post_checks += [
+                checks.ControlRoleNodeCordonedCheck(
+                    self.node, self.deployment, force=self.force
+                ),
+            ]
+
+        run_preflight_checks(post_checks, console)
+
+        console.print(f"Enable maintenance for node: {self.node}")
+
+    def dry_run(self, console: Console, show_hints: bool) -> dict:
+        """Dry run command steps."""
+        node_status = self.cluster_status.get(self.node, "")
+
+        generate_operation_plan: list[BaseStep] = []
+
+        if "compute" in node_status:
+            generate_operation_plan.append(
+                CreateWatcherHostMaintenanceAuditStep(
+                    deployment=self.deployment,
+                    node=self.node,
+                )
+            )
+
+        if "storage" in node_status:
+            generate_operation_plan.append(
+                MicroCephActionStep(
+                    client=self.client,
+                    node=self.node,
+                    jhelper=self.jhelper,
+                    model=self.model,
+                    action_name="enter-maintenance",
+                    action_params={
+                        "name": self.node,
+                        "set-noout": not self.enable_ceph_crush_rebalancing,
+                        "stop-osds": self.stop_osds,
+                        "dry-run": True,
+                        "ignore-check": True,
+                    },
+                )
+            )
+
+        if "control" in node_status:
+            generate_operation_plan += [
+                CordonControlRoleNodeStep(
+                    self.node,
+                    self.client,
+                    self.jhelper,
+                    self.model,
+                    dry_run=True,
+                ),
+                DrainControlRoleNodeStep(
+                    self.node,
+                    self.client,
+                    self.jhelper,
+                    self.model,
+                    dry_run=True,
+                ),
+            ]
+
+        generate_operation_plan_results = run_plan(
+            generate_operation_plan, console, show_hints
+        )
+
+        audit_info = get_step_message(
+            generate_operation_plan_results, CreateWatcherHostMaintenanceAuditStep
+        )
+        microceph_enter_maintenance_dry_run_action_result = get_step_message(
+            generate_operation_plan_results, MicroCephActionStep
+        )
+        drain_k8s_node_dry_run_result = get_step_message(
+            generate_operation_plan_results, DrainControlRoleNodeStep
+        )
+        cordon_k8s_node_dry_run_result = get_step_message(
+            generate_operation_plan_results, CordonControlRoleNodeStep
+        )
+
+        if "compute" in node_status:
+            self.ops_viewer.add_watch_actions(actions=audit_info["actions"])
+        if "storage" in node_status:
+            self.ops_viewer.add_maintenance_action_steps(
+                action_result=microceph_enter_maintenance_dry_run_action_result
+            )
+        if "control" in node_status:
+            self.ops_viewer.add_drain_control_role_step(
+                result=drain_k8s_node_dry_run_result
+            )
+            self.ops_viewer.add_cordon_control_role_step(
+                result=cordon_k8s_node_dry_run_result
+            )
+
+        console.print(self.ops_viewer.dry_run_message)
+
+        return generate_operation_plan_results
+
+
+class DisableMaintenance(MaintenanceCommand):
+    """Command to disable maintenance mode."""
+
+    def __init__(
+        self,
+        node: str,
+        deployment: Deployment,
+        cluster_status: dict[str, Any],
+        disable_instance_rebalancing: bool = False,
+    ):
+        self.node = node
+        self.deployment = deployment
+        self.cluster_status = cluster_status
+        self.disable_instance_rebalancing = disable_instance_rebalancing
+
+        self.model = deployment.openstack_machines_model
+        self.client = deployment.get_client()
+        self.jhelper = JujuHelper(deployment.juju_controller)
+        self.ops_viewer = OperationViewer(node, OperationGoal.DisableMaintenance)
+
+    def check(self, console: Console) -> None:
+        """Run pre-flight checks."""
+        node_status = self.cluster_status.get(self.node, "")
+
+        # Run preflight_checks
+        preflight_checks: list[Check] = [
+            checks.NodeExistCheck(self.node, self.cluster_status),
+        ]
+
+        if "compute" in node_status:
+            preflight_checks += [
+                checks.WatcherApplicationExistsCheck(jhelper=self.jhelper),
+            ]
+
+        run_preflight_checks(preflight_checks, console)
+
+    def apply(self, console: Console, show_hints: bool, plan_results: dict) -> None:
+        """Run the core commands."""
+        node_status = self.cluster_status.get(self.node, "")
+
+        confirm = self.ops_viewer.prompt()
+        if not confirm:
+            raise CommandCancelledError("Operation Cancelled!")
+
+        operation_plan: list[BaseStep] = []
+        if "compute" in node_status:
+            operation_plan += [
+                EnableHypervisorStep(
+                    client=self.client,
+                    node=self.node,
+                    jhelper=self.jhelper,
+                    model=self.model,
+                ),
+            ]
+            if not self.disable_instance_rebalancing:
+                audit_info = get_step_message(
+                    plan_results,
+                    CreateWatcherWorkloadBalancingAuditStep,
+                )
+                operation_plan += [
+                    RunWatcherAuditStep(
+                        deployment=self.deployment,
+                        node=self.node,
+                        audit=audit_info["audit"],
+                    ),
+                ]
+        if "storage" in node_status:
+            operation_plan.append(
+                MicroCephActionStep(
+                    client=self.client,
+                    node=self.node,
+                    jhelper=self.jhelper,
+                    model=self.model,
+                    action_name="exit-maintenance",
+                    action_params={
+                        "name": self.node,
+                        "dry-run": False,
+                        "ignore-check": True,
+                    },
+                )
+            )
+        if "control" in node_status:
+            operation_plan.append(
+                UncordonControlRoleNodeStep(
+                    self.node,
+                    self.client,
+                    self.jhelper,
+                    self.model,
+                    dry_run=False,
+                )
+            )
+
+        operation_plan_results = run_plan(operation_plan, console, show_hints, True)
+        self.ops_viewer.check_operation_succeeded(operation_plan_results)
+
+    def verify(self, console: Console) -> None:
+        """Run verification steps."""
+        node_status = self.cluster_status.get(self.node, "")
+
+        post_checks: list[Check] = []
+
+        if "control" in node_status:
+            post_checks += [
+                checks.ControlRoleNodeUncordonedCheck(
+                    self.node,
+                    self.deployment,
+                    force=False,
+                ),
+            ]
+
+        run_preflight_checks(post_checks, console)
+
+        console.print(f"Disable maintenance for node: {self.node}")
+
+    def dry_run(self, console: Console, show_hints: bool) -> dict:
+        """Dry run command steps."""
+        node_status = self.cluster_status.get(self.node, "")
+
+        generate_operation_plan: list[BaseStep] = []
+
+        if "compute" in node_status:
+            if not self.disable_instance_rebalancing:
+                generate_operation_plan.append(
+                    CreateWatcherWorkloadBalancingAuditStep(
+                        deployment=self.deployment, node=self.node
+                    )
+                )
+        if "storage" in node_status:
+            generate_operation_plan.append(
+                MicroCephActionStep(
+                    client=self.client,
+                    node=self.node,
+                    jhelper=self.jhelper,
+                    model=self.model,
+                    action_name="exit-maintenance",
+                    action_params={
+                        "name": self.node,
+                        "dry-run": True,
+                        "ignore-check": True,
+                    },
+                )
+            )
+        if "control" in node_status:
+            generate_operation_plan.append(
+                UncordonControlRoleNodeStep(
+                    self.node,
+                    self.client,
+                    self.jhelper,
+                    self.model,
+                    dry_run=True,
+                )
+            )
+
+        generate_operation_plan_results = run_plan(
+            generate_operation_plan, console, show_hints
+        )
+
+        if not self.disable_instance_rebalancing:
+            audit_info = get_step_message(
+                generate_operation_plan_results, CreateWatcherWorkloadBalancingAuditStep
+            )
+        microceph_exit_maintenance_dry_run_action_result = get_step_message(
+            generate_operation_plan_results, MicroCephActionStep
+        )
+        uncordon_k8s_node_dry_run_result = get_step_message(
+            generate_operation_plan_results, UncordonControlRoleNodeStep
+        )
+
+        if "compute" in node_status:
+            self.ops_viewer.add_step(step_name=EnableHypervisorStep.__name__)
+            if not self.disable_instance_rebalancing:
+                self.ops_viewer.add_watch_actions(actions=audit_info["actions"])
+        if "storage" in node_status:
+            self.ops_viewer.add_maintenance_action_steps(
+                action_result=microceph_exit_maintenance_dry_run_action_result
+            )
+        if "control" in node_status:
+            self.ops_viewer.add_uncordon_control_role_step(
+                result=uncordon_k8s_node_dry_run_result
+            )
+
+        console.print(self.ops_viewer.dry_run_message)
+
+        return generate_operation_plan_results
 
 
 @click.command()
@@ -79,143 +586,23 @@ def enable(
     show_hints: bool = False,
 ) -> None:
     """Enable maintenance mode for node."""
-    jhelper = JujuHelper(deployment.juju_controller)
-
-    node_status = get_node_status(
+    cluster_status = get_cluster_status(
         deployment=deployment,
-        jhelper=jhelper,
+        jhelper=JujuHelper(deployment.juju_controller),
         console=console,
         show_hints=show_hints,
-        node=node,
     )
 
-    if not node_status:
-        raise click.ClickException(f"Node: {node} does not exist in cluster")
-
-    # This check is to avoid issue which maintenance mode haven't support
-    # control role, which should be removed after control role be supported.
-    if "control" in node_status:
-        msg = f"Node {node} is control role, which doesn't support maintenance mode"
-        if force:
-            LOG.warning(f"Ignore issue: {msg}")
-        else:
-            raise click.ClickException(msg)
-
-    # Run preflight_checks
-    preflight_checks: list[Check] = []
-
-    if "compute" in node_status:
-        preflight_checks += [
-            checks.WatcherApplicationExistsCheck(jhelper=jhelper),
-            checks.InstancesStatusCheck(jhelper=jhelper, node=node, force=force),
-            checks.NoEphemeralDiskCheck(jhelper=jhelper, node=node, force=force),
-        ]
-    if "storage" in node_status:
-        preflight_checks += [
-            checks.MicroCephMaintenancePreflightCheck(
-                client=deployment.get_client(),
-                jhelper=jhelper,
-                node=node,
-                model=deployment.openstack_machines_model,
-                force=force,
-                action_params={
-                    "name": node,
-                    "set-noout": not enable_ceph_crush_rebalancing,
-                    "stop-osds": stop_osds,
-                },
-            )
-        ]
-    run_preflight_checks(preflight_checks, console)
-
-    # Generate operations
-    generate_operation_plan: list[BaseStep] = []
-    if "compute" in node_status:
-        generate_operation_plan.append(
-            CreateWatcherHostMaintenanceAuditStep(deployment=deployment, node=node)
-        )
-    if "storage" in node_status:
-        generate_operation_plan.append(
-            MicroCephActionStep(
-                client=deployment.get_client(),
-                node=node,
-                jhelper=jhelper,
-                model=deployment.openstack_machines_model,
-                action_name="enter-maintenance",
-                action_params={
-                    "name": node,
-                    "set-noout": not enable_ceph_crush_rebalancing,
-                    "stop-osds": stop_osds,
-                    "dry-run": True,
-                    "ignore-check": True,
-                },
-            )
-        )
-
-    generate_operation_plan_results = run_plan(
-        generate_operation_plan, console, show_hints
+    enable_maintenance = EnableMaintenance(
+        node,
+        deployment,
+        cluster_status,
+        force=force,
+        stop_osds=stop_osds,
+        enable_ceph_crush_rebalancing=enable_ceph_crush_rebalancing,
     )
 
-    audit_info = get_step_message(
-        generate_operation_plan_results, CreateWatcherHostMaintenanceAuditStep
-    )
-    microceph_enter_maintenance_dry_run_action_result = get_step_message(
-        generate_operation_plan_results, MicroCephActionStep
-    )
-
-    ops_viewer = OperationViewer(node, OperationGoal.EnableMaintenance)
-    if "compute" in node_status:
-        ops_viewer.add_watch_actions(actions=audit_info["actions"])
-    if "storage" in node_status:
-        ops_viewer.add_maintenance_action_steps(
-            action_result=microceph_enter_maintenance_dry_run_action_result
-        )
-
-    if dry_run:
-        console.print(ops_viewer.dry_run_message)
-        return
-
-    confirm = ops_viewer.prompt()
-    if not confirm:
-        return
-
-    # Run operations
-    operation_plan: list[BaseStep] = []
-    if "compute" in node_status:
-        operation_plan.append(
-            RunWatcherAuditStep(
-                deployment=deployment, node=node, audit=audit_info["audit"]
-            )
-        )
-    if "storage" in node_status:
-        operation_plan.append(
-            MicroCephActionStep(
-                client=deployment.get_client(),
-                node=node,
-                jhelper=jhelper,
-                model=deployment.openstack_machines_model,
-                action_name="enter-maintenance",
-                action_params={
-                    "name": node,
-                    "set-noout": not enable_ceph_crush_rebalancing,
-                    "stop-osds": stop_osds,
-                    "dry-run": False,
-                    "ignore-check": True,
-                },
-            )
-        )
-
-    operation_plan_results = run_plan(operation_plan, console, show_hints, True)
-    ops_viewer.check_operation_succeeded(operation_plan_results)
-
-    # Run post checks
-    post_checks: list[Check] = []
-    if "compute" in node_status:
-        post_checks += [
-            checks.NovaInDisableStatusCheck(jhelper=jhelper, node=node, force=force),
-            checks.NoInstancesOnNodeCheck(jhelper=jhelper, node=node, force=force),
-        ]
-    run_preflight_checks(post_checks, console)
-    console.print(f"Enable maintenance for node: {node}")
+    enable_maintenance(console, show_hints, dry_run)
 
 
 @click.command()
@@ -246,113 +633,18 @@ def disable(
     show_hints: bool = False,
 ) -> None:
     """Disable maintenance mode for node."""
-    jhelper = JujuHelper(deployment.juju_controller)
-
-    node_status = get_node_status(
+    cluster_status = get_cluster_status(
         deployment=deployment,
-        jhelper=jhelper,
+        jhelper=JujuHelper(deployment.juju_controller),
         console=console,
         show_hints=show_hints,
-        node=node,
-    )
-    if not node_status:
-        raise click.ClickException(f"Node: {node} does not exist in cluster")
-
-    # Run preflight_checks
-    preflight_checks: list[Check] = []
-
-    if "compute" in node_status:
-        preflight_checks += [
-            checks.WatcherApplicationExistsCheck(jhelper=jhelper),
-        ]
-    run_preflight_checks(preflight_checks, console)
-
-    generate_operation_plan: list[BaseStep] = []
-    if "compute" in node_status:
-        if not disable_instance_workload_rebalancing:
-            generate_operation_plan.append(
-                CreateWatcherWorkloadBalancingAuditStep(
-                    deployment=deployment, node=node
-                )
-            )
-    if "storage" in node_status:
-        generate_operation_plan.append(
-            MicroCephActionStep(
-                client=deployment.get_client(),
-                node=node,
-                jhelper=jhelper,
-                model=deployment.openstack_machines_model,
-                action_name="exit-maintenance",
-                action_params={
-                    "name": node,
-                    "dry-run": True,
-                    "ignore-check": True,
-                },
-            )
-        )
-
-    generate_operation_plan_results = run_plan(
-        generate_operation_plan, console, show_hints
     )
 
-    if not disable_instance_workload_rebalancing:
-        audit_info = get_step_message(
-            generate_operation_plan_results, CreateWatcherWorkloadBalancingAuditStep
-        )
-    microceph_exit_maintenance_dry_run_action_result = get_step_message(
-        generate_operation_plan_results, MicroCephActionStep
+    disable_maintenance = DisableMaintenance(
+        node,
+        deployment,
+        cluster_status,
+        disable_instance_rebalancing=disable_instance_workload_rebalancing,
     )
 
-    ops_viewer = OperationViewer(node, OperationGoal.DisableMaintenance)
-    if "compute" in node_status:
-        ops_viewer.add_step(step_name=EnableHypervisorStep.__name__)
-        if not disable_instance_workload_rebalancing:
-            ops_viewer.add_watch_actions(actions=audit_info["actions"])
-    if "storage" in node_status:
-        ops_viewer.add_maintenance_action_steps(
-            action_result=microceph_exit_maintenance_dry_run_action_result
-        )
-
-    if dry_run:
-        console.print(ops_viewer.dry_run_message)
-        return
-
-    confirm = ops_viewer.prompt()
-    if not confirm:
-        return
-
-    operation_plan: list[BaseStep] = []
-    if "compute" in node_status:
-        operation_plan += [
-            EnableHypervisorStep(
-                client=deployment.get_client(),
-                node=node,
-                jhelper=jhelper,
-                model=deployment.openstack_machines_model,
-            ),
-        ]
-        if not disable_instance_workload_rebalancing:
-            operation_plan += [
-                RunWatcherAuditStep(
-                    deployment=deployment, node=node, audit=audit_info["audit"]
-                ),
-            ]
-    if "storage" in node_status:
-        operation_plan.append(
-            MicroCephActionStep(
-                client=deployment.get_client(),
-                node=node,
-                jhelper=jhelper,
-                model=deployment.openstack_machines_model,
-                action_name="exit-maintenance",
-                action_params={
-                    "name": node,
-                    "dry-run": False,
-                    "ignore-check": True,
-                },
-            )
-        )
-    operation_plan_results = run_plan(operation_plan, console, show_hints, True)
-    ops_viewer.check_operation_succeeded(operation_plan_results)
-
-    console.print(f"Disable maintenance for node: {node}")
+    disable_maintenance(console, show_hints, dry_run)

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -1344,7 +1344,9 @@ def remove(ctx: click.Context, name: str, force: bool, show_hints: bool) -> None
             client, name, jhelper, deployment.openstack_machines_model
         ),
         CordonK8SUnitStep(client, name, jhelper, deployment.openstack_machines_model),
-        DrainK8SUnitStep(client, name, jhelper, deployment.openstack_machines_model),
+        DrainK8SUnitStep(
+            client, name, jhelper, deployment.openstack_machines_model, remove_pvc=True
+        ),
         RemoveK8SUnitsStep(client, name, jhelper, deployment.openstack_machines_model),
         EnsureL2AdvertisementByHostStep(
             deployment,

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -1484,7 +1484,9 @@ def remove_node(ctx: click.Context, name: str, force: bool, show_hints: bool) ->
             client, name, jhelper, deployment.openstack_machines_model
         ),
         CordonK8SUnitStep(client, name, jhelper, deployment.openstack_machines_model),
-        DrainK8SUnitStep(client, name, jhelper, deployment.openstack_machines_model),
+        DrainK8SUnitStep(
+            client, name, jhelper, deployment.openstack_machines_model, remove_pvc=True
+        ),
         RemoveK8SUnitsStep(client, name, jhelper, deployment.openstack_machines_model),
         EnsureL2AdvertisementByHostStep(
             deployment,

--- a/sunbeam-python/sunbeam/steps/maintenance.py
+++ b/sunbeam-python/sunbeam/steps/maintenance.py
@@ -19,6 +19,11 @@ from sunbeam.core.juju import (
     UnitNotFoundException,
 )
 from sunbeam.core.watcher import WatcherActionFailedException
+from sunbeam.steps.k8s import (
+    CordonK8SUnitStep,
+    DrainK8SUnitStep,
+    UncordonK8SUnitStep,
+)
 from sunbeam.steps.microceph import APPLICATION as _MICROCEPH_APPLICATION
 
 if TYPE_CHECKING:
@@ -182,3 +187,75 @@ class RunWatcherAuditStep(BaseStep):
             ResultType.COMPLETED if not failed else ResultType.FAILED,
             actions,
         )
+
+
+class DrainControlRoleNodeStep(DrainK8SUnitStep):
+    def __init__(
+        self,
+        node: str,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        dry_run: bool = True,
+    ):
+        super().__init__(client, node, jhelper, model)
+        self.dry_run = dry_run
+
+    def run(self, status: Status | None = None) -> Result:
+        """Execute drain control role node step."""
+        step_key = f"Drain '{self.node}'"
+
+        if self.dry_run:
+            return Result(ResultType.COMPLETED, {"id": step_key})
+
+        result = super().run(status)
+        result.message = {"id": step_key}
+        return result
+
+
+class CordonControlRoleNodeStep(CordonK8SUnitStep):
+    def __init__(
+        self,
+        node: str,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        dry_run: bool = True,
+    ):
+        super().__init__(client, node, jhelper, model)
+        self.dry_run = dry_run
+
+    def run(self, status: Status | None = None) -> Result:
+        """Execute cordon control role node step."""
+        step_key = f"Cordon '{self.node}'"
+
+        if self.dry_run:
+            return Result(ResultType.COMPLETED, {"id": step_key})
+
+        result = super().run(status)
+        result.message = {"id": step_key}
+        return result
+
+
+class UncordonControlRoleNodeStep(UncordonK8SUnitStep):
+    def __init__(
+        self,
+        node: str,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        dry_run: bool = True,
+    ):
+        super().__init__(client, node, jhelper, model)
+        self.dry_run = dry_run
+
+    def run(self, status: Status | None = None) -> Result:
+        """Execute uncordon control role node step."""
+        step_key = f"Uncordon '{self.node}'"
+
+        if self.dry_run:
+            return Result(ResultType.COMPLETED, {"id": step_key})
+
+        result = super().run(status)
+        result.message = {"id": step_key}
+        return result

--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -536,6 +536,26 @@ def test_get_secret_not_found(jhelper, juju):
         jhelper.get_secret("test-model", "secret-id")
 
 
+def test_get_app_config_success(jhelper, juju):
+    test_config = {"key": "value"}
+    juju.config.return_value = test_config
+    config = jhelper.get_app_config("test-app", "test-model")
+    assert test_config == config
+    juju.config.assert_called()
+
+
+def test_get_app_config_not_found(jhelper, juju):
+    juju.config.side_effect = jubilant.CLIError(1, "config", stderr="not found")
+    with pytest.raises(jujulib.ApplicationNotFoundException):
+        jhelper.get_app_config("test-app", "test-model")
+
+
+def test_get_app_config_fail(jhelper, juju):
+    juju.config.side_effect = jubilant.CLIError(1, "config", stderr="fail")
+    with pytest.raises(jujulib.JujuException):
+        jhelper.get_secret("test-app", "test-model")
+
+
 def test_jhelper_add_k8s_cloud(jhelper: jujulib.JujuHelper):
     kubeconfig = yaml.safe_load(kubeconfig_yaml)
     jhelper.add_k8s_cloud("k8s", "k8s-creds", kubeconfig)

--- a/sunbeam-python/tests/unit/sunbeam/features/maintenance/test_utils.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/maintenance/test_utils.py
@@ -10,7 +10,7 @@ from sunbeam.core.common import ResultType
 from sunbeam.features.maintenance.utils import (
     OperationGoal,
     OperationViewer,
-    get_node_status,
+    get_cluster_status,
 )
 from sunbeam.steps.hypervisor import EnableHypervisorStep
 from sunbeam.steps.maintenance import (
@@ -22,13 +22,14 @@ from sunbeam.steps.maintenance import (
 @patch("sunbeam.features.maintenance.utils.LocalClusterStatusStep")
 @patch("sunbeam.features.maintenance.utils.run_plan")
 @patch("sunbeam.features.maintenance.utils.get_step_message")
-def test_get_node_status(
+def test_get_cluster_status(
     mock_get_step_message,
     mock_run_plan,
     mock_local_cluster_status_step,
 ):
     mock_deployment = Mock()
     mock_deployment.type = "local"
+    mock_deployment.openstack_machines_model = "openstack-machines"
     mock_jhelper = Mock()
     mock_get_step_message.return_value = {
         "openstack-machines": {
@@ -47,9 +48,7 @@ def test_get_node_status(
         }
     }
 
-    result = get_node_status(
-        mock_deployment, mock_jhelper, "console", False, "fake-node-a"
-    )
+    result = get_cluster_status(mock_deployment, mock_jhelper, "console", False)
 
     mock_local_cluster_status_step.assert_called_once_with(
         mock_deployment, mock_jhelper
@@ -60,7 +59,11 @@ def test_get_node_status(
     mock_get_step_message.assert_called_once_with(
         mock_run_plan.return_value, mock_local_cluster_status_step
     )
-    assert result == "target-status-val"
+    assert result == {
+        "fake-node-a": "target-status-val",
+        "fake-node-b": "not-target-status-val",
+        "fake-node-c": "not-target-status-val",
+    }
 
 
 class TestOperationViewer:

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_maintenance.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_maintenance.py
@@ -10,11 +10,14 @@ from watcherclient import v1 as watcher
 from sunbeam.core.common import ResultType, SunbeamException
 from sunbeam.core.juju import ActionFailedException, UnitNotFoundException
 from sunbeam.steps.maintenance import (
+    CordonControlRoleNodeStep,
     CreateWatcherAuditStepABC,
     CreateWatcherHostMaintenanceAuditStep,
     CreateWatcherWorkloadBalancingAuditStep,
+    DrainControlRoleNodeStep,
     MicroCephActionStep,
     RunWatcherAuditStep,
+    UncordonControlRoleNodeStep,
 )
 from sunbeam.steps.microceph import APPLICATION as _MICROCEPH_APPLICATION
 
@@ -226,3 +229,57 @@ class TestRunWatcherAuditStep:
         mock_watcher_helper.get_actions.assert_called_once_with(
             client=mock_watcher_client, audit=mock_audit
         )
+
+
+class TestDrainControlRoleNodeStep:
+    def test_run(self):
+        with patch("sunbeam.steps.maintenance.DrainK8SUnitStep.run") as parent_run:
+            step = DrainControlRoleNodeStep(
+                "fake-node", Mock(), Mock(), "fake-model", dry_run=False
+            )
+            step.run(Mock())
+            parent_run.assert_called_once()
+
+    def test_dry_run(self):
+        with patch("sunbeam.steps.maintenance.DrainK8SUnitStep.run") as parent_run:
+            step = DrainControlRoleNodeStep(
+                "fake-node", Mock(), Mock(), "fake-model", dry_run=True
+            )
+            step.run(Mock())
+            parent_run.assert_not_called()
+
+
+class TestCordonControlRoleNodeStep:
+    def test_run(self):
+        with patch("sunbeam.steps.maintenance.CordonK8SUnitStep.run") as parent_run:
+            step = CordonControlRoleNodeStep(
+                "fake-node", Mock(), Mock(), "fake-model", dry_run=False
+            )
+            step.run(Mock())
+            parent_run.assert_called_once()
+
+    def test_dry_run(self):
+        with patch("sunbeam.steps.maintenance.CordonK8SUnitStep.run") as parent_run:
+            step = CordonControlRoleNodeStep(
+                "fake-node", Mock(), Mock(), "fake-model", dry_run=True
+            )
+            step.run(Mock())
+            parent_run.assert_not_called()
+
+
+class TestUncordonControlRoleNodeStep:
+    def test_run(self):
+        with patch("sunbeam.steps.maintenance.UncordonK8SUnitStep.run") as parent_run:
+            step = UncordonControlRoleNodeStep(
+                "fake-node", Mock(), Mock(), "fake-model", dry_run=False
+            )
+            step.run(Mock())
+            parent_run.assert_called_once()
+
+    def test_dry_run(self):
+        with patch("sunbeam.steps.maintenance.UncordonK8SUnitStep.run") as parent_run:
+            step = UncordonControlRoleNodeStep(
+                "fake-node", Mock(), Mock(), "fake-model", dry_run=True
+            )
+            step.run(Mock())
+            parent_run.assert_not_called()


### PR DESCRIPTION
Add support for control role maintenance mode:
- add preflight checks for control role
- add drain and cordon when enabling maintenance mode for control role
- add uncordon step when disabling maintenance mode for control role

Additional changes:
- small refactoring for maintenance commands required by pep8
- adjust k8s related steps and utility 

Example of changes

```shell
$ sunbeam cluster maintenance enable sunbeam-02.example.com
Required operations to enable maintenance mode for sunbeam-02.example.com:
        0: Drain 'sunbeam-02.example.com'
        1: Cordon 'sunbeam-02.example.com'

Continue to run operation to enable maintenance mode for sunbeam-02.example.com:
        0: Drain 'sunbeam-02.example.com'
        1: Cordon 'sunbeam-02.example.com'
 [y/n]: 
```

```shell
$ sunbeam cluster maintenance disable sunbeam-03.example.com
Required operations to disable maintenance mode for sunbeam-03.example.com:
        0: Uncordon 'sunbeam-03.example.com'

Continue to run operation to disable maintenance mode for sunbeam-03.example.com:
        0: Uncordon 'sunbeam-03.example.com'
 [y/n]: 
```

Tested on **local** deployment with **internal** juju controller
- single node
  - control+compute+storage
- 3 nodes
  - control+compute+storage
  - control
  - control