### PR TITLE
Adds manila-data charm to the shared-filesystem feature

### DIFF
--- a/.github/assets/testing/edge.yml
+++ b/.github/assets/testing/edge.yml
@@ -99,6 +99,15 @@ features:
       charms:
         barbican-k8s:
           channel: 2024.1/edge
+  shared-filesystem:
+    software:
+      charms:
+        manila-k8s:
+          channel: 2024.1/edge
+        manila-cephfs-k8s:
+          channel: 2024.1/edge
+        manila-data:
+          channel: 2024.1/edge
   telemetry:
     software:
       charms:

--- a/.github/assets/testing/manifest.yml
+++ b/.github/assets/testing/manifest.yml
@@ -32,6 +32,12 @@ core:
         channel: OS_CHARM
       magnum-k8s:
         channel: OS_CHARM
+      manila-k8s:
+        channel: OS_CHARM
+      manila-cephfs-k8s:
+        channel: OS_CHARM
+      manila-data:
+        channel: OS_CHARM
       neutron-k8s:
         channel: OS_CHARM
       nova-k8s:

--- a/manifests/beta.yml
+++ b/manifests/beta.yml
@@ -96,6 +96,8 @@ features:
           channel: 2024.1/beta
         manila-cephfs-k8s:
           channel: 2024.1/beta
+        manila-data:
+          channel: 2024.1/beta
   telemetry:
     software:
       charms:

--- a/manifests/candidate.yml
+++ b/manifests/candidate.yml
@@ -96,6 +96,8 @@ features:
           channel: 2024.1/candidate
         manila-cephfs-k8s:
           channel: 2024.1/candidate
+        manila-data:
+          channel: 2024.1/candidate
   telemetry:
     software:
       charms:

--- a/manifests/edge.yml
+++ b/manifests/edge.yml
@@ -93,6 +93,8 @@ features:
           channel: 2024.1/edge
         manila-cephfs-k8s:
           channel: 2024.1/edge
+        manila-data:
+          channel: 2024.1/edge
   secrets:
     software:
       charms:

--- a/manifests/stable.yml
+++ b/manifests/stable.yml
@@ -98,6 +98,8 @@ features:
           channel: 2024.1/stable
         manila-cephfs-k8s:
           channel: 2024.1/stable
+        manila-data:
+          channel: 2024.1/stable
   telemetry:
     software:
       charms:

--- a/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/main.tf
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/main.tf
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "= 0.20.0"
+    }
+  }
+}
+
+provider "juju" {}
+
+data "juju_model" "machine_model" {
+  name = var.machine_model
+}
+
+resource "juju_application" "manila-data" {
+  name  = "manila-data"
+  trust = true
+  model = data.juju_model.machine_model.name
+  units = length(var.machine_ids)
+
+  charm {
+    name     = "manila-data"
+    channel  = var.charm-manila-data-channel
+    revision = var.charm-manila-data-revision
+    base     = "ubuntu@24.04"
+  }
+
+  config = merge({
+    snap-channel = var.manila-data-channel
+  }, var.charm-manila-data-config)
+  endpoint_bindings = var.endpoint_bindings
+}
+
+resource "juju_integration" "manila-data-identity" {
+  count = (var.keystone-offer-url != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.manila-data.name
+    endpoint = "identity-credentials"
+  }
+
+  application {
+    offer_url = var.keystone-offer-url
+    endpoint  = "identity-credentials"
+  }
+}
+
+resource "juju_integration" "manila-data-amqp" {
+  count = (var.amqp-offer-url != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.manila-data.name
+    endpoint = "amqp"
+  }
+
+  application {
+    offer_url = var.amqp-offer-url
+  }
+}
+
+resource "juju_integration" "manila-data-database" {
+  count = (var.database-offer-url != null) ? 1 : 0
+  model = var.machine_model
+
+  application {
+    name     = juju_application.manila-data.name
+    endpoint = "database"
+  }
+
+  application {
+    offer_url = var.database-offer-url
+  }
+}

