### PR TITLE
Retry fetching k8s nodes in EnsureK8SUnitsTaggedStep

### DIFF
--- a/sunbeam-python/sunbeam/core/k8s.py
+++ b/sunbeam-python/sunbeam/core/k8s.py
@@ -168,6 +168,14 @@ class K8SHelper:
         )
 
 
+def list_nodes(client: "l_client.Client", labels: dict) -> list["core_v1.Node"]:
+    """List all the nodes."""
+    try:
+        return list(client.list(core_v1.Node, labels=labels))
+    except l_exceptions.ApiError as e:
+        raise K8SError("Failed to list nodes") from e
+
+
 def find_node(client: "l_client.Client", name: str) -> "core_v1.Node":
     """Find a node by name."""
     try:

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -776,6 +776,18 @@ class TestEnsureK8SUnitsTaggedStep(unittest.TestCase):
         self.client.cluster.list_nodes_by_role.return_value = [
             {"name": "node1", "machineid": "1"}
         ]
+        self.jhelper.get_machines.return_value = {
+            "1": Mock(
+                network_interfaces={
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.1"])
+                }
+            ),
+            "2": Mock(
+                network_interfaces={
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.2"])
+                }
+            ),
+        }
         api_error = ApiError.__new__(ApiError)
         api_error.status = Mock(code=500)
         self.kube.list.side_effect = api_error


### PR DESCRIPTION
EnsureK8SUnitsTaggedStep tries to ensure the hostname tag/label is attached to k8s Node object for a given machine. The step tries to read the k8s node information and filters the node based on machine/node IP in
management space.

However in some cases the k8s node status is not yet updated with IP information. In this case the step fails as there are no nodes filtered.

Retry the function that filters the nodes and checks for hostname tag/label. Get the k8s node information within this function instead of passing k8s nodes as parameter to get the latest k8s node information.

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2121840