### PR TITLE
Apply configured PCI aliases

### DIFF
--- a/sunbeam-python/sunbeam/commands/configure.py
+++ b/sunbeam-python/sunbeam/commands/configure.py
@@ -333,7 +333,7 @@ def get_external_network_configs(client: Client) -> dict:
 def get_pci_whitelist_config(client: Client) -> dict:
     charm_config = {}
     variables = sunbeam.core.questions.load_answers(client, PCI_CONFIG_SECTION)
-    charm_config["pci-device-specs"] = json.dumps(variables.get("pci_whitelist", "[]"))
+    charm_config["pci-device-specs"] = json.dumps(variables.get("pci_whitelist", []))
     return charm_config
 
 

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -911,29 +911,6 @@ def bootstrap(
                 AddHypervisorUnitsStep(
                     client, fqdn, jhelper, deployment.openstack_machines_model
                 ),
-                LocalConfigSRIOVStep(
-                    client,
-                    fqdn,
-                    jhelper,
-                    deployment.openstack_machines_model,
-                    manifest,
-                    accept_defaults,
-                ),
-                LocalConfigDPDKStep(
-                    client,
-                    fqdn,
-                    jhelper,
-                    deployment.openstack_machines_model,
-                    manifest,
-                    accept_defaults,
-                ),
-                ReapplyHypervisorTerraformPlanStep(
-                    client,
-                    hypervisor_tfhelper,
-                    jhelper,
-                    manifest,
-                    model=deployment.openstack_machines_model,
-                ),
             ]
         )
 

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -1448,6 +1448,15 @@ def join(
                 ),
             ]
         )
+        if manifest and manifest.core.config.pci and manifest.core.config.pci.aliases:
+            plan4.append(
+                ReapplyOpenStackTerraformPlanStep(
+                    client,
+                    openstack_tfhelper,
+                    jhelper,
+                    manifest,
+                )
+            )
 
     run_plan(plan4, console, show_hints)
 

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -163,6 +163,7 @@ from sunbeam.steps.openstack import (
     OpenStackPatchLoadBalancerServicesIPStep,
     PromptDatabaseTopologyStep,
     PromptRegionStep,
+    ReapplyOpenStackTerraformPlanStep,
 )
 from sunbeam.steps.sso import (
     DeployIdentityProvidersStep,
@@ -983,6 +984,7 @@ def configure_sriov(
     admin_credentials["OS_INSECURE"] = "true"
 
     tfhelper_hypervisor = deployment.get_tfhelper("hypervisor-plan")
+    tfhelper_openstack = deployment.get_tfhelper("openstack-plan")
 
     plan: list[BaseStep] = [
         LocalConfigSRIOVStep(
@@ -1003,6 +1005,15 @@ def configure_sriov(
             model=deployment.openstack_machines_model,
         ),
     ]
+    if manifest and manifest.core.config.pci and manifest.core.config.pci.aliases:
+        plan.append(
+            ReapplyOpenStackTerraformPlanStep(
+                client,
+                tfhelper_openstack,
+                jhelper,
+                manifest,
+            )
+        )
     run_plan(plan, console, show_hints)
 
 

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -864,6 +864,16 @@ def deploy(
         ),
     ]
 
+    if manifest and manifest.core.config.pci and manifest.core.config.pci.aliases:
+        plan2.append(
+            ReapplyOpenStackTerraformPlanStep(
+                client,
+                tfhelper_openstack_deploy,
+                jhelper,
+                manifest,
+            )
+        )
+
     plan2.append(SetBootstrapped(client))
     run_plan(plan2, console, show_hints)
 

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -177,6 +177,7 @@ from sunbeam.steps.openstack import (
     OpenStackPatchLoadBalancerServicesIPStep,
     PromptDatabaseTopologyStep,
     PromptRegionStep,
+    ReapplyOpenStackTerraformPlanStep,
 )
 from sunbeam.steps.sso import (
     DeployIdentityProvidersStep,
@@ -1743,6 +1744,7 @@ def configure_sriov(
     admin_credentials["OS_INSECURE"] = "true"
 
     tfhelper_hypervisor = deployment.get_tfhelper("hypervisor-plan")
+    tfhelper_openstack = deployment.get_tfhelper("openstack-plan")
 
     plan: list[BaseStep] = [
         MaasConfigSRIOVStep(
@@ -1761,6 +1763,15 @@ def configure_sriov(
             model=deployment.openstack_machines_model,
         ),
     ]
+    if manifest and manifest.core.config.pci and manifest.core.config.pci.aliases:
+        plan.append(
+            ReapplyOpenStackTerraformPlanStep(
+                client,
+                tfhelper_openstack,
+                jhelper,
+                manifest,
+            )
+        )
     run_plan(plan, console, show_hints)
 
 

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
@@ -52,6 +52,7 @@ class TestDeployControlPlaneStep(unittest.TestCase):
         self.jhelper.run_action.return_value = {}
         self.tfhelper = Mock()
         self.manifest = MagicMock()
+        self.manifest.core.config.pci = None
         self.client = Mock()
         self.deployment = Mock()
         self.deployment.get_client.return_value = self.client
@@ -585,6 +586,7 @@ class TestReapplyOpenStackTerraformPlanStep(unittest.TestCase):
         self.tfhelper = Mock()
         self.jhelper = Mock()
         self.manifest = Mock()
+        self.manifest.core.config.pci = None
 
     def tearDown(self):
         self.read_config.stop()


### PR DESCRIPTION
The Sunbeam manifest allows defining Nova PCI aliases, however the setting is currently ignored.

This change will ensure that the aliases are propagated to the nova-k8s charm.