### PR TITLE
fix(maas): Add early exit from `is_skip` method

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -1923,6 +1923,9 @@ class MaasSetHypervisorUnitsOptionsStep(SetHypervisorUnitsOptionsStep):
         result = super().is_skip(status)
         if result.result_type == ResultType.FAILED:
             return result
+        # Skip if no compute nodes to configure
+        if not self.names:
+            return Result(ResultType.SKIPPED, "No compute nodes to configure.")
         nics = self._get_maas_nics()
         LOG.debug("Nics: %r", nics)
 
@@ -1995,6 +1998,9 @@ class MaasConfigureOpenstackNetworkAgentsStep(
         result = super().is_skip(status)
         if result.result_type == ResultType.FAILED:
             return result
+        # Skip if no network nodes to configure
+        if not self.names:
+            return Result(ResultType.SKIPPED, "No network nodes to configure.")
         nics = self._get_maas_nics()
         LOG.debug("Nics: %r", nics)
 


### PR DESCRIPTION
This PR adds a fix for the check of `neutron:physnet1` in case there are no network nodes in the cluster, by exiting earlier from `is_skip` method for `MaasConfigureOpenstackNetworkAgentsStep`. 
Since this class is using a similar approach as `MaasSetHypervisorUnitsOptionsStep`, updated that method as well.