### PR TITLE
Fix external juju controller apiendpoints filtering

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -340,7 +340,7 @@ def get_juju_controller_plans(
                 deployment.name, "empty-creds", credential_definition, controller
             ),
             BackupBootstrapUserStep("admin", data_location),
-            ClusterUpdateJujuControllerStep(client, controller, False, False),
+            ClusterUpdateJujuControllerStep(client, controller, False),
             SaveJujuAdminUserLocallyStep(controller, data_location),
         ]
 
@@ -420,7 +420,7 @@ def get_juju_migrate_plans(
             from_controller,
             to_controller,
         ),
-        ClusterUpdateJujuControllerStep(client, deployment.controller, False, False),
+        ClusterUpdateJujuControllerStep(client, deployment.controller, False),
         SaveJujuAdminUserLocallyStep(deployment.controller, data_location),
     ]
 

--- a/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
@@ -605,7 +605,9 @@ class TestClusterUpdateJujuControllerStep:
     def test_init_step(self):
         step = ClusterUpdateJujuControllerStep(MagicMock(), "10.0.0.10:10")
         assert step.filter_ips(["10.0.0.6:17070"], "10.0.0.0/24") == ["10.0.0.6:17070"]
-        assert step.filter_ips(["10.10.0.6:17070"], "10.0.0.0/24") == []
+        assert step.filter_ips(["10.10.0.6:17070"], "10.0.0.0/24") == [
+            "10.10.0.6:17070"
+        ]
         assert step.filter_ips(["10.10.0.6:17070"], "10.0.0.0/24,10.10.0.0/24") == [
             "10.10.0.6:17070"
         ]
@@ -662,37 +664,6 @@ class TestClusterUpdateJujuControllerStep:
         result = step.is_skip()
 
         assert result.result_type == ResultType.SKIPPED
-
-    def test_skip_reapply_step_with_no_endpoints_filter(
-        self, cclient, snap, run, load_answers
-    ):
-        controller_name = "lxdcloud"
-        endpoints = ["10.0.0.1:17070", "[fd42:9331:57e6:2088:216:3eff:fe82:2bb6]:17070"]
-        management_cidr = "10.0.0.0/24"
-
-        controller = json.dumps(
-            {controller_name: {"details": {"api-endpoints": endpoints}}}
-        )
-        run.return_value = subprocess.CompletedProcess(
-            args={}, returncode=0, stdout=controller
-        )
-
-        load_answers.return_value = {"bootstrap": {"management_cidr": management_cidr}}
-        cclient.cluster.get_config.return_value = json.dumps(
-            {
-                "name": controller_name,
-                "api_endpoints": [endpoints[0]],
-                "ca_cert": "TMP_CA_CERT",
-                "is_external": False,
-            }
-        )
-
-        step = ClusterUpdateJujuControllerStep(
-            cclient, controller_name, filter_endpoints=False
-        )
-        result = step.is_skip()
-
-        assert result.result_type == ResultType.COMPLETED
 
 
 @pytest.fixture()


### PR DESCRIPTION
Save all controller IPs if the filter of juju controller
api endpoints with the management network did not result
in any IPs