### PR TITLE
Set juju on k8s traffic policy to local

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -144,6 +144,7 @@ from sunbeam.steps.k8s import (
     EnsureL2AdvertisementByHostStep,
     MigrateK8SKubeconfigStep,
     PatchCoreDNSStep,
+    PatchServiceExternalTrafficStep,
     RemoveK8SUnitsStep,
     StoreK8SKubeConfigStep,
     UpdateK8SCloudStep,
@@ -471,6 +472,13 @@ def get_juju_bootstrap_plans(
             deployment.controller,
             bootstrap_args=bootstrap_args,
             proxy_settings=proxy_settings,
+        ),
+        # note(gboutry): workaround for LP#2111922
+        # Find more permanent solution when juju supports HA on k8s
+        PatchServiceExternalTrafficStep(
+            deployment,
+            "controller-service",
+            "controller-" + deployment.controller,
         ),
     ]
 

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -1686,3 +1686,80 @@ class PatchCoreDNSStep(BaseStep):
             return Result(ResultType.FAILED, str(e))
 
         return Result(ResultType.COMPLETED)
+
+
+class PatchServiceExternalTrafficStep(BaseStep):
+    """Patch service external traffic policy to Local.
+
+    This is a workaround for LP#2111922.
+    Using externalTrafficPolicy will force metallb to announce
+    from nodes hosting the pods of the deployment. Since Juju does
+    not support HA on k8s, only the node hosting the Juju pod will be
+    eligible to announce the service IP. This will that the connection
+    isn't broken when new k8s node join, as the mac address will not change
+    uncontrollably.
+    """
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        service_name: str,
+        namespace: str,
+    ):
+        super().__init__(
+            "Patch Service Traffic announcement",
+            "Patching Service Traffic announcement",
+        )
+        self.deployment = deployment
+        self.client = deployment.get_client()
+        self.service_name = service_name
+        self.namespace = namespace
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                 ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        try:
+            self.kube = get_kube_client(
+                self.client,
+                self.namespace,
+            )
+        except KubeClientError as e:
+            LOG.debug("Failed to create k8s client", exc_info=True)
+            return Result(ResultType.FAILED, str(e))
+
+        try:
+            service = self.kube.get(core_v1.Service, name=self.service_name)
+            if service.spec is None or service.spec.externalTrafficPolicy == "Local":
+                return Result(ResultType.SKIPPED)
+        except l_exceptions.ApiError as e:
+            LOG.debug("Failed to get service", exc_info=True)
+            return Result(ResultType.FAILED, str(e))
+        return Result(ResultType.COMPLETED)
+
+    def run(self, status: Status | None = None) -> Result:
+        """Run the step to completion."""
+        try:
+            service = self.kube.get(core_v1.Service, name=self.service_name)
+            if service.spec is None:
+                LOG.debug("Service has no spec")
+                return Result(ResultType.FAILED, "Service has no spec")
+
+            service.spec.externalTrafficPolicy = "Local"
+            self.kube.patch(
+                core_v1.Service,
+                name=self.service_name,
+                namespace=self.namespace,
+                obj={
+                    "spec": {
+                        "externalTrafficPolicy": "Local",
+                    }
+                },
+            )
+        except (l_exceptions.ApiError, K8SError) as e:
+            LOG.debug("Failed to patch service", exc_info=True)
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -32,6 +32,7 @@ from sunbeam.steps.k8s import (
     EnsureL2AdvertisementByHostStep,
     KubeClientError,
     PatchCoreDNSStep,
+    PatchServiceExternalTrafficStep,
     StoreK8SKubeConfigStep,
     _get_kube_client,
     _get_machines_space_ips,
@@ -1095,3 +1096,95 @@ class TestPatchCoreDNSStep(unittest.TestCase):
         assert result.result_type == ResultType.FAILED
         self.jhelper.get_leader_unit.assert_called_once()
         self.jhelper.run_cmd_on_machine_unit_payload.assert_not_called()
+
+
+class TestPatchServiceExternalTrafficStep(unittest.TestCase):
+    def setUp(self):
+        self.deployment = Mock()
+        self.deployment.get_client.return_value = Mock()
+        self.client = self.deployment.get_client()
+        self.service_name = "test-service"
+        self.namespace = "test-namespace"
+        self.step = PatchServiceExternalTrafficStep(
+            self.deployment, self.service_name, self.namespace
+        )
+        self.kube = Mock()
+        self.step.kube = self.kube
+
+    def test_is_skip_external_traffic_policy_already_local(self):
+        service = Mock()
+        service.spec = Mock()
+        service.spec.externalTrafficPolicy = "Local"
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=self.kube):
+            self.kube.get.return_value = service
+            result = self.step.is_skip()
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_is_skip_external_traffic_policy_not_local(self):
+        service = Mock()
+        service.spec = Mock()
+        service.spec.externalTrafficPolicy = "Cluster"
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=self.kube):
+            self.kube.get.return_value = service
+            result = self.step.is_skip()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip_service_has_no_spec(self):
+        service = Mock()
+        service.spec = None
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=self.kube):
+            self.kube.get.return_value = service
+            result = self.step.is_skip()
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_is_skip_kube_client_error(self):
+        with patch(
+            "sunbeam.steps.k8s.get_kube_client", side_effect=KubeClientError("fail")
+        ):
+            result = self.step.is_skip()
+        assert result.result_type == ResultType.FAILED
+
+    def test_is_skip_api_error(self):
+        api_error = lightkube.core.exceptions.ApiError.__new__(
+            lightkube.core.exceptions.ApiError
+        )
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=self.kube):
+            self.kube.get.side_effect = api_error
+            result = self.step.is_skip()
+        assert result.result_type == ResultType.FAILED
+
+    def test_run_success(self):
+        service = Mock()
+        service.spec = Mock()
+        service.spec.externalTrafficPolicy = "Cluster"
+        with patch.object(self.step, "kube") as kube_mock:
+            kube_mock.get.return_value = service
+            kube_mock.patch.return_value = None
+            result = self.step.run(None)
+        kube_mock.get.assert_called_once_with(
+            lightkube.resources.core_v1.Service, name=self.service_name
+        )
+        kube_mock.patch.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_service_has_no_spec(self):
+        service = Mock()
+        service.spec = None
+        with patch.object(self.step, "kube") as kube_mock:
+            kube_mock.get.return_value = service
+            result = self.step.run(None)
+        assert result.result_type == ResultType.FAILED
+        assert "Service has no spec" in result.message
+
+    def test_run_patch_api_error(self):
+        service = Mock()
+        service.spec = Mock()
+        service.spec.externalTrafficPolicy = "Cluster"
+        api_error = lightkube.core.exceptions.ApiError.__new__(
+            lightkube.core.exceptions.ApiError
+        )
+        with patch.object(self.step, "kube") as kube_mock:
+            kube_mock.get.return_value = service
+            kube_mock.patch.side_effect = api_error
+            result = self.step.run(None)
+        assert result.result_type == ResultType.FAILED


### PR DESCRIPTION
Prevent MetalLB from electing a new announcer for the K8S service when the controller in the embedded controller on k8s. This will prevent broken websockets connections while multiple k8s are joining.

Closes-Bug: #2111922