### PR TITLE
Run the functional tests every 2 days

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -7,6 +7,9 @@ on:
         description: "Filename of the built snap artifact"
         value: local-${{ jobs.build.outputs.snap }}
 
+  schedule:
+    - cron: '22 4 */2 * *'
+
 jobs:
   build:
     name: Build snap


### PR DESCRIPTION
So we know exactly when the test got broken and it's easier to know a culprit in dependencies.

At this moment, the last merge was two weeks ago. And it seems like there are some broken pieces since then. By enabling a periodic functional test, it would be helpful to know when it got broken.

Issues in edge channels since the last merges are:
- https://bugs.launchpad.net/snap-openstack/+bug/2119486
- https://bugs.launchpad.net/snap-openstack/+bug/2119451
- https://bugs.launchpad.net/snap-openstack/+bug/2119425 (well, this one cannot be caught since the functional test uses `--accept-defaults`)