--- a/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/variables.tf
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/variables.tf
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+variable "charm-manila-data-channel" {
+  description = "Operator channel for manila_data deployment"
+  type        = string
+  default     = "2024.1/edge"
+}
+
+variable "charm-manila-data-revision" {
+  description = "Operator channel revision for manila_data deployment"
+  type        = number
+  default     = null
+}
+
+variable "charm-manila-data-config" {
+  description = "Operator config for manila_data deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "charm_manila_data_config" {
+  description = "Operator config for manila_data deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "manila-data-channel" {
+  description = "Manila Data snap channel to deploy, not the operator channel"
+  default     = "2024.1/edge"
+}
+
+variable "machine_ids" {
+  description = "List of machine ids to include"
+  type        = list(string)
+  default     = []
+}
+
+variable "machine_model" {
+  description = "Model to deploy to"
+  type        = string
+}
+
+variable "endpoint_bindings" {
+  description = "Endpoint bindings for manila_data"
+  type        = set(map(string))
+  default     = null
+}
+
+variable "keystone-offer-url" {
+  description = "Offer URL for openstack keystone endpoints"
+  type        = string
+  default     = null
+}
+
+variable "amqp-offer-url" {
+  description = "Offer URL for amqp"
+  type        = string
+  default     = null
+}
+
+variable "database-offer-url" {
+  description = "Offer URL for database"
+  type        = string
+  default     = null
+}

