### PR TITLE
baremetal: Adds ironic-conductor groups

### DIFF
--- a/sunbeam-python/sunbeam/features/baremetal/README.md
+++ b/sunbeam-python/sunbeam/features/baremetal/README.md
@@ -31,11 +31,12 @@ features:
           channel: 2025.1/edge
     config:
       shards: ["foo", "lish"]
+      conductor-groups: ["foo", "lish"]
 ```
 
-**Note**: Rerunning the `sunbeam enable baremetal` command with a different manifest file will replace the previously deployed feature configuration (e.g.: deployed `nova-ironic` shards).
+**Note**: Rerunning the `sunbeam enable baremetal` command with a different manifest file will replace the previously deployed feature configuration (e.g.: deployed `nova-ironic` shards, Ironic Conductor groups).
 
-After the feature is enabled, you can use the `sunbeam baremetal` subcommand to manage the deployed `nova-ironic` shards.
+After the feature is enabled, you can use the `sunbeam baremetal` subcommand to manage the deployed `nova-ironic` shards, and Ironic Conductor groups.
 
 ## Managing `nova-ironic` shards
 
@@ -55,6 +56,29 @@ The following command can be used to list the currently deployed shards:
 
 ```bash
 sunbeam baremetal shard list
+```
+
+## Managing Ironic Conductor groups
+
+By default, sunbeam deploys an `ironic-conductor-k8s` charm with an empty `conductor-group` configuration option. Additional Ironic Conductor groups will be deployed while enabling the `baremetal` feature, based on the `conductor-groups` configuration mentioned above.
+
+Additional Ironic Conductor groups can be added through the following command:
+
+```bash
+sunbeam baremetal conductor-groups add GROUP-NAME
+```
+
+Ironic Conductor Groups can be removed by running the following command:
+
+```bash
+sunbeam baremetal conductor-groups delete GROUP-NAME
+```
+
+The following command can be used to list the currently Ironic Conductor
+Groups:
+
+```bash
+sunbeam baremetal conductor-groups list
 ```
 
 ## Contents

--- a/sunbeam-python/sunbeam/features/baremetal/constants.py
+++ b/sunbeam-python/sunbeam/features/baremetal/constants.py
@@ -4,3 +4,4 @@
 IRONIC_CONDUCTOR_APP = "ironic-conductor"
 IRONIC_APP_TIMEOUT = 600
 NOVA_IRONIC_SHARDS_TFVAR = "ironic-compute-shards"
+IRONIC_CONDUCTOR_GROUPS_TFVAR = "ironic-conductor-groups"

--- a/sunbeam-python/sunbeam/features/baremetal/feature_config.py
+++ b/sunbeam-python/sunbeam/features/baremetal/feature_config.py
@@ -11,6 +11,13 @@ from sunbeam.core.manifest import (
 class BaremetalFeatureConfig(FeatureConfig):
     shards: list[str] = pydantic.Field(examples=["foo", "bar"], default=[])
 
+    conductor_groups: list[str] = pydantic.Field(
+        examples=["foo", "bar"],
+        alias="conductor-groups",
+        validation_alias="conductor_groups",
+        default=[],
+    )
+
     @pydantic.field_validator("shards")
     @classmethod
     def validate_shards(cls, v: list):
@@ -20,5 +27,17 @@ class BaremetalFeatureConfig(FeatureConfig):
 
         if len(v) != len(set(v)):
             raise ValueError("Shards must be unique.")
+
+        return v
+
+    @pydantic.field_validator("conductor_groups")
+    @classmethod
+    def validate_conductor_groups(cls, v: list):
+        """Validate conductor_groups."""
+        if len(v) == 0:
+            return v
+
+        if len(v) != len(set(v)):
+            raise ValueError("Conductor groups must be unique.")
 
         return v

--- a/sunbeam-python/tests/unit/sunbeam/features/baremetal/test_feature_config.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/baremetal/test_feature_config.py
@@ -25,3 +25,21 @@ class TestBaremetalFeatureConfig:
         feature_config.BaremetalFeatureConfig()
         feature_config.BaremetalFeatureConfig(shards=[])
         feature_config.BaremetalFeatureConfig(shards=["foo", "lish"])
+
+    def test_validate_conductor_groups(self):
+        # must be list.
+        with pytest.raises(pydantic.ValidationError):
+            feature_config.BaremetalFeatureConfig(conductor_groups="foo")
+
+        # must be strings.
+        with pytest.raises(pydantic.ValidationError):
+            feature_config.BaremetalFeatureConfig(conductor_groups=[5])
+
+        # no duplicates.
+        with pytest.raises(pydantic.ValidationError):
+            feature_config.BaremetalFeatureConfig(conductor_groups=["foo", "foo"])
+
+        # valid examples.
+        feature_config.BaremetalFeatureConfig()
+        feature_config.BaremetalFeatureConfig(conductor_groups=[])
+        feature_config.BaremetalFeatureConfig(conductor_groups=["foo", "lish"])


### PR DESCRIPTION
Adds the possibility to deploy `ironic-conductor` groups when enabling the baremetal feature, and through additional baremetal subcommands after enablement.

Depends-On: https://github.com/canonical/sunbeam-terraform/pull/123