### PR TITLE
Add GPU passthrough to pci_whitelist

### DIFF
--- a/sunbeam-python/sunbeam/provider/common/nic_utils.py
+++ b/sunbeam-python/sunbeam/provider/common/nic_utils.py
@@ -21,6 +21,15 @@ def fetch_nics(client: Client, node_name: str, jhelper: JujuHelper, model: str):
     return json.loads(action_result.get("result", "{}"))
 
 
+def fetch_gpus(client: Client, node_name: str, jhelper: JujuHelper, model: str):
+    LOG.debug("Fetching gpus...")
+    node = client.cluster.get_node_info(node_name)
+    machine_id = str(node.get("machineid"))
+    unit = jhelper.get_unit_from_machine("openstack-hypervisor", machine_id, model)
+    action_result = jhelper.run_action(unit, model, "list-gpus")
+    return json.loads(action_result.get("result", "{}"))
+
+
 def get_nic_str_repr(nic: dict):
     """Get the string representation for a nic retrieved through list-nics."""
     vendor = nic.get("vendor_name") or nic.get("vendor_id") or "Unknown vendor"
@@ -58,6 +67,67 @@ def is_sriov_nic_whitelisted(
             return True, spec_dict.get("physical_network")
 
     return False, None
+
+
+def is_pci_device_whitelisted(
+    node_name: str,
+    device: dict,
+    pci_whitelist: list[dict],
+    excluded_devices: dict[str, list],
+) -> bool:
+    """Returns True if pci device is whitelisted."""
+    pci_address = device["pci_address"]
+
+    node_excluded_devices = excluded_devices.get(node_name) or []
+    if pci_address in node_excluded_devices:
+        return False
+
+    for spec_dict in pci_whitelist:
+        if not isinstance(spec_dict, dict):
+            raise ValueError("Invalid device spec, expecting a dict: %s." % spec_dict)
+
+        pci_spec = devspec.PciDeviceSpec(spec_dict)
+        dev = {
+            "vendor_id": device["vendor_id"].replace("0x", ""),
+            "product_id": device["product_id"].replace("0x", ""),
+            "address": device["pci_address"],
+        }
+        match = pci_spec.match(dev)
+        if match:
+            return True
+
+    return False
+
+
+def whitelist_pci_passthrough_device(
+    node_name: str,
+    device: dict,
+    pci_whitelist: list[dict],
+    excluded_devices: dict[str, list],
+):
+    pci_address = device["pci_address"]
+    LOG.debug("Whitelisting PCI device: %s", pci_address)
+
+    node_excluded_devices = excluded_devices.get(node_name) or []
+    if pci_address in node_excluded_devices:
+        # If user excludes a PCI device via manifest, do not add
+        # the device in pci_whitelist
+        LOG.debug("PCI device excluded: %s", pci_address)
+        return
+
+    # Update the global whitelist if needed.
+    whitelisted = is_pci_device_whitelisted(
+        node_name, device, pci_whitelist, excluded_devices
+    )
+    if not whitelisted:
+        new_dev_spec = {
+            "address": device["pci_address"],
+            "vendor_id": device["vendor_id"].replace("0x", ""),
+            "product_id": device["product_id"].replace("0x", ""),
+        }
+        pci_whitelist.append(new_dev_spec)
+    else:
+        LOG.debug("PCI device already whitelisted: %s", pci_address)
 
 
 def whitelist_sriov_nic(


### PR DESCRIPTION
Retrieve GPU passthrough devices from openstack-hypervisor and add all the passthrough devices to pci whitelist. openstack-hypervisor currently supports providing GPU devices list (PCI class 0x03 and 0x1200) and so only those devices are added to pci whitelist.
This is handled as part of configure sriov instead of adding new command as all the detected devices will be part of pci whitelist by default.

Users can add or exclude PCI passthroguh devices via manifest as well to pci config section.

- [x] Depends-On: https://github.com/canonical/snap-openstack-hypervisor/pull/121
- [x] Depends-On: https://review.opendev.org/c/openstack/sunbeam-charms/+/963347