### PR TITLE
Wait for apps to be reported ready multiple times

### DIFF
--- a/sunbeam-python/sunbeam/core/steps.py
+++ b/sunbeam-python/sunbeam/core/steps.py
@@ -280,7 +280,7 @@ class AddMachineUnitsStep(BaseStep):
             return Result(ResultType.FAILED, str(e))
 
         apps = [self.application, *self.subordinate_applications]
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         accepted_status = self.get_accepted_unit_status()
         try:

--- a/sunbeam-python/sunbeam/features/instance_recovery/consul.py
+++ b/sunbeam-python/sunbeam/features/instance_recovery/consul.py
@@ -186,7 +186,7 @@ class DeployConsulClientStep(BaseStep):
 
         apps = ConsulFeature.set_consul_client_application_names(self.deployment)
         LOG.debug(f"Application monitored for readiness: {apps}")
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_desired_status(

--- a/sunbeam-python/sunbeam/features/interface/v1/openstack.py
+++ b/sunbeam-python/sunbeam/features/interface/v1/openstack.py
@@ -476,7 +476,7 @@ class UpgradeOpenStackApplicationStep(BaseStep, JujuStepHelper):
         except TerraformException as e:
             LOG.exception(f"Error upgrading feature {self.feature.name}")
             return Result(ResultType.FAILED, str(e))
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_desired_status(
@@ -570,7 +570,7 @@ class EnableOpenStackApplicationStep(
 
         apps = self.feature.set_application_names(self.deployment)
         LOG.debug(f"Application monitored for readiness: {apps}")
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_desired_status(
@@ -694,7 +694,7 @@ class WaitForApplicationsStep(BaseStep):
     def run(self, status: Status | None = None) -> Result:
         """Wait for applications to be idle."""
         LOG.debug(f"Application monitored for readiness: {self.apps}")
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(self.apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, self.apps, status_queue, status)
         try:
             self.jhelper.wait_until_desired_status(

--- a/sunbeam-python/sunbeam/features/ldap/feature.py
+++ b/sunbeam-python/sunbeam/features/ldap/feature.py
@@ -168,7 +168,7 @@ class UpdateLDAPDomainStep(BaseStep, JujuStepHelper):
         charm_name = "keystone-ldap-{}".format(self.charm_config["domain-name"])
         apps = ["keystone", charm_name]
         LOG.debug(f"Application monitored for readiness: {apps}")
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_active(
@@ -238,7 +238,7 @@ class AddLDAPDomainStep(BaseStep, JujuStepHelper):
         charm_name = "keystone-ldap-{}".format(self.charm_config["domain-name"])
         apps = ["keystone", charm_name]
         LOG.debug(f"Application monitored for readiness: {apps}")
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_active(

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -161,7 +161,7 @@ class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
 
         apps = self.jhelper.get_application_names(self.model)
         LOG.debug(f"Application monitored for readiness: {apps}")
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_active(

--- a/sunbeam-python/sunbeam/steps/openstack.py
+++ b/sunbeam-python/sunbeam/steps/openstack.py
@@ -565,7 +565,7 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         apps = list(set(apps) - set(self.remove_blocked_apps_from_features()))
 
         LOG.debug(f"Applications monitored for readiness: {apps}")
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_active(
@@ -663,7 +663,7 @@ class ReapplyOpenStackTerraformPlanStep(BaseStep, JujuStepHelper):
         if not storage_nodes:
             apps.remove("cinder")
         LOG.debug(f"Application monitored for readiness: {apps}")
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_active(

--- a/sunbeam-python/sunbeam/steps/sso.py
+++ b/sunbeam-python/sunbeam/steps/sso.py
@@ -303,7 +303,7 @@ class UpdateExternalProviderStep(BaseStep, JujuStepHelper):
 
         charm_name = "keystone-idp-{}".format(self._provider_name)
         apps = ["keystone", "horizon", charm_name]
-        app_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        app_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, app_queue, status)
         try:
             self.jhelper.wait_until_active(
@@ -509,7 +509,7 @@ class _BaseExternalProviderStep(_BaseProviderStep, _OIDCValidationMixin):
 
         charm_name = f"keystone-idp-{self._provider_name}"
         apps = ["keystone", "horizon", charm_name]
-        app_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        app_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, app_queue, status)
         try:
             self.jhelper.wait_until_active(
@@ -962,7 +962,7 @@ class DeployIdentityProvidersStep(BaseStep, JujuStepHelper):
         except TerraformException as e:
             return Result(ResultType.FAILED, str(e))
 
-        app_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        app_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, app_queue, status)
         try:
             self.jhelper.wait_until_active(

--- a/sunbeam-python/sunbeam/steps/upgrades/inter_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/inter_channel.py
@@ -121,7 +121,7 @@ class BaseUpgrade(BaseStep, JujuStepHelper):
         except TerraformException as e:
             LOG.exception("Error upgrading cloud")
             return Result(ResultType.FAILED, str(e))
-        status_queue: queue.Queue[str] = queue.Queue(maxsize=len(apps))
+        status_queue: queue.Queue[str] = queue.Queue()
         task = update_status_background(self, apps, status_queue, status)
         try:
             self.jhelper.wait_until_desired_status(

--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import queue
 from unittest.mock import MagicMock, Mock, patch
 
 import jubilant
@@ -685,15 +684,6 @@ class TestJujuActionHelper:
                 "fake-action",
                 {"p1": "v1", "p2": "v2"},
             )
-
-
-def test_wait_until_desired_status_invalid_queue(jhelper: jujulib.JujuHelper):
-    status_queue: queue.Queue[str] = queue.Queue(1)
-
-    with pytest.raises(ValueError):
-        jhelper.wait_until_desired_status(
-            "test-model", ["app1", "app2"], queue=status_queue
-        )
 
 
 def test_wait_until_desired_status_timeout(jhelper: jujulib.JujuHelper, juju):


### PR DESCRIPTION
Current wait implementation is a bit optimistic, waiting for apps to report success a single time before being considered ready. As in cluster resize, some applications, such as mysql-router will flap between active and maintenance, some were considered ready too early.

Closes-Bug: #2120630