### PR TITLE
Rework endpoint hostname and IP configuration

### DIFF
--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -235,6 +235,17 @@ class CoreConfig(pydantic.BaseModel):
         # Excluded PCI addresses per node.
         excluded_devices: dict[str, list[str]] | None = None
 
+    class _Endpoints(pydantic.BaseModel):
+        class _Endpoint(pydantic.BaseModel):
+            hostname: str | None = None
+            ip: pydantic.IPvAnyAddress | None = None
+
+        ingress_internal: _Endpoint | None = pydantic.Field(
+            None, alias="ingress-internal"
+        )
+        ingress_public: _Endpoint | None = pydantic.Field(None, alias="ingress-public")
+        ingress_rgw: _Endpoint | None = pydantic.Field(None, alias="ingress-rgw")
+
     proxy: _ProxyConfig | None = None
     bootstrap: _BootstrapConfig | None = None
     database: str | None = None
@@ -242,9 +253,7 @@ class CoreConfig(pydantic.BaseModel):
     addons: _Addons | None = None
     identity: _Identity | None = None
     k8s_addons: _K8sAddons | None = pydantic.Field(default=None, alias="k8s-addons")
-    traefik_endpoints: dict[str, str] | None = pydantic.Field(
-        default=None, alias="traefik-endpoints"
-    )
+    endpoints: _Endpoints | None = None
     user: _User | None = None
     external_network: _ExternalNetwork | None = None
     microceph_config: pydantic.RootModel[dict[str, _HostMicroCephConfig]] | None = None

--- a/sunbeam-python/sunbeam/core/openstack.py
+++ b/sunbeam-python/sunbeam/core/openstack.py
@@ -1,6 +1,66 @@
 # SPDX-FileCopyrightText: 2024 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
+import typing
+
+from rich.console import Console
+
+from sunbeam.core.questions import QuestionBank, show_questions
+
 OPENSTACK_MODEL = "openstack"
 REGION_CONFIG_KEY = "Region"
 DEFAULT_REGION = "RegionOne"
+ENDPOINTS_CONFIG_KEY = "Endpoints"
+
+INGRESS_ENDPOINT_TYPES = ["internal", "public", "rgw"]
+
+
+INGRESS_ENDPOINT_TERRAFORM_MAP = {
+    "internal": "traefik-config",
+    "public": "traefik-public-config",
+    "rgw": "traefik-rgw-config",
+}
+
+
+def get_ingress_endpoint_key(endpoint_type: str) -> str:
+    """Get the config key for an ingress endpoint type."""
+    return f"ingress-{endpoint_type}"
+
+
+def generate_endpoint_preseed_questions(
+    endpoint_questions_func: typing.Callable[[str], dict],
+    console: Console,
+    variables: dict,
+) -> list[str]:
+    """Generate preseed questions for endpoint configuration.
+
+    Args:
+        endpoint_questions_func: Function that takes endpoint type and returns questions
+        console: Rich console for output
+        variables: Previous answers/variables
+
+    Returns:
+        List of preseed content lines
+    """
+    preseed_content = ["    endpoints:"]
+
+    for endpoint in INGRESS_ENDPOINT_TYPES:
+        questions = endpoint_questions_func(endpoint)
+        questions = {
+            k: v for k, v in questions.items() if not k.startswith("configure")
+        }
+        endpoint_bank = QuestionBank(
+            questions=questions,
+            console=console,
+            previous_answers=variables.get(get_ingress_endpoint_key(endpoint), {}),
+        )
+        preseed_content.extend(
+            show_questions(
+                endpoint_bank,
+                section=get_ingress_endpoint_key(endpoint),
+                section_description=f"{endpoint.title()} Endpoint",
+                initial_indent=6,
+            )
+        )
+
+    return preseed_content

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -78,6 +78,7 @@ from sunbeam.provider.local.deployment import LOCAL_TYPE, LocalDeployment
 from sunbeam.provider.local.steps import (
     LocalClusterStatusStep,
     LocalConfigSRIOVStep,
+    LocalEndpointsConfigurationStep,
     LocalSetHypervisorUnitsOptionsStep,
 )
 from sunbeam.steps import cluster_status
@@ -816,6 +817,13 @@ def bootstrap(
         )
 
     if is_control_node:
