### PR TITLE
fix: handle vault charm config rename

### DIFF
--- a/sunbeam-python/sunbeam/features/tls/vault.py
+++ b/sunbeam-python/sunbeam/features/tls/vault.py
@@ -49,7 +49,12 @@ from sunbeam.features.tls.common import (
     certificate_questions,
     handle_list_outstanding_csrs,
 )
-from sunbeam.features.vault.feature import VaultCommandFailedException, VaultHelper
+from sunbeam.features.vault.feature import (
+    VaultCommandFailedException,
+    VaultHelper,
+    migrate_vault_config_in_db,
+    vault_pki_config_key,
+)
 from sunbeam.utils import click_option_show_hints, pass_method_obj
 
 CA_APP_NAME = "vault"
@@ -97,11 +102,21 @@ class VaultTlsFeature(TlsFeature):
         )
         return content
 
+    def _get_vault_channel(self, jhelper: JujuHelper) -> str:
+        """Return the deployed vault charm channel, or VAULT_CHANNEL as default."""
+        from sunbeam.versions import VAULT_CHANNEL
+
+        try:
+            app = jhelper.get_application(CA_APP_NAME, OPENSTACK_MODEL)
+            return app.charm_channel or VAULT_CHANNEL
+        except SunbeamException:
+            return VAULT_CHANNEL
+
     def _build_tls_config_maps(
         self,
         jhelper: JujuHelper,
         endpoints: list[str],
-    ) -> dict[str, dict[str, str]]:
+    ) -> dict[str, dict[str, str | bool]]:
         """Get the TLS config maps for specified endpoints."""
         external: dict[str, str] = {}
         missing: list[str] = []
@@ -128,7 +143,7 @@ class VaultTlsFeature(TlsFeature):
                 "Please configure these hostnames using Sunbeam bootstrap."
             )
 
-        maps: dict[str, dict[str, str]] = {}
+        maps: dict[str, dict[str, str | bool]] = {}
         domains = set()
         for hostname in external.values():
             if "." in hostname:
@@ -140,7 +155,12 @@ class VaultTlsFeature(TlsFeature):
             )
 
         common_domain = domains.pop()
-        maps["vault-config"] = {"common_name": common_domain}
+        vault_channel = self._get_vault_channel(jhelper)
+        config_key = vault_pki_config_key(vault_channel)
+        vault_config: dict[str, str | bool] = {config_key: common_domain}
+        if config_key == "pki_ca_common_name":
+            vault_config["pki_allow_subdomains"] = True
+        maps["vault-config"] = vault_config
 
         if "public" in external:
             maps["traefik-public-config"] = {"external_hostname": external["public"]}
@@ -215,6 +235,10 @@ class VaultTlsFeature(TlsFeature):
             "manual-tls-certificates-channel": "1/stable",
         }
         jhelper = JujuHelper(deployment.juju_controller)
+        vault_channel = self._get_vault_channel(jhelper)
+        migrate_vault_config_in_db(
+            deployment.get_client(), self.get_tfvar_config_key(), vault_channel
+        )
         tfvars.update(self._build_tls_config_maps(jhelper, config.endpoints))
         tfvars["enable-tls-for-public-endpoint"] = "public" in config.endpoints
         tfvars["enable-tls-for-internal-endpoint"] = "internal" in config.endpoints
@@ -467,5 +491,5 @@ class VaultTlsFeature(TlsFeature):
                 found: {', '.join(external.values())}"
             )
         common_domain = domains.pop()
-        endpoints_config.update({"vault-config": {"common_name": common_domain}})
-        console.print(f"Set {CA_APP_NAME}.common_name = {common_domain}")
+        LOG.debug("Common domain for vault PKI: %s", common_domain)
+        console.print(f"Set Vault CA common name to {common_domain}")

