### PR TITLE
Allow longer timeout on app readiness

### DIFF
--- a/sunbeam-python/sunbeam/features/pro/feature.py
+++ b/sunbeam-python/sunbeam/features/pro/feature.py
@@ -40,7 +40,7 @@ LOG = logging.getLogger(__name__)
 console = Console()
 
 APPLICATION = "ubuntu-pro"
-APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
+APP_TIMEOUT = 300  # 5 minutes, managing the application should be fast
 UNIT_TIMEOUT = 1200  # 15 minutes, adding / removing units can take a long time
 
 

--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -56,7 +56,7 @@ else:
 LOG = logging.getLogger(__name__)
 CONFIG_KEY = "TerraformVarsHypervisor"
 APPLICATION = "openstack-hypervisor"
-HYPERVISOR_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
+HYPERVISOR_APP_TIMEOUT = 300  # 5 minutes, managing the application should be fast
 HYPERVISOR_DESTROY_TIMEOUT = 600
 HYPERVISOR_UNIT_TIMEOUT = (
     1800  # 30 minutes, adding / removing units can take a long time

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -96,10 +96,10 @@ K8S_CONFIG_KEY = "TerraformVarsK8S"
 K8S_ADDONS_CONFIG_KEY = "TerraformVarsK8SAddons"
 TRAEFIK_CONFIG_KEY = "TerraformVarsTraefikEndpoints"
 APPLICATION = "k8s"
-K8S_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
+K8S_APP_TIMEOUT = 300  # 5 minutes, managing the application should be fast
 K8S_DESTROY_TIMEOUT = 900
 K8S_UNIT_TIMEOUT = 1800  # 30 minutes, adding / removing units can take a long time
-K8S_ENABLE_ADDONS_TIMEOUT = 180  # 3 minutes
+K8S_ENABLE_ADDONS_TIMEOUT = 300  # 5 minutes
 K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
 
 COREDNS_HPA = {

--- a/sunbeam-python/sunbeam/steps/sunbeam_machine.py
+++ b/sunbeam-python/sunbeam/steps/sunbeam_machine.py
@@ -18,7 +18,7 @@ from sunbeam.core.terraform import TerraformHelper
 LOG = logging.getLogger(__name__)
 CONFIG_KEY = "TerraformVarsSunbeamMachine"
 APPLICATION = "sunbeam-machine"
-SUNBEAM_MACHINE_APP_TIMEOUT = 180  # 3 minutes, managing the application should be fast
+SUNBEAM_MACHINE_APP_TIMEOUT = 300  # 5 minutes, managing the application should be fast
 SUNBEAM_MACHINE_UNIT_TIMEOUT = (
     1200  # 20 minutes, adding / removing units can take a long time
 )


### PR DESCRIPTION
With new app waiting code, the app can be considered unready longer as new units can be joining in the meanwhile.

While this is not a solution, it should help lessen the symptoms when multiple nodes are joining at the same time.