### PR TITLE
Fix external juju controller apiendpoints filtering

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -334,7 +334,7 @@ def get_juju_controller_plans(
                 deployment.name, "empty-creds", credential_definition, controller
             ),
             BackupBootstrapUserStep("admin", data_location),
-            ClusterUpdateJujuControllerStep(client, controller, False, False),
+            ClusterUpdateJujuControllerStep(client, controller, False),
             SaveJujuAdminUserLocallyStep(controller, data_location),
         ]
 
@@ -414,7 +414,7 @@ def get_juju_migrate_plans(
             from_controller,
             to_controller,
         ),
-        ClusterUpdateJujuControllerStep(client, deployment.controller, False, False),
+        ClusterUpdateJujuControllerStep(client, deployment.controller, False),
         SaveJujuAdminUserLocallyStep(deployment.controller, data_location),
     ]
 

--- a/sunbeam-python/sunbeam/steps/clusterd.py
+++ b/sunbeam-python/sunbeam/steps/clusterd.py
@@ -460,11 +460,9 @@ class ClusterAddJujuUserStep(BaseStep):
 class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
     """Save Juju controller in cluster database.
 
-    The controller IP is filtered based on the management_cidr
-    saved in the cluster database by default.
-    If filter_endpoints is False, the controller IP is not
-    filtered and all the controller IPs are saved in cluster
-    database.
+    The controller IPs are filtered based on the management_cidr
+    and if the filter did not return any IPs, all controller IPs
+    will be saved in cluster database.
     """
 
     def __init__(
@@ -472,7 +470,6 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
         client: Client,
         controller: str,
         is_external: bool = False,
-        filter_endpoints: bool = True,
     ):
         super().__init__(
             "Add Juju controller to cluster DB",
@@ -482,7 +479,6 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
         self.client = client
         self.controller = controller
         self.is_external = is_external
-        self.filter_endpoints = filter_endpoints
 
     def _extract_ip(self, ip) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
         """Extract ip from ipv4 or ipv6 ip:port."""
@@ -497,13 +493,16 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
     def filter_ips(self, ips: list[str], network_str: str | None) -> list[str]:
         """Filter ips missing from specified networks.
 
+        If there are no IPs from specified neworks, return all IPs.
+
         :param ips: list of ips to filter
         :param network_str: network to filter ips from, separated by comma
         """
         if network_str is None:
             return ips
+
         networks = [ipaddress.ip_network(network) for network in network_str.split(",")]
-        return list(
+        filtered_ips = list(
             filter(
                 lambda ip: any(
                     True for network in networks if self._extract_ip(ip) in network
@@ -511,6 +510,7 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
                 ips,
             )
         )
+        return filtered_ips or ips
 
     def is_skip(self, status: Status | None = None) -> Result:
         """Determines if the step should be skipped or not.
@@ -523,10 +523,6 @@ class ClusterUpdateJujuControllerStep(BaseStep, JujuStepHelper):
         try:
             variables = questions.load_answers(self.client, BOOTSTRAP_CONFIG_KEY)
             self.networks = variables.get("bootstrap", {}).get("management_cidr")
-
-            # Do not filter api endpoints based on management cidr
-            if not self.filter_endpoints:
-                self.networks = None
 
             juju_controller = JujuController.load(self.client)
             LOG.debug(f"Controller(s) present at: {juju_controller.api_endpoints}")

--- a/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_clusterd.py
@@ -605,7 +605,9 @@ class TestClusterUpdateJujuControllerStep:
     def test_init_step(self):
         step = ClusterUpdateJujuControllerStep(MagicMock(), "10.0.0.10:10")
         assert step.filter_ips(["10.0.0.6:17070"], "10.0.0.0/24") == ["10.0.0.6:17070"]
-        assert step.filter_ips(["10.10.0.6:17070"], "10.0.0.0/24") == []
+        assert step.filter_ips(["10.10.0.6:17070"], "10.0.0.0/24") == [
+            "10.10.0.6:17070"
+        ]
         assert step.filter_ips(["10.10.0.6:17070"], "10.0.0.0/24,10.10.0.0/24") == [
             "10.10.0.6:17070"
         ]
@@ -662,37 +664,6 @@ class TestClusterUpdateJujuControllerStep:
         result = step.is_skip()
 
         assert result.result_type == ResultType.SKIPPED
-
-    def test_skip_reapply_step_with_no_endpoints_filter(
-        self, cclient, snap, run, load_answers
-    ):
-        controller_name = "lxdcloud"
-        endpoints = ["10.0.0.1:17070", "[fd42:9331:57e6:2088:216:3eff:fe82:2bb6]:17070"]
-        management_cidr = "10.0.0.0/24"
-
-        controller = json.dumps(
-            {controller_name: {"details": {"api-endpoints": endpoints}}}
-        )
-        run.return_value = subprocess.CompletedProcess(
-            args={}, returncode=0, stdout=controller
-        )
-
-        load_answers.return_value = {"bootstrap": {"management_cidr": management_cidr}}
-        cclient.cluster.get_config.return_value = json.dumps(
-            {
-                "name": controller_name,
-                "api_endpoints": [endpoints[0]],
-                "ca_cert": "TMP_CA_CERT",
-                "is_external": False,
-            }
-        )
-
-        step = ClusterUpdateJujuControllerStep(
-            cclient, controller_name, filter_endpoints=False
-        )
-        result = step.is_skip()
-
-        assert result.result_type == ResultType.COMPLETED
 
 
 @pytest.fixture()


### PR DESCRIPTION
Save all controller IPs if the filter of juju controller api endpoints with the management network did not result in any IPs

(cherry picked from commit 26b1aa803b41b42dfb9367ee472a720358736304)