### PR TITLE
[observability] Increase timeout to 30 minutes

### DIFF
--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -85,7 +85,7 @@ console = Console()
 
 OBSERVABILITY_FEATURE_KEY = "ObservabilityProviderType"
 OBSERVABILITY_MODEL = "observability"
-OBSERVABILITY_DEPLOY_TIMEOUT = 1200  # 20 minutes
+OBSERVABILITY_DEPLOY_TIMEOUT = 1800  # 30 minutes
 COS_TFPLAN = "cos-plan"
 GRAFANA_AGENT_TFPLAN = "grafana-agent-plan"
 COS_CONFIG_KEY = "TerraformVarsFeatureObservabilityPlanCos"


### PR DESCRIPTION
Sometimes grafana-agent deployment times out waiting for one of the unit in install hook. However the
unit comes to active state after sometime.

Increase timeout to wait for apps to 30 minutes

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2122552