+        plan1.append(
+            LocalEndpointsConfigurationStep(
+                client,
+                manifest,
+                accept_defaults=accept_defaults,
+            )
+        )
         plan1.append(
             DeployControlPlaneStep(
                 deployment,

--- a/sunbeam-python/sunbeam/provider/local/deployment.py
+++ b/sunbeam-python/sunbeam/provider/local/deployment.py
@@ -33,7 +33,11 @@ from sunbeam.core.juju import (
     JujuController,
 )
 from sunbeam.core.k8s import K8SHelper
-from sunbeam.core.openstack import REGION_CONFIG_KEY
+from sunbeam.core.openstack import (
+    ENDPOINTS_CONFIG_KEY,
+    REGION_CONFIG_KEY,
+    generate_endpoint_preseed_questions,
+)
 from sunbeam.core.questions import QuestionBank, load_answers, show_questions
 from sunbeam.provider.local.steps import local_hypervisor_questions
 from sunbeam.steps.clusterd import (
@@ -46,6 +50,7 @@ from sunbeam.steps.microceph import CONFIG_DISKS_KEY, microceph_questions
 from sunbeam.steps.openstack import (
     TOPOLOGY_KEY,
     database_topology_questions,
+    endpoint_questions,
     region_questions,
 )
 
@@ -268,6 +273,17 @@ class LocalDeployment(Deployment):
                 comment_out=True,
             )
         )
+
+        # Endpoints configuration
+        try:
+            variables = load_answers(client, ENDPOINTS_CONFIG_KEY)
+        except ClusterServiceUnavailableException:
+            variables = {}
+
+        preseed_content.extend(
+            generate_endpoint_preseed_questions(endpoint_questions, console, variables)
+        )
+
         try:
             variables = load_answers(client, CONFIG_DISKS_KEY)
         except ClusterServiceUnavailableException:

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -91,6 +91,7 @@ from sunbeam.provider.maas.steps import (
     MaasDeployInfraMachinesStep,
     MaasDeployK8SApplicationStep,
     MaasDeployMachinesStep,
+    MaasEndpointsConfigurationStep,
     MaasRemoveDeploymentCredentialsStep,
     MaasRemoveMachineFromClusterdStep,
     MaasSaveClusterdCredentialsStep,
@@ -745,6 +746,15 @@ def deploy(
             jhelper,
             deployment.openstack_machines_model,
             tfhelper_openstack_deploy,
+        )
+    )
+    plan2.append(
+        MaasEndpointsConfigurationStep(
+            deployment,
+            client,
+            maas_client,
+            manifest,
+            accept_defaults=accept_defaults,
         )
     )
     plan2.append(

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -1282,15 +1282,6 @@ class TestMaasDeployK8SApplicationStep:
                 "load-balancer-l2-mode": True,
                 "node-labels": "sunbeam/deployment=test_deployment",
             },
-            "traefik-config": {
-                "external_hostname": None,
-            },
-            "traefik-public-config": {
-                "external_hostname": None,
-            },
-            "traefik-rgw-config": {
-                "external_hostname": None,
-            },
         }
 
         assert step.extra_tfvars() == expected_tfvars
@@ -1311,7 +1302,7 @@ class TestMaasDeployK8SApplicationStep:
         )
         result = step.is_skip()
         assert result.result_type == ResultType.FAILED
-        assert result.message == "Failed to get ip ranges"
+        assert result.message == "Failed to find ip ranges for space: 'public_space'"
 
     def test_is_skip_with_no_public_ranges(self, mocker, deployment_k8s):
         mocker.patch(
@@ -1329,7 +1320,9 @@ class TestMaasDeployK8SApplicationStep:
         )
         result = step.is_skip()
         assert result.result_type == ResultType.FAILED
-        assert result.message == "No public ip range found"
+        assert (
+            result.message == "Failed to find public ip range for label: 'public_api'"
+        )
 
     def test_is_skip_with_internal_ranges_error(self, mocker, deployment_k8s):
         mocker.patch(
@@ -1358,7 +1351,7 @@ class TestMaasDeployK8SApplicationStep:
         )
         result = step.is_skip()
         assert result.result_type == ResultType.FAILED
-        assert result.message == "Failed to get ip ranges"
+        assert result.message == "Failed to find ip ranges for space: 'internal_space'"
 
     def test_is_skip_with_no_internal_ranges(self, mocker, deployment_k8s):
         mocker.patch(
@@ -1387,7 +1380,9 @@ class TestMaasDeployK8SApplicationStep:
         )
         result = step.is_skip()
         assert result.result_type == ResultType.FAILED
-        assert result.message == "No internal ip range found"
+        assert (
+            result.message == "Failed to find public ip range for label: 'internal_api'"
+        )
 
 
 class FakeIPPool:

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
@@ -20,7 +20,7 @@ from sunbeam.core.k8s import (
     METALLB_IP_ANNOTATION,
 )
 from sunbeam.core.manifest import Manifest
-from sunbeam.core.openstack import REGION_CONFIG_KEY
+from sunbeam.core.openstack import ENDPOINTS_CONFIG_KEY, REGION_CONFIG_KEY
 from sunbeam.core.terraform import TerraformException
 from sunbeam.steps.openstack import (
     DATABASE_MEMORY_KEY,
@@ -66,6 +66,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
                 }
             ),
             DATABASE_MEMORY_KEY: json.dumps({}),
+            ENDPOINTS_CONFIG_KEY: json.dumps({}),
         }
 
         def _read_config_mock(key):


### PR DESCRIPTION
Implement endpoint configuration functionality for OpenStack services, allowing users to set custom IP addresses and hostnames for internal, public, and RGW endpoints. This includes new configuration steps for both local and MAAS providers, enhanced manifest schema support, and integration with Terraform for traefik ingress configuration.

Observability endpoint configuration is excluded at the moment.