### PR TITLE
fix(maas): do not require data on storage nodes

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/deployment.py
+++ b/sunbeam-python/sunbeam/provider/maas/deployment.py
@@ -63,7 +63,6 @@ ROLE_NETWORK_MAPPING = {
         Networks.STORAGE,
     ],
     RoleTags.STORAGE: [
-        Networks.DATA,
         Networks.INTERNAL,
         Networks.MANAGEMENT,
         Networks.STORAGE,


### PR DESCRIPTION
The data network is not required on storage nodes, as it is about tenant connectivity (east-west) traffic for VMs between hypervisors.

Closes-Bug: #2130358