### PR TITLE
Pin traefik to revision 236

### DIFF
--- a/manifests/2024.1/beta.yml
+++ b/manifests/2024.1/beta.yml
@@ -39,6 +39,9 @@ core:
           snap-channel: squid/stable
       microovn:
         channel: latest/edge
+      traefik-k8s:
+        channel: latest/stable
+        revision: 236
 features:
   caas:
     software:

--- a/manifests/2024.1/candidate.yml
+++ b/manifests/2024.1/candidate.yml
@@ -39,6 +39,9 @@ core:
           snap-channel: squid/stable
       microovn:
         channel: latest/edge
+      traefik-k8s:
+        channel: latest/stable
+        revision: 236
 features:
   caas:
     software:

--- a/manifests/2024.1/edge.yml
+++ b/manifests/2024.1/edge.yml
@@ -41,6 +41,9 @@ core:
           snap-channel: squid/stable
       microovn:
         channel: latest/edge
+      traefik-k8s:
+        channel: latest/stable
+        revision: 236
 features:
   caas:
     software:

--- a/manifests/2024.1/stable.yml
+++ b/manifests/2024.1/stable.yml
@@ -41,6 +41,9 @@ core:
           snap-channel: squid/stable
       microovn:
         channel: latest/edge
+      traefik-k8s:
+        channel: latest/stable
+        revision: 236
 features:
   caas:
     software:

--- a/manifests/2025.1/beta.yml
+++ b/manifests/2025.1/beta.yml
@@ -37,6 +37,9 @@ core:
         channel: squid/stable
         config:
           snap-channel: squid/stable
+      traefik-k8s:
+        channel: latest/stable
+        revision: 236
 features:
   caas:
     software:

--- a/manifests/2025.1/candidate.yml
+++ b/manifests/2025.1/candidate.yml
@@ -37,6 +37,9 @@ core:
         channel: squid/stable
         config:
           snap-channel: squid/stable
+      traefik-k8s:
+        channel: latest/stable
+        revision: 236
 features:
   caas:
     software:

--- a/manifests/2025.1/edge.yml
+++ b/manifests/2025.1/edge.yml
@@ -39,6 +39,9 @@ core:
         channel: squid/stable
         config:
           snap-channel: squid/stable
+      traefik-k8s:
+        channel: latest/stable
+        revision: 236
 features:
   caas:
     software:

--- a/manifests/2025.1/stable.yml
+++ b/manifests/2025.1/stable.yml
@@ -39,6 +39,9 @@ core:
         channel: squid/stable
         config:
           snap-channel: squid/stable
+      traefik-k8s:
+        channel: latest/stable
+        revision: 236
 features:
   caas:
     software:


### PR DESCRIPTION
New revision on stable branch 254 has completely broken sunbeam's expectations for TLS. Pin while we implement a rework.