### PR TITLE
Add DPDK configuration

### DIFF
--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -5,6 +5,7 @@ import ipaddress
 import json
 import logging
 import os
+import typing
 from pathlib import Path
 
 import click
@@ -28,6 +29,8 @@ from sunbeam.core.terraform import (
 
 CLOUD_CONFIG_SECTION = "CloudConfig"
 PCI_CONFIG_SECTION = "PCI"
+DPDK_CONFIG_SECTION = "DPDK"
+
 LOG = logging.getLogger(__name__)
 console = Console()
 
@@ -169,6 +172,54 @@ def ext_net_questions_local_only():
     }
 
 
+def dpdk_questions():
+    return {
+        "enabled": sunbeam.core.questions.ConfirmQuestion(
+            "Enable and configure DPDK",
+            default_value=False,
+            description=(
+                "Enable OVS DPDK data path, handling packets in userspace. It provides "
+                "improved performance compared to the standard OVS kernel data path. "
+                "DPDK capable network interfaces are required."
+            ),
+        ),
+        "datapath_cores": sunbeam.core.questions.PromptQuestion(
+            "The number of cores allocated to OVS datapath processing",
+            default_value=0,
+            description=(
+                "The specified number of cores will be allocated to OVS datapath "
+                "processing, taking into account the NUMA location of physical "
+                "DPDK ports. Isolated cpu cores must be preconfigured using kernel "
+                "parameters."
+            ),
+        ),
+        "control_plane_cores": sunbeam.core.questions.PromptQuestion(
+            "The number of cores allocated to OVS control plane processing",
+            default_value=0,
+            description=(
+                "The specified number of cores will be allocated to OVS control "
+                "plane processing, taking into account the NUMA location of physical "
+                "DPDK ports. Isolated cpu cores must be preconfigured using kernel "
+                "parameters."
+            ),
+        ),
+        "memory": sunbeam.core.questions.PromptQuestion(
+            "The amount of memory in MB allocated to OVS from huge pages",
+            default_value=0,
+            description=(
+                "The total amount of memory in MB to allocate from huge pages for OVS "
+                "DPDK. The memory will be distributed across NUMA nodes based on the "
+                "location of the physical DPDK ports. Currently uses 1GB pages, make "
+                "sure to specify a multiple of 1024 and preallocate enough 1GB pages."
+            ),
+        ),
+        "driver": sunbeam.core.questions.PromptQuestion(
+            "The DPDK-compatible driver used for DPDK physical ports",
+            default_value="vfio-pci",
+        ),
+    }
+
+
 VARIABLE_DEFAULTS: dict[str, dict[str, str | int | bool | None]] = {
     "user": {
         "username": "demo",
@@ -283,6 +334,20 @@ def get_pci_whitelist_config(client: Client) -> dict:
     charm_config = {}
     variables = sunbeam.core.questions.load_answers(client, PCI_CONFIG_SECTION)
     charm_config["pci-device-specs"] = json.dumps(variables.get("pci_whitelist", "[]"))
+    return charm_config
+
+
+def get_dpdk_config(client: Client) -> dict:
+    charm_config = {}
+    variables = sunbeam.core.questions.load_answers(client, DPDK_CONFIG_SECTION)
+    charm_config["dpdk-enabled"] = variables.get("enabled", False)
+    charm_config["dpdk-datapath-cores"] = int(variables.get("datapath_cores") or 0)
+    charm_config["dpdk-control-plane-cores"] = int(
+        variables.get("control_plane_cores") or 0
+    )
+    charm_config["dpdk-memory"] = int(variables.get("memory") or 0)
+    charm_config["dpdk-driver"] = variables.get("driver") or "vfio-pci"
+    charm_config["dpdk-memory"] = int(variables.get("memory") or 0)
     return charm_config
 
 
@@ -617,6 +682,111 @@ class SetHypervisorUnitsOptionsStep(BaseStep):
                 LOG.debug(_message, exc_info=True)
                 return Result(ResultType.FAILED, _message)
         return Result(ResultType.COMPLETED)
+
+
+class BaseConfigDPDKStep(BaseStep):
+    """Prompt the user for DPDK configuration.
+
+    Subclasses are expected to provide the dpdk port list based on the
+    deployment type (local or maas).
+    """
+
+    def __init__(
+        self,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        manifest: Manifest | None = None,
+        accept_defaults: bool = False,
+    ):
+        super().__init__("DPDK Settings", "Configure DPDK")
+        self.client = client
+        self.jhelper = jhelper
+        self.model = model
+        self.manifest = manifest
+        self.accept_defaults = accept_defaults
+        self.variables: dict = {}
+
+        self.nics: typing.Any = None
+
+    def has_prompts(self) -> bool:
+        """Returns true if the step has prompts that it can ask the user."""
+        return True
+
+    def _prompt_nics(
+        self,
+        console: Console | None = None,
+        show_hint: bool = False,
+    ) -> None:
+        pass
+
+    def _get_dpdk_manifest_config(self) -> typing.Any:
+        if not self.manifest:
+            return None
+        return self.manifest.core.config.dpdk
+
+    def _get_dpdk_manifest_ports(self) -> dict:
+        dpdk_manifest_config = self._get_dpdk_manifest_config()
+        if dpdk_manifest_config and dpdk_manifest_config.ports:
+            return dpdk_manifest_config.ports
+        return {}
+
+    def prompt(
+        self,
+        console: Console | None = None,
+        show_hint: bool = False,
+    ) -> None:
+        """Prompt the user for DPDK configuration."""
+        self.variables = sunbeam.core.questions.load_answers(
+            self.client, DPDK_CONFIG_SECTION
+        )
+        preseed = {}
+        if self.manifest and (dpdk := self.manifest.core.config.dpdk):
+            preseed = dpdk.model_dump(by_alias=True)
+
+        dpdk_bank = sunbeam.core.questions.QuestionBank(
+            questions=dpdk_questions(),
+            console=console,
+            preseed=preseed,
+            previous_answers=self.variables,
+            accept_defaults=self.accept_defaults,
+            show_hint=show_hint,
+        )
+
+        self.variables["enabled"] = dpdk_bank.enabled.ask()
+        if not self.variables["enabled"]:
+            LOG.debug("DPDK disabled.")
+        else:
+            self._prompt_nics(console, show_hint)
+
+            self.variables["datapath_cores"] = dpdk_bank.datapath_cores.ask()
+            self.variables["control_plane_cores"] = dpdk_bank.control_plane_cores.ask()
+            self.variables["memory"] = dpdk_bank.memory.ask()
+            if int(self.variables["memory"] or 0) % 1024:
+                raise click.ClickException(
+                    "DPDK uses 1GB huge pages, please specify a multple of 1024. "
+                    "Received: %s (MB)." % self.variables["memory"]
+                )
+            self.variables["driver"] = dpdk_bank.driver.ask()
+
+        sunbeam.core.questions.write_answers(
+            self.client, DPDK_CONFIG_SECTION, self.variables
+        )
+
+    def run(self, status: Status | None = None) -> Result:
+        """Run the step to completion."""
+        return Result(ResultType.COMPLETED)
+
+    def is_skip(self, status: Status | None = None) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                 ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        if not self.nics:
+            return Result(ResultType.SKIPPED)
+        else:
+            return Result(ResultType.COMPLETED)
 
 
 def _sorter(cmd: tuple[str, click.Command]) -> int:

--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -185,7 +185,7 @@ def dpdk_questions():
         ),
         "datapath_cores": sunbeam.core.questions.PromptQuestion(
             "The number of cores allocated to OVS datapath processing",
-            default_value=0,
+            default_value="1",
             description=(
                 "The specified number of cores will be allocated to OVS datapath "
                 "processing, taking into account the NUMA location of physical "
@@ -195,7 +195,7 @@ def dpdk_questions():
         ),
         "control_plane_cores": sunbeam.core.questions.PromptQuestion(
             "The number of cores allocated to OVS control plane processing",
-            default_value=0,
+            default_value="1",
             description=(
                 "The specified number of cores will be allocated to OVS control "
                 "plane processing, taking into account the NUMA location of physical "
@@ -205,7 +205,7 @@ def dpdk_questions():
         ),
         "memory": sunbeam.core.questions.PromptQuestion(
             "The amount of memory in MB allocated to OVS from huge pages",
-            default_value=0,
+            default_value="1024",
             description=(
                 "The total amount of memory in MB to allocate from huge pages for OVS "
                 "DPDK. The memory will be distributed across NUMA nodes based on the "

--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -246,6 +246,15 @@ class CoreConfig(pydantic.BaseModel):
         ingress_public: _Endpoint | None = pydantic.Field(None, alias="ingress-public")
         ingress_rgw: _Endpoint | None = pydantic.Field(None, alias="ingress-rgw")
 
+    class _DPDK(pydantic.BaseModel):
+        enabled: bool = False
+        datapath_cores: int = 0
+        control_plane_cores: int = 0
+        # MB
+        memory: int = 0
+        driver: str = "vfio-pci"
+        ports: dict[str, list[str]]
+
     proxy: _ProxyConfig | None = None
     bootstrap: _BootstrapConfig | None = None
     database: str | None = None
@@ -258,6 +267,7 @@ class CoreConfig(pydantic.BaseModel):
     external_network: _ExternalNetwork | None = None
     microceph_config: pydantic.RootModel[dict[str, _HostMicroCephConfig]] | None = None
     pci: _PCI | None = None
+    dpdk: _DPDK | None = None
 
 
 class CoreManifest(pydantic.BaseModel):

--- a/sunbeam-python/sunbeam/core/questions.py
+++ b/sunbeam-python/sunbeam/core/questions.py
@@ -113,6 +113,7 @@ class Question(typing.Generic[T]):
         password: bool = False,
         validation_function: Callable[[T], None] | None = None,
         description: str | None = None,
+        accept_defaults: bool = False,
     ):
         """Setup question.
 
@@ -126,6 +127,7 @@ class Question(typing.Generic[T]):
         :param validation_function: A function to use to validate the answer,
                                     must raise ValueError when value is invalid.
         :param description: A description of the question, displayed when asking.
+        :param accept_defaults: Use the default and suppress the question.
         """
         self.preseed = None
         self.console = None
@@ -135,7 +137,7 @@ class Question(typing.Generic[T]):
         self.default_function = default_function
         self.default_value = default_value
         self.choices = choices
-        self.accept_defaults = False
+        self.accept_defaults = accept_defaults
         self.password = password
         self.validation_function = validation_function
         self.description = description

--- a/sunbeam-python/sunbeam/provider/common/nic_utils.py
+++ b/sunbeam-python/sunbeam/provider/common/nic_utils.py
@@ -21,6 +21,14 @@ def fetch_nics(client: Client, node_name: str, jhelper: JujuHelper, model: str):
     return json.loads(action_result.get("result", "{}"))
 
 
+def get_nic_str_repr(nic: dict):
+    """Get the string representation for a nic retrieved through list-nics."""
+    vendor = nic.get("vendor_name") or nic.get("vendor_id") or "Unknown vendor"
+    product = nic.get("product_name") or nic.get("product_id") or "Unknown product"
+    name = nic.get("name") or "Unknown ifname"
+    return f"{vendor} {product} ({name})"
+
+
 def is_sriov_nic_whitelisted(
     node_name: str,
     nic: dict,

--- a/sunbeam-python/sunbeam/provider/local/steps.py
+++ b/sunbeam-python/sunbeam/provider/local/steps.py
@@ -713,7 +713,9 @@ class LocalConfigDPDKStep(BaseConfigDPDKStep):
             nic_str_repr = nic_utils.get_nic_str_repr(nic)
             question = f"Enable interface DPDK mode? {nic_str_repr}"
             enable_dpdk = sunbeam.core.questions.ConfirmQuestion(
-                question, default_value=(nic["name"] in previous_nics)
+                question,
+                default_value=(nic["name"] in previous_nics),
+                accept_defaults=self.accept_defaults,
             ).ask()
             if enable_dpdk:
                 enabled_nic_names.append(nic["name"])

--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -15,6 +15,7 @@ from sunbeam.clusterd.service import (
     NodeNotExistInClusterException,
 )
 from sunbeam.commands.configure import (
+    get_dpdk_config,
     get_external_network_configs,
     get_pci_whitelist_config,
 )
@@ -419,6 +420,10 @@ class ReapplyHypervisorTerraformPlanStep(BaseStep):
         pci_whitelist_config = get_pci_whitelist_config(self.client)
         LOG.debug("Adding PCI whitelist configuration: %s", pci_whitelist_config)
         self.extra_tfvars["charm_config"].update(pci_whitelist_config)
+
+        dpdk_config = get_dpdk_config(self.client)
+        LOG.debug("Adding DPDK configuration: %s", dpdk_config)
+        self.extra_tfvars["charm_config"].update(dpdk_config)
 
         statuses = ["active", "unknown"]
         if len(self.client.cluster.list_nodes_by_role("storage")) < 1:

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_hypervisor.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_hypervisor.py
@@ -189,6 +189,10 @@ class TestReapplyHypervisorTerraformPlanStep(unittest.TestCase):
             "sunbeam.steps.hypervisor.get_pci_whitelist_config",
             Mock(return_value={}),
         )
+        self.get_dpdk_config = patch(
+            "sunbeam.steps.hypervisor.get_dpdk_config",
+            Mock(return_value={}),
+        )
 
     def setUp(self):
         self.client = Mock()
@@ -196,6 +200,7 @@ class TestReapplyHypervisorTerraformPlanStep(unittest.TestCase):
         self.read_config.start()
         self.get_network_config.start()
         self.get_pci_whitelist_config.start()
+        self.get_dpdk_config.start()
         self.tfhelper = Mock()
         self.jhelper = Mock()
         self.manifest = Mock()
@@ -204,6 +209,7 @@ class TestReapplyHypervisorTerraformPlanStep(unittest.TestCase):
         self.read_config.stop()
         self.get_network_config.stop()
         self.get_pci_whitelist_config.stop()
+        self.get_dpdk_config.stop()
 
     def test_is_skip(self):
         self.client.cluster.list_nodes_by_role.return_value = ["node-1"]
@@ -229,8 +235,9 @@ class TestReapplyHypervisorTerraformPlanStep(unittest.TestCase):
 
     @patch("sunbeam.steps.hypervisor.get_external_network_configs")
     @patch("sunbeam.steps.hypervisor.get_pci_whitelist_config")
+    @patch("sunbeam.steps.hypervisor.get_dpdk_config")
     def test_run_after_configure_step(
-        self, get_pci_whitelist_config, get_external_network_configs
+        self, get_dpdk_config, get_pci_whitelist_config, get_external_network_configs
     ):
         # This is a case where external network configs are already added
         # and Reapply terraform plan is called.
@@ -244,8 +251,16 @@ class TestReapplyHypervisorTerraformPlanStep(unittest.TestCase):
         pci_config_tfvars = {
             "pci-device-specs": '[{"vendor_id": "8086", "product_id": "1563", "physical_network": "physnet1"}]'
         }
+        dpdk_config_tfvars = {
+            "dpdk-enabled": False,
+            "dpdk-datapath-cores": 0,
+            "dpdk-controlplane-cores": 0,
+            "dpdk-memory": 0,
+            "dpdk-driver": "vfio-pci",
+        }
         get_external_network_configs.return_value = network_config_tfvars
         get_pci_whitelist_config.return_value = pci_config_tfvars
+        get_dpdk_config.return_value = dpdk_config_tfvars
         step = ReapplyHypervisorTerraformPlanStep(
             self.client, self.tfhelper, self.jhelper, self.manifest, "test-model"
         )
@@ -256,6 +271,7 @@ class TestReapplyHypervisorTerraformPlanStep(unittest.TestCase):
         expected_override_tfvars = {"charm_config": {}}
         expected_override_tfvars["charm_config"].update(network_config_tfvars)
         expected_override_tfvars["charm_config"].update(pci_config_tfvars)
+        expected_override_tfvars["charm_config"].update(dpdk_config_tfvars)
 
         override_tfvars_from_mock_call = (
             self.tfhelper.update_tfvars_and_apply_tf.call_args.kwargs.get(


### PR DESCRIPTION
This PR will allow enabling and configuring OVS DPDK, specifically:

* the number of cores used by the OVS DPDK control plane and data path
* the amount of memory used by OVS DPDK from huge pages
* physical DPDK ports
* DPDK-compatible driver (defaults to vfio-pci)

The specified amount of cores will be reserved in the EPA service, make sure to configure isolated CPUs using kernel arguments. At the same time, 1GB huge pages must be preallocated.

The pinned CPUs and memory will be distributed across NUMA nodes based on the NUMA location of the physical DPDK interfaces.

Note that the specified DPDK interfaces will be persistently bound to the configured DPDK-compatible driver and will no longer be visible on the host.

Any physical interfaces that are going to be used with DPDK are expected to be connected to OVS bridges, either directly or through a bond. The bridge and bond definitions should be predefined through Maas/Netplan.

The openstack-hypervisor charm will take care of disabling the system ovs installation, move bridge definitions to the snap installation (through netplan) and then reconfigure them to use the newly defined DPDK ports.

Note that Netplan is not aware of DPDK ports, as such those will be removed from the Netplan configuration and defined in OVS.

We expect the host Netplan installation to include the following change in order to work with snap OVS installations: https://github.com/canonical/netplan/pull/549