### PR TITLE
Fix destroy timeout on openstack-machines model

### DIFF
--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -309,9 +309,8 @@ class JujuHelper:
             raise JujuException(e.stderr)
         return models.get("models", [])
 
-    @functools.cache
-    def get_model(self, model: str) -> "dict":
-        """Fetch model.
+    def _get_model_uncached(self, model: str) -> "dict":
+        """Fetch model without caching.
 
         :model: Name of the model
         """
@@ -320,13 +319,35 @@ class JujuHelper:
                 return m
         raise ModelNotFoundException(f"Model {model!r} not found")
 
+    @functools.cache
+    def get_model(self, model: str) -> "dict":
+        """Fetch model (cached).
+
+        :model: Name of the model
+        """
+        return self._get_model_uncached(model)
+
     def model_exists(self, model: str) -> bool:
-        """Check if model exists.
+        """Check if model exists (uses cache).
 
         :model: Name of the model
         """
         try:
             self.get_model(model)
+        except JujuException:
+            return False
+        return True
+
+    def model_exists_live(self, model: str) -> bool:
+        """Check if model exists without cache.
+
+        Use this in destroy/removal paths where the model state
+        is actively changing and cached results would be stale.
+
+        :model: Name of the model
+        """
+        try:
+            self._get_model_uncached(model)
         except JujuException:
             return False
         return True
@@ -1297,7 +1318,7 @@ class JujuHelper:
             timeout = 60 * 15
 
         start = time.monotonic()
