### PR TITLE
[vault] Increase charm status update timeout

### DIFF
--- a/sunbeam-python/sunbeam/features/vault/feature.py
+++ b/sunbeam-python/sunbeam/features/vault/feature.py
@@ -65,7 +65,7 @@ from sunbeam.versions import VAULT_CHANNEL
 
 VAULT_COMMAND_TIMEOUT = 300  # 5 minutes
 VAULT_CHARM_UPDATES_TIMEOUT = (
-    360  # 6 minutes, slightly greater than update-status interval
+    600  # 10 minutes, note that charm status get updated on update-status interval
 )
 VAULT_APPLICATION_NAME = "vault"
 VAULT_CONTAINER_NAME = "vault"


### PR DESCRIPTION
Commit [1] increases the timeout on app readiness
to ensure the status is not flaky.

Due to this reason, the vault charm status wait
timeout need to be increased. Current value of
6 minutes is not good enough as the vault charm
gets updates only on update-status hook

Increase the timeout value to 10 min

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2122478

[1] https://github.com/canonical/snap-openstack/commit/24c84d273e1dada7619910caf39e3c525a33bc57