### PR TITLE
shared-filesystems: Update to microceph-ceph-nfs terraform plan

### DIFF
--- a/cloud/etc/deploy-microceph/main.tf
+++ b/cloud/etc/deploy-microceph/main.tf
@@ -40,8 +40,17 @@ resource "juju_application" "microceph" {
 
 # juju_offer.microceph_offer will be created
 resource "juju_offer" "microceph_offer" {
+  name             = "microceph"
   application_name = juju_application.microceph.name
   endpoints        = ["ceph"]
+  model            = data.juju_model.machine_model.name
+}
+
+# juju_offer.microceph_ceph_nfs_offer will be created
+resource "juju_offer" "microceph_ceph_nfs_offer" {
+  name             = "microceph-ceph-nfs"
+  application_name = juju_application.microceph.name
+  endpoints        = ["ceph-nfs"]
   model            = data.juju_model.machine_model.name
 }
 

--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -1491,60 +1491,6 @@ class JujuHelper:
 
         return cidrs
 
-    def create_offer(
-        self,
-        model: str,
-        application_name: str,
-        endpoint: str,
-        offer_name: None | str = None,
-    ):
-        """Create an offer.
-
-        This function creates a juju offer for the given application and endpoint.
-        """
-        _model = self.get_model(model)["name"]  # ensure model is long name
-        try:
-            # Juju offer does not accept --model option, so switch the model explicitly
-            self._juju.cli("switch", _model, include_model=False)
-            self._juju.offer(
-                f"{_model}.{application_name}",
-                endpoint=endpoint,
-                name=offer_name,
-            )
-        except jubilant.CLIError as e:
-            raise JujuException(
-                f"Failed to create offer for "
-                f"{_model}.{application_name}:{endpoint}: {str(e)}"
-            ) from e
-
-    def remove_offer(self, model: str, offer_name: str):
-        """Remove a juju offer."""
-        _model = self.get_model(model)["name"]  # ensure model is long name
-        offer_url = f"{_model}.{offer_name}"
-        try:
-            self._juju.cli("switch", _model, include_model=False)
-            self._juju.cli("remove-offer", offer_url, include_model=False)
-        except jubilant.CLIError as e:
-            raise JujuException(f"Failed to remove offer {offer_url}: {str(e)}") from e
-
-    def offer_exists(self, model: str, offer_name: str) -> bool:
-        """Checks whether a juju offer exists."""
-        _model = self.get_model(model)["name"]  # ensure model is long name
-        offer_url = f"{_model}.{offer_name}"
-        # Command to run juju show-offer --model <> <offer-url>
-        # so set the model
-        self._juju.model = _model
-        try:
-            self._juju.cli("show-offer", offer_url)
-            return True
-        except jubilant.CLIError as e:
-            if "not found" in e.stderr:
-                return False
-
-            raise JujuException(
-                f"Failed to check if offer {offer_url} exists: {str(e)}"
-            ) from e
-
     def consume_offer(self, model: str, offer_url: str, alias: str = ""):
         """Consume an offer.
 

--- a/sunbeam-python/sunbeam/features/shared_filesystem/feature.py
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/feature.py
@@ -7,19 +7,14 @@ from pathlib import Path
 import click
 from packaging.version import Version
 from rich.console import Console
-from rich.status import Status
 
 from sunbeam.core.common import (
     BaseStep,
-    Result,
-    ResultType,
     run_plan,
 )
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import (
-    JujuException,
     JujuHelper,
-    JujuStepHelper,
 )
 from sunbeam.core.manifest import (
     AddManifestStep,
@@ -38,7 +33,6 @@ from sunbeam.features.interface.v1.openstack import (
     TerraformPlanLocation,
 )
 from sunbeam.features.shared_filesystem import manila_data
-from sunbeam.steps import microceph
 from sunbeam.utils import click_option_show_hints, pass_method_obj
 from sunbeam.versions import OPENSTACK_CHANNEL
 
@@ -50,85 +44,6 @@ MANILA_DATA_APP = "manila-data"
 
 LOG = logging.getLogger(__name__)
 console = Console()
-
-
-class CreateCephNFSOfferStep(BaseStep, JujuStepHelper):
-    """Create microceph-ceph-nfs offer using Terraform."""
-
-    def __init__(
-        self,
-        deployment: Deployment,
-        jhelper: JujuHelper,
-    ):
-        super().__init__(
-            f"Create {microceph.NFS_OFFER_NAME} offer",
-            f"Creating {microceph.NFS_OFFER_NAME} offer",
-        )
-        self.model = deployment.openstack_machines_model
-        self.jhelper = jhelper
-
-    def is_skip(self, status: Status | None = None) -> Result:
-        """Determines if the step should be skipped or not.
-
-        :return: ResultType.SKIPPED if the Step should be skipped,
-                ResultType.COMPLETED or ResultType.FAILED otherwise
-        """
-        if self.jhelper.offer_exists(self.model, microceph.NFS_OFFER_NAME):
-            return Result(ResultType.SKIPPED)
-
-        return Result(ResultType.COMPLETED)
-
-    def run(self, status: Status | None = None) -> Result:
-        """Apply terraform configuration to deploy microceph-ceph-nfs offer."""
-        try:
-            self.jhelper.create_offer(
-                self.model,
-                microceph.APPLICATION,
-                microceph.CEPH_NFS_RELATION,
-                microceph.NFS_OFFER_NAME,
-            )
-        except JujuException as e:
-            LOG.exception(f"Error creating {microceph.NFS_OFFER_NAME} offer")
-            return Result(ResultType.FAILED, str(e))
-
-        return Result(ResultType.COMPLETED)
-
-
-class RemoveCephNFSOfferStep(BaseStep, JujuStepHelper):
-    """Remove microceph-ceph-nfs offer using Terraform."""
-
-    def __init__(
-        self,
-        deployment: Deployment,
-        jhelper: JujuHelper,
-    ):
-        super().__init__(
-            f"Remove {microceph.NFS_OFFER_NAME} offer",
-            f"Removing {microceph.NFS_OFFER_NAME} offer",
-        )
-        self.model = deployment.openstack_machines_model
-        self.jhelper = jhelper
-
-    def is_skip(self, status: Status | None = None) -> Result:
-        """Determines if the step should be skipped or not.
-
-        :return: ResultType.SKIPPED if the Step should be skipped,
-                ResultType.COMPLETED or ResultType.FAILED otherwise
-        """
-        if not self.jhelper.offer_exists(self.model, microceph.NFS_OFFER_NAME):
-            return Result(ResultType.SKIPPED)
-
-        return Result(ResultType.COMPLETED)
-
-    def run(self, status: Status | None = None) -> Result:
-        """Execute configuration using terraform."""
-        try:
-            self.jhelper.remove_offer(self.model, microceph.NFS_OFFER_NAME)
-        except JujuException as e:
-            LOG.exception(f"Error removing {microceph.NFS_OFFER_NAME} offer")
-            return Result(ResultType.FAILED, str(e))
-
-        return Result(ResultType.COMPLETED)
 
 
 class SharedFilesystemFeature(OpenStackControlPlaneFeature):
@@ -226,7 +141,6 @@ class SharedFilesystemFeature(OpenStackControlPlaneFeature):
             ]
         )
 
-        ceph_nfs_plan = [CreateCephNFSOfferStep(deployment, jhelper)]
         manila_data_plan = [
             TerraformInitStep(tfhelper_manila_data),
             manila_data.DeployManilaDataApplicationStep(
@@ -239,7 +153,7 @@ class SharedFilesystemFeature(OpenStackControlPlaneFeature):
             ),
         ]
 
-        run_plan(ceph_nfs_plan, console, show_hints)
+        run_plan(plan, console, show_hints)
         run_plan(manila_data_plan, console, show_hints)
 
         click.echo("Shared Filesystems enabled.")
@@ -255,7 +169,6 @@ class SharedFilesystemFeature(OpenStackControlPlaneFeature):
             DisableOpenStackApplicationStep(deployment, tfhelper, jhelper, self),
         ]
 
-        ceph_nfs_plan = [RemoveCephNFSOfferStep(deployment, jhelper)]
         manila_data_plan = [
             TerraformInitStep(tfhelper_manila_data),
             manila_data.DestroyManilaDataApplicationStep(
@@ -269,7 +182,6 @@ class SharedFilesystemFeature(OpenStackControlPlaneFeature):
 
         run_plan(manila_data_plan, console, show_hints)
         run_plan(plan, console, show_hints)
-        run_plan(ceph_nfs_plan, console, show_hints)
 
         click.echo("Shared Filesystems disabled.")
 

--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -311,54 +311,6 @@ def test_get_space_networks_invalid_cidr(jhelper, juju):
         jhelper.get_space_networks("test-model", "space")
 
 
-def test_create_offer(jhelper, juju):
-    juju.offer.side_effect = jubilant.CLIError(1, "offer", stderr="expected")
-
-    with pytest.raises(jujulib.JujuException):
-        jhelper.create_offer("test-model", "foo", "lish")
-
-    juju.offer.assert_called_once_with(
-        "admin/test-model.foo", endpoint="lish", name=None
-    )
-
-
-def test_remove_offer(jhelper, juju):
-    juju.cli.side_effect = (
-        None,
-        jubilant.CLIError(1, "remove-offer", stderr="expected"),
-    )
-
-    with pytest.raises(jujulib.JujuException):
-        jhelper.remove_offer("test-model", "foo")
-
-    juju.cli.assert_called_with(
-        "remove-offer", "admin/test-model.foo", include_model=False
-    )
-
-
-def test_offer_exists_true(jhelper, juju):
-    result = jhelper.offer_exists("test-model", "foo")
-
-    assert result
-    juju.cli.assert_called_once_with("show-offer", "admin/test-model.foo")
-
-
-def test_offer_exists_false(jhelper, juju):
-    juju.cli.side_effect = jubilant.CLIError(1, "show-offer", stderr="not found")
-
-    result = jhelper.offer_exists("test-model", "foo")
-
-    assert not result
-    juju.cli.assert_called_once_with("show-offer", "admin/test-model.foo")
-
-
-def test_offer_exists_fail(jhelper, juju):
-    juju.cli.side_effect = jubilant.CLIError(1, "show-offer", stderr="unexpected")
-
-    with pytest.raises(jujulib.JujuException):
-        jhelper.offer_exists("test-model", "foo")
-
-
 def test_remove_saas_success(jhelper, juju):
     jhelper.remove_saas("test-model", "saas1")
     juju.cli.assert_called()

--- a/sunbeam-python/tests/unit/sunbeam/features/shared_filesystem/test_feature.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/shared_filesystem/test_feature.py
@@ -8,7 +8,7 @@ import pytest
 
 from sunbeam.features.shared_filesystem import feature as manila_feature
 from sunbeam.features.shared_filesystem import manila_data
-from sunbeam.steps import microceph, openstack
+from sunbeam.steps import openstack
 
 
 @pytest.fixture()
@@ -66,12 +66,8 @@ class TestSharedFilesystemFeature:
         manila._manifest.core.software.charms = {}
         feature_config = Mock()
 
-        # Run enable plans, ceph-nfs offer is already created.
+        # Run enable plans.
         manila.run_enable_plans(deployment, feature_config, False)
-
-        # CreateCephNFSOfferStep calls.
-        jhelper.offer_exists.assert_called_once_with("foo", microceph.NFS_OFFER_NAME)
-        jhelper.create_offer.assert_not_called()
 
         # AddManilaDataUnitsStep calls.
         jhelper.wait_application_ready.assert_any_call(
@@ -79,18 +75,6 @@ class TestSharedFilesystemFeature:
             "foo",
             accepted_status=["active", "unknown", "blocked"],
             timeout=manila_data.MANILA_DATA_UNIT_TIMEOUT,
-        )
-
-        # Run enable plans, microceph-ceph-nfs doesn't exist.
-        jhelper.offer_exists.return_value = False
-
-        manila.run_enable_plans(deployment, feature_config, False)
-
-        jhelper.create_offer.assert_called_once_with(
-            "foo",
-            microceph.APPLICATION,
-            microceph.CEPH_NFS_RELATION,
-            microceph.NFS_OFFER_NAME,
         )
 
     @patch.object(manila_feature, "JujuHelper")
@@ -103,7 +87,7 @@ class TestSharedFilesystemFeature:
         manila._manifest = Mock()
         manila._manifest.core.software.charms = {}
 
-        # Run disable plans, ceph-nfs offer is already created.
+        # Run disable plans.
         manila.run_disable_plans(deployment, False)
 
         # DeployManilaDataApplicationStep calls.
@@ -130,18 +114,6 @@ class TestSharedFilesystemFeature:
         jhelper.wait_application_gone.assert_any_call(
             manila.set_application_names(deployment), "openstack", timeout=ANY
         )
-
-        # RemoveCephNFSOfferStep calls.
-        jhelper.offer_exists.assert_called_once_with("foo", microceph.NFS_OFFER_NAME)
-        jhelper.remove_offer.assert_called_once_with("foo", microceph.NFS_OFFER_NAME)
-
-        # Run disable plans, microceph-ceph-nfs doesn't exist.
-        jhelper.remove_offer.reset_mock()
-        jhelper.offer_exists.return_value = False
-
-        manila.run_disable_plans(deployment, False)
-
-        jhelper.remove_offer.assert_not_called()
 
     def test_set_tfvars_on_enable(self, deployment):
         manila = manila_feature.SharedFilesystemFeature()


### PR DESCRIPTION
Currently, we are creating the microceph `ceph-nfs` offer through jubilant. We can now create it through the terraform plan instead, simplifying the feature enablement.