### PR TITLE
Make the dpdk ports list optional

### DIFF
--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -254,7 +254,7 @@ class CoreConfig(pydantic.BaseModel):
         # MB
         memory: int = 0
         driver: str = "vfio-pci"
-        ports: dict[str, list[str]]
+        ports: dict[str, list[str]] | None = None
 
     proxy: _ProxyConfig | None = None
     bootstrap: _BootstrapConfig | None = None


### PR DESCRIPTION
If the "dpdk" manifest section is defined, the "ports" field is expected even if dpdk is disabled.

We'll fix this, making it optional.