### PR TITLE
Adds missing step to shared-filesystem feature

### DIFF
--- a/sunbeam-python/sunbeam/features/shared_filesystem/feature.py
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/feature.py
@@ -240,6 +240,7 @@ class SharedFilesystemFeature(OpenStackControlPlaneFeature):
         ]
 
         run_plan(ceph_nfs_plan, console, show_hints)
+        run_plan(plan, console, show_hints)
         run_plan(manila_data_plan, console, show_hints)
 
         click.echo("Shared Filesystems enabled.")


### PR DESCRIPTION
The step is meant to deploy the `manila-k8s`, `manila-cephfs-k8s`, and mysql router charms.