### PR TITLE
ci: drop unused input arguments

### DIFF
--- a/.github/workflows/test-snap.yml
+++ b/.github/workflows/test-snap.yml
@@ -28,16 +28,6 @@ on:
         required: true
         default: squid/beta
         type: string
-      microovn-charm-channel:
-        description: Specify microovn charms channel
-        required: true
-        default: latest/edge
-        type: string
-      microovn-snap-channel:
-        description: Specify microovn snap channel
-        required: true
-        default: latest/edge
-        type: string
       rabbitmq-charm-channel:
         description: Specify rabbitmq charms channel
         required: true


### PR DESCRIPTION
Too many input arguments will fail the workflow and prevent tests from being run.