### PR TITLE
Fix maintenance mode steps order (UI only)

### DIFF
--- a/sunbeam-python/sunbeam/features/maintenance/commands.py
+++ b/sunbeam-python/sunbeam/features/maintenance/commands.py
@@ -342,11 +342,11 @@ class EnableMaintenance(MaintenanceCommand):
                 action_result=microceph_enter_maintenance_dry_run_action_result
             )
         if "control" in node_status:
-            self.ops_viewer.add_drain_control_role_step(
-                result=drain_k8s_node_dry_run_result
-            )
             self.ops_viewer.add_cordon_control_role_step(
                 result=cordon_k8s_node_dry_run_result
+            )
+            self.ops_viewer.add_drain_control_role_step(
+                result=drain_k8s_node_dry_run_result
             )
 
         console.print(self.ops_viewer.dry_run_message)


### PR DESCRIPTION
Current printed orders (the actual step is correct, only the printed order is wrong)

```
Continue to run operation to enable maintenance mode for sunbeam-02.example.com:
        0: Drain 'sunbeam-02.example.com'
        1: Cordon 'sunbeam-02.example.com'
```

It should be `cordon -> drain` not `drain -> cordon`. This PR fix the misleading plan.