-        while self.model_exists(model):
+        while self.model_exists_live(model):
             if time.monotonic() - start > timeout:
                 raise TimeoutError(
                     f"Timed out while waiting for model {model!r} to be gone"

--- a/sunbeam-python/sunbeam/steps/openstack.py
+++ b/sunbeam-python/sunbeam/steps/openstack.py
@@ -1540,7 +1540,7 @@ class DestroyControlPlaneStep(BaseStep):
             LOG.debug(
                 "Timeout waiting for model to be removed, trying through provider sdk"
             )
-            if not self.jhelper.model_exists(self._MODEL):
+            if not self.jhelper.model_exists_live(self._MODEL):
                 return Result(ResultType.COMPLETED)
             self.jhelper.destroy_model(self._MODEL, destroy_storage=True, force=True)
             try:

--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -152,6 +152,113 @@ def test_model_exists_false(jhelper):
     assert not jhelper.model_exists("nope")
 
 
+def test_get_model_uncached_found(jhelper):
+    result = jhelper._get_model_uncached("test-model")
+    assert result == {
+        "short-name": "test-model",
+        "name": "admin/test-model",
+        "model-uuid": "1234",
+    }
+
+
+def test_get_model_uncached_not_found(jhelper):
+    with pytest.raises(jujulib.ModelNotFoundException):
+        jhelper._get_model_uncached("nope")
+
+
+def test_get_model_uncached_always_calls_models(jhelper):
+    """_get_model_uncached does not cache; each call queries models()."""
+    jhelper._get_model_uncached("test-model")
+    jhelper._get_model_uncached("test-model")
+    assert jhelper.models.call_count == 2
+
+
+def test_model_exists_live_true(jhelper):
+    assert jhelper.model_exists_live("test-model")
+
+
+def test_model_exists_live_false(jhelper):
+    assert not jhelper.model_exists_live("nope")
+
+
+def test_model_exists_live_bypasses_cache(jhelper):
+    """model_exists_live sees fresh data even when get_model cache is stale."""
+    # Seed the cache
+    assert jhelper.get_model("test-model") is not None
+
+    # Now model disappears
+    jhelper.models = Mock(return_value=[])
+
+    # Cached model_exists still returns True (stale cache)
+    assert jhelper.model_exists("test-model") is True
+
+    # Live check sees the model is gone
+    assert jhelper.model_exists_live("test-model") is False
+
+
+@patch("time.sleep")
+def test_wait_model_gone_model_already_gone(mock_sleep, jhelper):
+    """Returns immediately if model does not exist."""
+    jhelper.models = Mock(return_value=[])
+    jhelper.get_model.cache_clear()
+
+    jhelper.wait_model_gone("test-model", timeout=60)
+
+    mock_sleep.assert_not_called()
+
+
+@patch("time.sleep")
+def test_wait_model_gone_model_disappears(mock_sleep, jhelper):
+    """Exits loop once model is gone, verifying live checks on each iteration."""
+    model_data = [
+        {"short-name": "test-model", "name": "admin/test-model", "model-uuid": "1234"}
+    ]
+    jhelper.models = Mock(
+        side_effect=[
+            model_data,  # first check: model still present
+            [],  # second check: model gone
+        ]
+    )
+    jhelper.get_model.cache_clear()
+
+    jhelper.wait_model_gone("test-model", timeout=60)
+
+    assert jhelper.models.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@patch("time.sleep")
+@patch("time.monotonic")
+def test_wait_model_gone_timeout_raises(mock_monotonic, mock_sleep, jhelper):
+    """TimeoutError is raised when model does not disappear in time."""
+    # start=0, first iteration: model exists, check timeout -> 9999 > 1 -> raise
+    mock_monotonic.side_effect = [0, 9999]
+
+    with pytest.raises(TimeoutError):
+        jhelper.wait_model_gone("test-model", timeout=1)
+
+
+@patch("time.sleep")
+def test_wait_model_gone_does_not_use_cache(mock_sleep, jhelper):
+    """Regression test: wait_model_gone uses live checks, not cached model_exists.
+
+    This is the exact bug scenario (see LP#2146354)
+    get_model cache has the model, but the model
+    is actually gone. wait_model_gone must detect this via model_exists_live.
+    """
+    # Seed the get_model cache so cached model_exists would return True forever
+    assert jhelper.get_model("test-model") is not None
+
+    # Now model disappears from the controller
+    jhelper.models = Mock(return_value=[])
+
+    # wait_model_gone should return immediately (model is gone per live check)
+    # If it used cached model_exists, it would loop until timeout
+    jhelper.wait_model_gone("test-model", timeout=5)
+
+    mock_sleep.assert_not_called()
+
+
 def test_get_model_name_with_owner(jhelper):
     assert jhelper.get_model_name_with_owner("test-model") == "admin/test-model"
 


### PR DESCRIPTION
When try to destroy-deployment the sunbeam is stuck on destroy openstack-machines model, 
while the model is actually destroy it still perceives to be existing until reach timeout
```
           DEBUG    Starting step 'Destroy model openstack-machines'                                                                                                                                                             common.py:312
           DEBUG    Running step Destroy model openstack-machines                                                                                                                                                                common.py:331
           INFO     cli: juju destroy-model sunbeamuser/openstack-machines --no-prompt --destroy-storage                                                                                                                          _juju.py:308
⠋ Destroying model openstack-machines ...                                                                                                                                                                                                     
⠸ Destroying model openstack-machines ...                                                                                                                                                                                                     
⠦ Destroying model openstack-machines ...                                                                                                                                                                                                     
⠇ Destroying model openstack-machines ... [13:06:42] DEBUG    Error destroying model openstack-machines                                                                                                                                       
                              juju.py:1623                                                                                                                                                                                                    
                    Traceback (most recent call last):                                                                                                                                                                                        
                      File "/snap/openstack/945/lib/python3.12/site-packages/sunbeam/steps/juju.py", line 1618, in run                                                                                                                        
                        self.jhelper.wait_model_gone(                                                                                                                                                                                         
                      File "/snap/openstack/945/lib/python3.12/site-packages/sunbeam/core/juju.py", line 1290, in wait_model_gone                                                                                                             
                        raise TimeoutError(                                                                                                                                                                                                   
                    TimeoutError: Timed out while waiting for model 'openstack-machines' to be gone                                                                                                                                           
           DEBUG    Finished running step 'Destroy model openstack-machines'. Result: ResultType.FAILED                                                                                                                          common.py:334
Error: Timed out while waiting for model 'openstack-machines' to be gone   
```

On the next run it will complain about `openstack-machines` missing
```
           DEBUG    Finished running step 'Initialize Terraform'. Result: ResultType.COMPLETED                                                                                                                                   common.py:334
           DEBUG    Starting step 'Destroy Hypervisor'                                                                                                                                                                           common.py:312
           DEBUG    Running command /snap/openstack/945/bin/terraform state pull                                                                                                                                              terraform.py:315
⠙ Destroying Hypervisor ...            DEBUG    Command finished. stderr=                                                                                                                                                                     
            terraform.py:325                                                                                                                                                                                                                  
           INFO     cli: juju models --controller foundations-maas --format json --all                                                                                                                                            _juju.py:308
⠸ Destroying Hypervisor ...            DEBUG    Model not found                                                                                                                                                                               
                steps.py:318                                                                                                                                                                                                                  
                    Traceback (most recent call last):                                                                                                                                                                                        
                      File "/snap/openstack/945/lib/python3.12/site-packages/sunbeam/core/steps.py", line 316, in is_skip                                                                                                                     
                        _has_juju_resources = len(self._list_applications(self.model)) > 0                                                                                                                                                    
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                         
                      File "/snap/openstack/945/lib/python3.12/site-packages/sunbeam/core/steps.py", line 288, in _list_applications                                                                                                          
                        _model = self.jhelper.get_model_status(model)                                                                                            
                        ...
                                  ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                        
                      File "/snap/openstack/945/lib/python3.12/site-packages/sunbeam/core/juju.py", line 321, in get_model                                                                                                                    
                        raise ModelNotFoundException(f"Model {model!r} not found")                                                                                                                                                            
                    sunbeam.core.juju.ModelNotFoundException: Model 'openstack-machines' not found                                                                                                                                            
           DEBUG    Skipping step Destroy Hypervisor                                                                                                                                                                             common.py:322
           DEBUG    Starting step 'Initialize Terraform'                                                                                                                                                                         common.py:312
           DEBUG    Running step Initialize Terraform                                        
```

so even when re-add the model the situation from the first output repeats!
```
$ juju models
Controller: foundations-maas

Model            Cloud/Region  Type  Status     Machines  Cores  Units  Access  Last connection
openstack-infra  pc6b/default  maas  available         3     24  4      admin   2 hours ago
$ juju add-model openstack-machines pc6b
Added 'openstack-machines' model on pc6b/default with credential 'pc6b' for user 'sunbeamuser'
```


So I modified 2 files and added additional debugging and mount bound them
`/snap/openstack/945/lib/python3.12/site-packages/sunbeam/core/juju.py`
`/snap/openstack/945/lib/python3.12/site-packages/sunbeam/core/steps/juju.py`
the copies landed in:
`/var/snap/openstack/common/juju.py`
`/var/snap/openstack/common/steps_juju.py`

Here are the diffs (added .txt so github will allow me to attach them)

[sunbeam_steps_juju.py.diff.txt](https://github.com/user-attachments/files/26247861/sunbeam_steps_juju.py.diff.txt)
[sunbeam_core_juju.py.diff.txt](https://github.com/user-attachments/files/26247863/sunbeam_core_juju.py.diff.txt)

This is the debug log output:
[sunbeam-deploy.log](https://github.com/user-attachments/files/26247877/sunbeam-deploy.log)


The problem is this function is called TWICE with the same argument, 
1. when pulling terraform state
```
           DEBUG    Starting step 'Destroy Hypervisor'                                                                                                                                                                           common.py:312
           DEBUG    Running command /snap/openstack/945/bin/terraform state pull                                                                                                                                              terraform.py:315
⠙ Destroying Hypervisor ...            DEBUG    Command finished. stderr=                                                                                                                                                                     
           DEBUG    ===== Trying to look for model openstack-machines                                                                                                                                                              juju.py:321
           DEBUG    ===== models(self) Trying run CLI models --all                                                                                                                                                                 juju.py:308
           INFO     cli: juju models --controller foundations-maas --format json --all                                                                                                                                            _juju.py:308
⠸ Destroying Hypervisor ... [14:55:25] DEBUG    ===== Found openstack-machines sunbeamuser/openstack-machines f0c21a14-9acc-482e-8ff8-5a090b5fe451
           INFO     cli: juju status --model foundations-maas:sunbeamuser/openstack-machines --format json                                                                                                                        _juju.py:308
⠴ Destroying Hypervisor ...            DEBUG    Skipping step Destroy Hypervisor                                                                                                                                                              
           DEBUG    Starting step 'Initialize Terraform'                                                       
 ```
2. when waiting for the model to be destroyed , it never enter get_model
```
           DEBUG    Starting step 'Destroy model openstack-machines'                                                                                                                                                             common.py:312
           DEBUG    === model_exists running self.get_model(openstack-machines)                                                                                                                                                    juju.py:334
           DEBUG    Running step Destroy model openstack-machines                                                                                                                                                                common.py:331
           INFO     cli: juju destroy-model sunbeamuser/openstack-machines --no-prompt --destroy-storage                                                                                                                          _juju.py:308
⠇ Destroying model openstack-machines ... [14:55:30] DEBUG    === Running jhelper.wait_model_gone()                                                                                                                                           
           DEBUG    === wait_model_gone self.model_exists loop                                                                                                                                                                    juju.py:1294
           DEBUG    === model_exists running self.get_model(openstack-machines)                                                                                                                                                    juju.py:334
⠹ Destroying model openstack-machines ... [14:55:40] DEBUG    === time passed: 10.006787786027417                                                                                                                                             
           DEBUG    === model_exists running self.get_model(openstack-machines)                                                                                                                                                    juju.py:334
⠧ Destroying model openstack-machines ... [14:55:50] DEBUG    === time passed: 20.01368316099979    
```
 
 The function excerpt from the current 2024.1/stable
 https://github.com/canonical/snap-openstack/blob/stable/2024.1/sunbeam-python/sunbeam/core/juju.py#L265-L274
 ```
     @functools.cache
    def get_model(self, model: str) -> "dict":
        """Fetch model.

        :model: Name of the model
        """
        for m in self.models():
            if model in (m["short-name"], m["name"], m["model-uuid"]):
                return m
        raise ModelNotFoundException(f"Model {model!r} not found")
 ```
 