--- a/sunbeam-python/sunbeam/features/shared_filesystem/manila_data.py
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/manila_data.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from typing import Any
+
+from rich.status import Status
+
+from sunbeam.clusterd.client import Client
+from sunbeam.clusterd.service import (
+    ConfigItemNotFoundException,
+)
+from sunbeam.core.common import Result, ResultType, read_config
+from sunbeam.core.deployment import Deployment, Networks
+from sunbeam.core.juju import (
+    JujuHelper,
+)
+from sunbeam.core.manifest import Manifest
+from sunbeam.core.steps import (
+    AddMachineUnitsStep,
+    DeployMachineApplicationStep,
+    DestroyMachineApplicationStep,
+)
+from sunbeam.core.terraform import TerraformException, TerraformHelper
+
+LOG = logging.getLogger(__name__)
+CONFIG_KEY = "TerraformVarsManilaDataPlan"
+APPLICATION = "manila-data"
+MANILA_DATA_APP_TIMEOUT = 600
+MANILA_DATA_UNIT_TIMEOUT = 600
+
+
+def get_mandatory_control_plane_offers(
+    tfhelper: TerraformHelper,
+) -> dict[str, str | None]:
+    """Get mandatory control plane offers."""
+    openstack_tf_output = tfhelper.output()
+
+    tfvars = {
+        "keystone-offer-url": openstack_tf_output.get("keystone-offer-url"),
+        "database-offer-url": openstack_tf_output.get("manila-data-database-offer-url"),
+        "amqp-offer-url": openstack_tf_output.get("rabbitmq-offer-url"),
+    }
+    return tfvars
+
+
+class DeployManilaDataApplicationStep(DeployMachineApplicationStep):
+    """Deploy Manila Data application using Terraform."""
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+        model: str,
+        refresh: bool = False,
+    ):
+        super().__init__(
+            deployment,
+            client,
+            tfhelper,
+            jhelper,
+            manifest,
+            CONFIG_KEY,
+            APPLICATION,
+            model,
+            "Deploy Manila Data",
+            "Deploying Manila Data",
+            refresh,
+        )
+        self._offers: dict[str, str | None] = {}
+
+    def get_application_timeout(self) -> int:
+        """Return application timeout in seconds."""
+        return MANILA_DATA_APP_TIMEOUT
+
+    def get_accepted_application_status(self) -> list[str]:
+        """Return accepted application status."""
+        accepted_status = super().get_accepted_application_status()
+        offers = self._get_offers()
+        if not offers or not all(offers.values()):
+            accepted_status.append("blocked")
+        return accepted_status
+
+    def _get_offers(self):
+        if not self._offers:
+            self._offers = get_mandatory_control_plane_offers(
+                self.deployment.get_tfhelper("openstack-plan")
+            )
+        return self._offers
+
+    def extra_tfvars(self) -> dict:
+        """Extra terraform vars to pass to terraform apply."""
+        # storage_nodes = self.client.cluster.list_nodes_by_role("storage")
+        tfvars: dict[str, Any] = {
+            "endpoint_bindings": [
+                {
+                    "space": self.deployment.get_space(Networks.MANAGEMENT),
+                },
+                {
+                    "endpoint": "amqp",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "database",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+                {
+                    "endpoint": "identity-credentials",
+                    "space": self.deployment.get_space(Networks.INTERNAL),
+                },
+            ],
+            "charm-manila-data-config": {},
+        }
+
+        tfvars.update(self._get_offers())
+
+        return tfvars
+
+
+class AddManilaDataUnitsStep(AddMachineUnitsStep):
+    """Add Manila Data Unit."""
+
+    def __init__(
+        self,
+        client: Client,
+        names: list[str] | str,
+        jhelper: JujuHelper,
+        model: str,
+        openstack_tfhelper: TerraformHelper,
+    ):
+        super().__init__(
+            client,
+            names,
+            jhelper,
+            CONFIG_KEY,
+            APPLICATION,
+            model,
+            "Add Manila Data unit",
+            "Adding Manila Data unit to machine",
+        )
+        self.os_tfhelper = openstack_tfhelper
+
+    def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
+        return MANILA_DATA_UNIT_TIMEOUT
+
+    def get_accepted_unit_status(self) -> dict[str, list[str]]:
+        """Accepted status to pass wait_units_ready function."""
+        offers = get_mandatory_control_plane_offers(self.os_tfhelper)
+
+        allow_blocked = {"agent": ["idle"], "workload": ["active", "blocked"]}
+        if not offers or not all(offers.values()):
+            return allow_blocked
+
+        try:
+            config = read_config(self.client, CONFIG_KEY)
+        except ConfigItemNotFoundException:
+            config = {}
+
+        # check if values in offers are the same in config
+        for key, value in offers.items():
+            if key not in config or config[key] != value:
+                return allow_blocked
+
+        return super().get_accepted_unit_status()
+
+
+class DestroyManilaDataApplicationStep(DestroyMachineApplicationStep):
+    """Destroy Manila Data application using Terraform."""
+
+    def __init__(
+        self,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+        model: str,
+    ):
+        super().__init__(
+            client,
+            tfhelper,
+            jhelper,
+            manifest,
+            CONFIG_KEY,
+            [APPLICATION],
+            model,
+            "Destroy Manila Data",
+            "Destroying Manila Data",
+        )
+
+    def get_application_timeout(self) -> int:
+        """Return application timeout in seconds."""
+        return MANILA_DATA_APP_TIMEOUT
+
+    def run(self, status: Status | None = None) -> Result:
+        """Destroy Manila Data application."""
+        # note(gboutry):this is a workaround for
+        # https://github.com/juju/terraform-provider-juju/issues/473
+        try:
+            resources = self.tfhelper.state_list()
+        except TerraformException as e:
+            LOG.debug(f"Failed to list terraform state: {str(e)}")
+            return Result(ResultType.FAILED, "Failed to list terraform state")
+
+        for resource in resources:
+            if "integration" in resource:
+                try:
+                    self.tfhelper.state_rm(resource)
+                except TerraformException as e:
+                    LOG.debug(f"Failed to remove resource {resource}: {str(e)}")
+                    return Result(
+                        ResultType.FAILED,
+                        f"Failed to remove resource {resource} from state",
+                    )
+
+        return super().run(status)

--- a/sunbeam-python/tests/unit/sunbeam/features/shared_filesystem/test_manila_data.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/shared_filesystem/test_manila_data.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+
+from sunbeam.clusterd.service import (
+    ConfigItemNotFoundException,
+)
+from sunbeam.core.common import ResultType
+from sunbeam.core.deployment import Networks
+from sunbeam.core.terraform import TerraformException
+from sunbeam.features.shared_filesystem.manila_data import (
+    MANILA_DATA_APP_TIMEOUT,
+    MANILA_DATA_UNIT_TIMEOUT,
+    AddManilaDataUnitsStep,
+    DeployManilaDataApplicationStep,
+    DestroyManilaDataApplicationStep,
+)
+
+
+class TestDeployManilaDataApplicationStep(unittest.TestCase):
+    def setUp(self):
+        self.deployment = MagicMock()
+        self.client = MagicMock()
+        self.tfhelper = MagicMock()
+        self.os_tfhelper = MagicMock()
+        self.jhelper = MagicMock()
+        self.manifest = MagicMock()
+        self.model = "test-model"
+        self.deployment.get_tfhelper.side_effect = lambda plan: {
+            "openstack-plan": self.os_tfhelper,
+        }[plan]
+        self.deploy_manila_data_step = DeployManilaDataApplicationStep(
+            self.deployment,
+            self.client,
+            self.tfhelper,
+            self.jhelper,
+            self.manifest,
+            self.model,
+        )
+
+    def test_get_unit_timeout(self):
+        self.assertEqual(
+            self.deploy_manila_data_step.get_application_timeout(),
+            MANILA_DATA_APP_TIMEOUT,
+        )
+
+    def test_get_accepted_application_status(self):
+        self.deploy_manila_data_step._get_offers = Mock(
+            return_value={"keystone-offer-url": None}
+        )
+
+        accepted_status = self.deploy_manila_data_step.get_accepted_application_status()
+        self.assertIn("blocked", accepted_status)
+
+    def test_get_accepted_application_status_with_offers(self):
+        self.deploy_manila_data_step._get_offers = Mock(
+            return_value={"keystone-offer-url": "url"}
+        )
+
+        accepted_status = self.deploy_manila_data_step.get_accepted_application_status()
+        self.assertNotIn("blocked", accepted_status)
+
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.get_mandatory_control_plane_offers",
+        return_value={"keystone-offer-url": "url"},
+    )
+    def test_get_offers(self, mandatory_control_plane_offers):
+        self.assertDictEqual(self.deploy_manila_data_step._offers, {})
+        self.deploy_manila_data_step._get_offers()
+        mandatory_control_plane_offers.assert_called_once()
+        self.assertDictEqual(
+            self.deploy_manila_data_step._offers,
+            mandatory_control_plane_offers.return_value,
+        )
+        mandatory_control_plane_offers.reset_mock()
+        self.deploy_manila_data_step._get_offers()
+        # Should not call again
+        mandatory_control_plane_offers.assert_not_called()
+
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.get_mandatory_control_plane_offers",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    def test_extra_tfvars(self, get_mandatory_control_plane_offers):
+        self.deployment.get_space.side_effect = lambda network: {
+            Networks.MANAGEMENT: "management",
+            Networks.INTERNAL: "internal",
+        }[network]
+
+        tfvars = self.deploy_manila_data_step.extra_tfvars()
+
+        expected_tfvars = {
+            "endpoint_bindings": [
+                {
+                    "space": "management",
+                },
+                {
+                    "endpoint": "amqp",
+                    "space": "internal",
+                },
+                {
+                    "endpoint": "database",
+                    "space": "internal",
+                },
+                {
+                    "endpoint": "identity-credentials",
+                    "space": "internal",
+                },
+            ],
+            "charm-manila-data-config": {},
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        }
+        self.assertEqual(tfvars, expected_tfvars)
+
+
+class TestAddManilaDataUnitsStep(unittest.TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+        self.names = ["node1"]
+        self.jhelper = MagicMock()
+        self.model = "test-model"
+        self.os_tfhelper = MagicMock()
+        self.add_manila_data_units_step = AddManilaDataUnitsStep(
+            self.client,
+            self.names,
+            self.jhelper,
+            self.model,
+            self.os_tfhelper,
+        )
+
+    def test_get_unit_timeout(self):
+        self.assertEqual(
+            self.add_manila_data_units_step.get_unit_timeout(),
+            MANILA_DATA_UNIT_TIMEOUT,
+        )
+
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.get_mandatory_control_plane_offers",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.read_config",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    def test_get_accepted_unit_status(
+        self, get_mandatory_control_plane_offers, read_config
+    ):
+        self.client.cluster.list_nodes_by_role.return_value = ["node1"]
+        accepted_status = self.add_manila_data_units_step.get_accepted_unit_status()
+        self.assertNotIn("blocked", accepted_status["workload"])
+        get_mandatory_control_plane_offers.assert_called_once()
+        read_config.assert_called_once()
+
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.get_mandatory_control_plane_offers",
+        return_value={"keystone-offer-url": None},
+    )
+    def test_get_accepted_unit_status_with_missing_offers(
+        self, get_mandatory_control_plane_offers
+    ):
+        accepted_status = self.add_manila_data_units_step.get_accepted_unit_status()
+        self.assertIn("blocked", accepted_status["workload"])
+        get_mandatory_control_plane_offers.assert_called_once()
+
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.get_mandatory_control_plane_offers",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.read_config",
+        return_value={
+            "keystone-offer-url": "keystone-differ",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    def test_get_accepted_unit_status_with_different_config(
+        self, get_mandatory_control_plane_offers, read_config
+    ):
+        accepted_status = self.add_manila_data_units_step.get_accepted_unit_status()
+        self.assertIn("blocked", accepted_status["workload"])
+        get_mandatory_control_plane_offers.assert_called_once()
+        read_config.assert_called_once()
+
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.get_mandatory_control_plane_offers",
+        return_value={
+            "keystone-offer-url": "keystone-offer",
+            "database-offer-url": "database-offer",
+            "amqp-offer-url": "amqp-offer",
+        },
+    )
+    @patch(
+        "sunbeam.features.shared_filesystem.manila_data.read_config",
+        side_effect=ConfigItemNotFoundException("config not found"),
+    )
+    def test_get_accepted_unit_status_with_config_exception(
+        self, get_mandatory_control_plane_offers, read_config
+    ):
+        accepted_status = self.add_manila_data_units_step.get_accepted_unit_status()
+        self.assertIn("blocked", accepted_status["workload"])
+        get_mandatory_control_plane_offers.assert_called_once()
+        read_config.assert_called_once()
+
+
+class TestDestroyManilaDataApplicationStep(unittest.TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+        self.tfhelper = MagicMock()
+        self.jhelper = MagicMock()
+        self.manifest = MagicMock()
+        self.model = "test-model"
+        self.destroy_manila_data_app_step = DestroyManilaDataApplicationStep(
+            self.client,
+            self.tfhelper,
+            self.jhelper,
+            self.manifest,
+            self.model,
+        )
+
+    def test_get_unit_timeout(self):
+        self.assertEqual(
+            self.destroy_manila_data_app_step.get_application_timeout(),
+            MANILA_DATA_APP_TIMEOUT,
+        )
+
+    def test_run_state_list_failed(self):
+        self.tfhelper.state_list.side_effect = TerraformException("expected")
+
+        result = self.destroy_manila_data_app_step.run()
+
+        self.assertEqual(result.result_type, ResultType.FAILED)
+        self.tfhelper.state_list.assert_called_once_with()
+
+    def test_run_state_rm_failed(self):
+        self.tfhelper.state_list.return_value = ["db-integration"]
+        self.tfhelper.state_rm.side_effect = TerraformException("expected")
+
+        result = self.destroy_manila_data_app_step.run()
+
+        self.assertEqual(result.result_type, ResultType.FAILED)
+        self.tfhelper.state_list.assert_called_once_with()
+        self.tfhelper.state_rm.assert_called_once_with("db-integration")
+
+    def test_run(self):
+        self.tfhelper.state_list.return_value = ["db-integration", "other"]
+
+        result = self.destroy_manila_data_app_step.run()
+
+        self.assertEqual(result.result_type, ResultType.COMPLETED)
+        self.tfhelper.state_list.assert_called_once_with()
+        self.tfhelper.state_rm.assert_called_once_with("db-integration")


### PR DESCRIPTION
`manila-data` is a machine charm, and will be deployed in the openstack-machines` model, on a storage node. It requires the following relations:

- `database`
- `amqp`
- `identity-credentials`

Depends On: https://github.com/canonical/sunbeam-terraform/pull/116