--- a/sunbeam-python/sunbeam/features/vault/feature.py
+++ b/sunbeam-python/sunbeam/features/vault/feature.py
@@ -64,6 +64,8 @@ from sunbeam.features.interface.v1.openstack import (
 from sunbeam.utils import click_option_show_hints, pass_method_obj
 from sunbeam.versions import VAULT_CHANNEL
 
+VAULT_PKI_CA_COMMON_NAME_MIN_VERSION = Version("1.18")
+
 VAULT_COMMAND_TIMEOUT = 300  # 5 minutes
 VAULT_CHARM_UPDATES_TIMEOUT = (
     600  # 10 minutes, note that charm status get updated on update-status interval
@@ -77,6 +79,67 @@ DEFAULT_VAULT_KEY_THRESHOLD = 1
 
 LOG = logging.getLogger(__name__)
 console = Console()
+
+
+def vault_pki_config_key(channel: str) -> str:
+    """Return the vault charm config key for PKI CA common name.
+
+    Vault 1.18+ renamed 'common_name' to 'pki_ca_common_name'.
+    """
+    try:
+        track = channel.split("/")[0]
+        version = Version(track)
+    except (ValueError, IndexError):
+        return "pki_ca_common_name"
+    if version >= VAULT_PKI_CA_COMMON_NAME_MIN_VERSION:
+        return "pki_ca_common_name"
+    return "common_name"
+
+
+def migrate_vault_config_in_db(
+    client: Client,
+    tfvar_config: str,
+    channel: str,
+) -> None:
+    """Migrate vault-config keys in stored tfvars for the given channel.
+
+    Renames common_name <-> pki_ca_common_name and manages
+    pki_allow_subdomains based on the target channel.
+    """
+    config_key = vault_pki_config_key(channel)
+    old_key = (
+        "common_name" if config_key == "pki_ca_common_name" else "pki_ca_common_name"
+    )
+
+    try:
+        stored = read_config(client, tfvar_config)
+    except ConfigItemNotFoundException:
+        return
+
+    vault_config = stored.get("vault-config")
+    if not isinstance(vault_config, dict):
+        return
+
+    changed = False
+
+    if old_key in vault_config:
+        if config_key in vault_config:
+            del vault_config[old_key]
+        else:
+            vault_config[config_key] = vault_config.pop(old_key)
+        changed = True
+
+    if config_key == "pki_ca_common_name":
+        if not vault_config.get("pki_allow_subdomains"):
+            vault_config["pki_allow_subdomains"] = True
+            changed = True
+    else:
+        if "pki_allow_subdomains" in vault_config:
+            del vault_config["pki_allow_subdomains"]
+            changed = True
+
+    if changed:
+        update_config(client, tfvar_config, stored)
 
 
 class VaultCommandFailedException(SunbeamException):

--- a/sunbeam-python/sunbeam/steps/vault.py
+++ b/sunbeam-python/sunbeam/steps/vault.py
@@ -21,12 +21,17 @@ from sunbeam.core.juju import (
 )
 from sunbeam.core.manifest import Manifest
 from sunbeam.core.openstack import OPENSTACK_MODEL
-from sunbeam.core.terraform import TerraformException, TerraformHelper
+from sunbeam.core.terraform import (
+    TerraformException,
+    TerraformHelper,
+    TerraformStateLockedException,
+)
 from sunbeam.features.interface.v1.openstack import OPENSTACK_TERRAFORM_VARS
 from sunbeam.features.vault.feature import (
     VaultCommandFailedException,
     VaultHelper,
     auto_unseal_vault,
+    migrate_vault_config_in_db,
 )
 from sunbeam.versions import VAULT_CHANNEL
 
@@ -60,6 +65,7 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
         self.tfhelper = tfhelper
         self.application = application
         self.tfvar_config = OPENSTACK_TERRAFORM_VARS
+        self._skip_charm_refresh = False
 
     def upgrade(
         self, revision: int | None = None, channel: str = VAULT_CHANNEL
@@ -75,18 +81,11 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
             trust=True,
         )
 
-    def is_skip(self, context: StepContext) -> Result:
-        """Determines if the step should be skipped or not.
+    def _needs_charm_refresh(self) -> Result:
+        """Determine whether the charm itself needs refreshing.
 
-        Skips when:
-        - application is not deployed
-        - channel pinned in manifest has track below VAULT_CHANNEL
-        - manifest pins a revision that matches the deployed charm
-        - no revision pinned and deployed charm is already at the latest
-          revision for the target channel
-
-        :return: ResultType.SKIPPED if the Step should be skipped,
-                ResultType.COMPLETED or ResultType.FAILED otherwise
+        Returns SKIPPED when the deployed charm already matches the target,
+        FAILED when the manifest channel is invalid, COMPLETED otherwise.
         """
         try:
             app = self.jhelper.get_application(self.application, OPENSTACK_MODEL)
@@ -105,8 +104,6 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
         if charm_manifest and charm_manifest.channel:
             target_track = target_channel.split("/")[0]
             minimum_vault_track = VAULT_CHANNEL.split("/")[0]
-            # Skip if the manifest pins a channel whose track is below the
-            # minimum supported channel.
             if target_track != minimum_vault_track and not self.channel_update_needed(
                 VAULT_CHANNEL, target_channel
             ):
@@ -129,11 +126,8 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
                 )
                 LOG.debug(msg)
                 return Result(ResultType.SKIPPED, msg)
-            # Proceed with upgrade if revision pinned in manifest differs from deployed.
             return Result(ResultType.COMPLETED)
 
-        # No revision pinned: Skip if deployed charm is already at the latest revision
-        # for the target channel.
         try:
             if app.base:
                 base = f"{app.base.name}@{app.base.channel}"
@@ -146,7 +140,6 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
                 )
         except JujuException as e:
             LOG.debug("Could not determine latest revision for %s: %s", CHARM_NAME, e)
-            # Proceed with refresh if we cannot confirm the revision.
             return Result(ResultType.COMPLETED)
 
         if deployed_channel == target_channel and app.charm_rev == latest_rev:
@@ -154,6 +147,28 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
                 ResultType.SKIPPED,
                 f"{CHARM_NAME} is already at the latest revision for "
                 f"channel {target_channel}",
+            )
+        return Result(ResultType.COMPLETED)
+
+    def is_skip(self, context: StepContext) -> Result:
+        """Determines if the step should be skipped or not.
+
+        Only skips when vault is not deployed or the manifest channel is
+        invalid.  The step always runs otherwise so that the DB migration
+        and terraform apply happen even when no charm refresh is needed.
+        """
+        result = self._needs_charm_refresh()
+        if result.result_type == ResultType.FAILED:
+            return result
+        # Remember whether the charm refresh itself can be skipped so that
+        # run() can avoid the unnecessary upgrade + wait cycle.
+        self._skip_charm_refresh = result.result_type == ResultType.SKIPPED
+        try:
+            self.jhelper.get_application(self.application, OPENSTACK_MODEL)
+        except ApplicationNotFoundException:
+            return Result(
+                ResultType.SKIPPED,
+                f"{self.application} application has not been deployed yet",
             )
         return Result(ResultType.COMPLETED)
 
@@ -165,45 +180,58 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
             charm_manifest.channel if charm_manifest else None
         ) or VAULT_CHANNEL
 
-        try:
-            self.update_status(context, f"Refreshing Vault to channel {target_channel}")
-            self.upgrade(revision=revision, channel=target_channel)
-        except JujuException as e:
-            LOG.error(f"Failed to refresh Vault: {e}")
-            return Result(
-                ResultType.FAILED,
-                f"Failed to refresh Vault: {e}",
-            )
+        if not self._skip_charm_refresh:
+            try:
+                self.update_status(
+                    context, f"Refreshing Vault to channel {target_channel}"
+                )
+                self.upgrade(revision=revision, channel=target_channel)
+            except JujuException as e:
+                LOG.error(f"Failed to refresh Vault: {e}")
+                return Result(
+                    ResultType.FAILED,
+                    f"Failed to refresh Vault: {e}",
+                )
 
-        try:
-            self.update_status(context, "Waiting for Vault to stabilise")
-            # Vault expected to be blocked and unsealed after refresh
-            self.jhelper.wait_until_desired_status(
-                OPENSTACK_MODEL,
-                [self.application],
-                status=["blocked"],
-                workload_status_message=["Please unseal Vault"],
-                timeout=VAULT_UPGRADE_TIMEOUT,
-            )
-        except (JujuWaitException, TimeoutError) as e:
-            LOG.error(f"Timed out waiting for {self.application}: {e}")
-            return Result(
-                ResultType.FAILED,
-                f"Timed out waiting for {self.application} to stabilise: {e}",
-            )
+            try:
+                self.update_status(context, "Waiting for Vault to stabilise")
+                # After refresh vault may be blocked on missing config
+                # (1.18+ requires pki_ca_common_name) or waiting to be unsealed.
+                self.jhelper.wait_until_desired_status(
+                    OPENSTACK_MODEL,
+                    [self.application],
+                    status=["blocked"],
+                    timeout=VAULT_UPGRADE_TIMEOUT,
+                )
+            except (JujuWaitException, TimeoutError) as e:
+                LOG.error(f"Timed out waiting for {self.application}: {e}")
+                return Result(
+                    ResultType.FAILED,
+                    f"Timed out waiting for {self.application} to stabilise: {e}",
+                )
 
         try:
             self.update_status(
                 context, "Updating terraform plan with new vault channel"
             )
+            migrate_vault_config_in_db(self.client, self.tfvar_config, target_channel)
             self.tfhelper.update_tfvars_and_apply_tf(
                 self.client,
                 self.manifest,
                 tfvar_config=self.tfvar_config,
                 override_tfvars={"vault-channel": target_channel},
             )
-        except TerraformException as e:
-            LOG.warning(f"Failed to reapply terraform plan after vault upgrade: {e}")
+        except (TerraformException, TerraformStateLockedException) as e:
+            return Result(
+                ResultType.FAILED,
+                f"Failed to apply terraform plan after vault config migration: {e}",
+            )
+
+        if self._skip_charm_refresh:
+            return Result(
+                ResultType.COMPLETED,
+                "Vault config migrated, no charm refresh needed.",
+            )
 
         try:
             self.update_status(

--- a/sunbeam-python/tests/unit/sunbeam/features/test_vault.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_vault.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.core.common import ResultType
 from sunbeam.core.juju import (
     ActionFailedException,
@@ -19,6 +20,8 @@ from sunbeam.features.vault.feature import (
     VaultInitStep,
     VaultStatusStep,
     VaultUnsealStep,
+    migrate_vault_config_in_db,
+    vault_pki_config_key,
 )
 
 
@@ -540,3 +543,162 @@ class TestVaultStatusStep:
 
         assert result.result_type == ResultType.FAILED
         assert result.message == error_message
+
+
+class TestVaultPkiConfigKey:
+    @pytest.mark.parametrize(
+        "channel, expected_key",
+        [
+            ("1.16/stable", "common_name"),
+            ("1.17/stable", "common_name"),
+            ("1.17/edge", "common_name"),
+            ("1.18/stable", "pki_ca_common_name"),
+            ("1.18/edge", "pki_ca_common_name"),
+            ("1.19/stable", "pki_ca_common_name"),
+            ("2.0/stable", "pki_ca_common_name"),
+        ],
+    )
+    def test_returns_correct_key_for_channel(self, channel, expected_key):
+        assert vault_pki_config_key(channel) == expected_key
+
+    def test_unparseable_channel_defaults_to_new_key(self):
+        assert vault_pki_config_key("latest/stable") == "pki_ca_common_name"
+
+    def test_empty_channel_defaults_to_new_key(self):
+        assert vault_pki_config_key("") == "pki_ca_common_name"
+
+
+class TestMigrateVaultConfigInDb:
+    def test_migrates_common_name_to_pki_ca_common_name(self):
+        stored = {
+            "_computed_keys": ["vault-config"],
+            "vault-config": {"common_name": "example.com"},
+            "keystone-channel": "2024.1/stable",
+        }
+        client = Mock()
+        client.cluster.get_config.return_value = json.dumps(stored)
+
+        with patch("sunbeam.features.vault.feature.read_config", return_value=stored):
+            with patch("sunbeam.features.vault.feature.update_config") as mock_update:
+                migrate_vault_config_in_db(
+                    client, "TerraformVarsOpenstack", "1.18/stable"
+                )
+
+        mock_update.assert_called_once()
+        saved_data = mock_update.call_args.args[2]
+        assert saved_data["vault-config"]["pki_ca_common_name"] == "example.com"
+        assert "common_name" not in saved_data["vault-config"]
+        assert saved_data["vault-config"]["pki_allow_subdomains"] is True
+
+    def test_migrates_pki_ca_common_name_to_common_name(self):
+        stored = {
+            "_computed_keys": ["vault-config"],
+            "vault-config": {
+                "pki_ca_common_name": "example.com",
+                "pki_allow_subdomains": True,
+            },
+        }
+        client = Mock()
+
+        with patch("sunbeam.features.vault.feature.read_config", return_value=stored):
+            with patch("sunbeam.features.vault.feature.update_config") as mock_update:
+                migrate_vault_config_in_db(
+                    client, "TerraformVarsOpenstack", "1.16/stable"
+                )
+
+        mock_update.assert_called_once()
+        saved_data = mock_update.call_args.args[2]
+        assert saved_data["vault-config"] == {"common_name": "example.com"}
+        assert "pki_allow_subdomains" not in saved_data["vault-config"]
+
+    def test_both_keys_present_preserves_new_key(self):
+        stored = {
+            "vault-config": {
+                "common_name": "old.example.com",
+                "pki_ca_common_name": "example.com",
+                "pki_allow_subdomains": True,
+            },
+        }
+        client = Mock()
+
+        with patch("sunbeam.features.vault.feature.read_config", return_value=stored):
+            with patch("sunbeam.features.vault.feature.update_config") as mock_update:
+                migrate_vault_config_in_db(
+                    client, "TerraformVarsOpenstack", "1.18/stable"
+                )
+
+        mock_update.assert_called_once()
+        saved_data = mock_update.call_args.args[2]
+        assert saved_data["vault-config"]["pki_ca_common_name"] == "example.com"
+        assert "common_name" not in saved_data["vault-config"]
+
+    def test_noop_when_key_already_correct(self):
+        stored = {
+            "vault-config": {
+                "pki_ca_common_name": "example.com",
+                "pki_allow_subdomains": True,
+            },
+        }
+        client = Mock()
+
+        with patch("sunbeam.features.vault.feature.read_config", return_value=stored):
+            with patch("sunbeam.features.vault.feature.update_config") as mock_update:
+                migrate_vault_config_in_db(
+                    client, "TerraformVarsOpenstack", "1.18/stable"
+                )
+
+        mock_update.assert_not_called()
+
+    def test_adds_pki_allow_subdomains_when_missing_on_118(self):
+        stored = {
+            "vault-config": {"pki_ca_common_name": "example.com"},
+        }
+        client = Mock()
+
+        with patch("sunbeam.features.vault.feature.read_config", return_value=stored):
+            with patch("sunbeam.features.vault.feature.update_config") as mock_update:
+                migrate_vault_config_in_db(
+                    client, "TerraformVarsOpenstack", "1.18/stable"
+                )
+
+        mock_update.assert_called_once()
+        saved_data = mock_update.call_args.args[2]
+        assert saved_data["vault-config"]["pki_allow_subdomains"] is True
+
+    def test_noop_when_no_vault_config(self):
+        stored = {"keystone-channel": "2024.1/stable"}
+        client = Mock()
+
+        with patch("sunbeam.features.vault.feature.read_config", return_value=stored):
+            with patch("sunbeam.features.vault.feature.update_config") as mock_update:
+                migrate_vault_config_in_db(
+                    client, "TerraformVarsOpenstack", "1.18/stable"
+                )
+
+        mock_update.assert_not_called()
+
+    def test_noop_when_config_not_found(self):
+        client = Mock()
+
+        with patch(
+            "sunbeam.features.vault.feature.read_config",
+            side_effect=ConfigItemNotFoundException,
+        ):
+            with patch("sunbeam.features.vault.feature.update_config") as mock_update:
+                migrate_vault_config_in_db(
+                    client, "TerraformVarsOpenstack", "1.18/stable"
+                )
+
+        mock_update.assert_not_called()
+
+    def test_noop_when_vault_config_is_none(self):
+        stored = {"vault-config": None}
+        client = Mock()
+
+        with patch("sunbeam.features.vault.feature.read_config", return_value=stored):
+            with patch("sunbeam.features.vault.feature.update_config") as mock_update:
+                migrate_vault_config_in_db(
+                    client, "TerraformVarsOpenstack", "1.18/stable"
+                )
+
+        mock_update.assert_not_called()

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_vault_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_vault_upgrade.py
@@ -10,12 +10,19 @@ from sunbeam.core.juju import (
     ApplicationNotFoundException,
     JujuException,
 )
+from sunbeam.core.terraform import TerraformException
 from sunbeam.features.vault.feature import VaultCommandFailedException
 from sunbeam.steps.vault import (
     CHARM_BASE,
     VAULT_CHANNEL,
     VaultCharmUpgradeStep,
 )
+
+
+@pytest.fixture
+def mock_migrate():
+    with patch("sunbeam.steps.vault.migrate_vault_config_in_db") as p:
+        yield p
 
 
 @pytest.fixture
@@ -63,7 +70,7 @@ class TestVaultCharmUpgradeStep:
         assert result.result_type == ResultType.FAILED
         assert "track is below" in result.message
 
-    def test_skip_when_manifest_channel_and_revision_match_deployment(
+    def test_no_skip_when_manifest_channel_and_revision_match_deployment(
         self, step, basic_jhelper, basic_manifest, step_context
     ):
         app = Mock(charm_rev=200, charm_channel="1.19/stable", base=None)
@@ -75,10 +82,10 @@ class TestVaultCharmUpgradeStep:
         with patch.object(step, "channel_update_needed", return_value=True):
             result = step.is_skip(step_context)
 
-        assert result.result_type == ResultType.SKIPPED
-        assert "already at manifest pinned" in result.message
+        assert result.result_type == ResultType.COMPLETED
+        assert step._skip_charm_refresh is True
 
-    def test_skip_when_already_at_latest_revision_for_target(
+    def test_no_skip_when_already_at_latest_revision_for_target(
         self, step, basic_jhelper, basic_manifest, step_context
     ):
         app = Mock(charm_rev=100, charm_channel=VAULT_CHANNEL, base=None)
@@ -88,8 +95,8 @@ class TestVaultCharmUpgradeStep:
 
         result = step.is_skip(step_context)
 
-        assert result.result_type == ResultType.SKIPPED
-        assert "latest revision" in result.message
+        assert result.result_type == ResultType.COMPLETED
+        assert step._skip_charm_refresh is True
 
     def test_not_skipped_when_newer_revision_available(
         self, step, basic_jhelper, basic_manifest, step_context
@@ -102,6 +109,7 @@ class TestVaultCharmUpgradeStep:
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
+        assert step._skip_charm_refresh is False
 
     def test_not_skipped_when_manifest_channel_is_upgrade(
         self, step, basic_jhelper, basic_manifest, step_context
@@ -122,7 +130,13 @@ class TestVaultCharmUpgradeStep:
         )
 
     def test_run_fails_when_vault_unsealed_after_upgrade(
-        self, step, basic_jhelper, basic_manifest, vaulthelper, step_context
+        self,
+        step,
+        basic_jhelper,
+        basic_manifest,
+        vaulthelper,
+        mock_migrate,
+        step_context,
     ):
         basic_manifest.find_charm.return_value = None
         vaulthelper.get_vault_status.return_value = {"sealed": False}
@@ -149,6 +163,7 @@ class TestVaultCharmUpgradeStep:
         basic_manifest,
         vaulthelper,
         mock_auto_unseal,
+        mock_migrate,
         step_context,
     ):
         basic_manifest.find_charm.return_value = Mock(
@@ -194,7 +209,13 @@ class TestVaultCharmUpgradeStep:
         assert "timed out" in result.message
 
     def test_run_vault_sealed_no_dev_mode(
-        self, step, basic_jhelper, vaulthelper, mock_auto_unseal, step_context
+        self,
+        step,
+        basic_jhelper,
+        vaulthelper,
+        mock_auto_unseal,
+        mock_migrate,
+        step_context,
     ):
         basic_jhelper.get_leader_unit.return_value = "vault/0"
         vaulthelper.get_vault_status.return_value = {"sealed": True}
@@ -213,6 +234,7 @@ class TestVaultCharmUpgradeStep:
         basic_jhelper,
         vaulthelper,
         mock_auto_unseal,
+        mock_migrate,
         step_context,
     ):
         basic_jhelper.get_leader_unit.return_value = "vault/0"
@@ -231,6 +253,7 @@ class TestVaultCharmUpgradeStep:
         basic_jhelper,
         vaulthelper,
         mock_auto_unseal,
+        mock_migrate,
         step_context,
     ):
         basic_jhelper.get_leader_unit.return_value = "vault/0"
@@ -242,3 +265,109 @@ class TestVaultCharmUpgradeStep:
         assert result.result_type == ResultType.COMPLETED
         assert "auto-unseal failed" in result.message
         assert "unseal failed" in result.message
+
+    def test_run_skips_unseal_when_charm_refresh_skipped(
+        self,
+        step,
+        basic_jhelper,
+        basic_manifest,
+        basic_tfhelper,
+        mock_migrate,
+        step_context,
+    ):
+        basic_manifest.find_charm.return_value = None
+        step._skip_charm_refresh = True
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        assert "no charm refresh needed" in result.message
+        mock_migrate.assert_called_once()
+        basic_jhelper.charm_refresh.assert_not_called()
+        basic_jhelper.get_leader_unit.assert_not_called()
+
+    def test_run_fails_when_terraform_fails_on_skip_path(
+        self,
+        step,
+        basic_jhelper,
+        basic_manifest,
+        basic_tfhelper,
+        mock_migrate,
+        step_context,
+    ):
+        basic_manifest.find_charm.return_value = None
+        basic_tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
+            "apply failed"
+        )
+        step._skip_charm_refresh = True
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "terraform" in result.message.lower()
+
+    def test_run_fails_when_terraform_fails_after_refresh(
+        self,
+        step,
+        basic_jhelper,
+        basic_manifest,
+        basic_tfhelper,
+        mock_migrate,
+        step_context,
+    ):
+        basic_manifest.find_charm.return_value = None
+        basic_tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
+            "apply failed"
+        )
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "terraform" in result.message.lower()
+        basic_jhelper.get_leader_unit.assert_not_called()
+
+    def test_run_calls_migrate_vault_config(
+        self,
+        step,
+        basic_jhelper,
+        basic_manifest,
+        basic_tfhelper,
+        vaulthelper,
+        mock_auto_unseal,
+        mock_migrate,
+        step_context,
+    ):
+        basic_manifest.find_charm.return_value = None
+        vaulthelper.get_vault_status.return_value = {"sealed": True}
+        basic_jhelper.get_leader_unit.return_value = "vault/0"
+        mock_auto_unseal.return_value = None
+
+        step.run(step_context)
+
+        mock_migrate.assert_called_once_with(
+            step.client, step.tfvar_config, VAULT_CHANNEL
+        )
+
+    def test_run_calls_migrate_with_manifest_channel(
+        self,
+        step,
+        basic_jhelper,
+        basic_manifest,
+        basic_tfhelper,
+        vaulthelper,
+        mock_auto_unseal,
+        mock_migrate,
+        step_context,
+    ):
+        basic_manifest.find_charm.return_value = Mock(
+            channel="1.19/stable", revision=None
+        )
+        vaulthelper.get_vault_status.return_value = {"sealed": True}
+        basic_jhelper.get_leader_unit.return_value = "vault/0"
+        mock_auto_unseal.return_value = None
+
+        step.run(step_context)
+
+        mock_migrate.assert_called_once_with(
+            step.client, step.tfvar_config, "1.19/stable"
+        )


### PR DESCRIPTION
Vault 1.18+ renamed the PKI CA config key from `common_name` to `pki_ca_common_name`. Also requires pki_allow_subdomains to be explicitly enabled. Detect the deployed vault channel at runtime and use the correct key for both greenfield deployments and upgrades.

Migration of stored tfvars happens during `refresh vault` and on TLS enable, ensuring the DB is consistent before any Terraform apply.

Remove misleading console output in pre_enable.

Closes-Bug: #2147090