### PR TITLE
Increase wait timeout for ReapplyHypervisorTerraformPlanStep

### DIFF
--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -434,12 +434,14 @@ class ReapplyHypervisorTerraformPlanStep(BaseStep):
         except TerraformException as e:
             return Result(ResultType.FAILED, str(e))
 
+        # Wait for more time since parallel node joins will take time
+        # for openstack-hypervisor application to get settled
         try:
             self.jhelper.wait_application_ready(
                 APPLICATION,
                 self.model,
                 accepted_status=statuses,
-                timeout=HYPERVISOR_APP_TIMEOUT,
+                timeout=HYPERVISOR_UNIT_TIMEOUT,
             )
         except TimeoutError as e:
             LOG.warning(str(e))


### PR DESCRIPTION
Currently ReapplyHypervisorTerraformPlanStep will wait for application openstack-hypervisor to settle for 300 seconds. However during parallel node joins, the application will not settle until all the node joins deal with hypervisor steps.

Increase the wait timeout while waiting for application openstack-hypervisor to be active

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2121929