### PR TITLE
feat: per-host CiliumNodeConfig for surgical cilium device binding

### DIFF
--- a/docs/agents/plans/cilium-per-host-device-config.md
+++ b/docs/agents/plans/cilium-per-host-device-config.md
@@ -1,0 +1,1317 @@
+# Cilium Per-Host Device Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fragile cluster-wide cilium device patterns with surgical per-host `CiliumNodeConfig` resources that name the exact internal-space NIC on each control node.
+
+**Architecture:** Revert three commits that introduced the cluster-wide annotation approach, extract shared per-host logic from `EnsureL2AdvertisementByHostStep` into `_PerHostK8SResourceStep`, then build `EnsureCiliumDeviceByHostStep` on top of it. Integrate into all command plans before the L2Advertisement steps.
+
+**Tech Stack:** Python 3.12, lightkube (k8s client), jubilant (juju), pytest, Cilium `cilium.io/v2` CRD
+
+**Spec:** `docs/agents/specs/cilium-per-host-device-config-design.md`
+
+---
+
+### Task 1: Revert the three commits
+
+**Files:**
+- Modify: `sunbeam-python/sunbeam/steps/k8s.py`
+- Modify: `sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py`
+- Modify: `sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py`
+- Modify: `sunbeam-python/sunbeam/steps/upgrades/intra_channel.py`
+
+- [ ] **Step 1: Revert newest commit first**
+
+```bash
+git revert --no-commit f001990cf7e3c81a0c040224016ebc66c5290b5d
+```
+
+- [ ] **Step 2: Revert second commit**
+
+```bash
+git revert --no-commit 2be63d7bf63c46e7ab77bd45bcd519fec9275a06
+```
+
+- [ ] **Step 3: Revert oldest commit**
+
+```bash
+git revert --no-commit 4627372886174154be4784761f04de77881c5aae
+```
+
+- [ ] **Step 4: Resolve any conflicts and verify the revert**
+
+After the three reverts, verify these are gone from `sunbeam-python/sunbeam/steps/k8s.py`:
+- `CILIUM_DEVICES_ANNOTATION_KEY` constant (was line 106)
+- `CILIUM_DEVICES_ANNOTATION_DEFAULT` constant (was lines 107-121)
+- `EnsureCiliumOnCorrectSpaceStep` class (was lines 589-794)
+- The `"cluster"` endpoint binding to `Networks.INTERNAL` in `DeployK8SApplicationStep.extra_tfvars()` — should only have the management default binding
+- The `cluster-annotations` line in `_get_k8s_config_tfvars()` and the comma-separated validation block
+- `_get_cluster_ips` should be reverted to `_get_management_ips` in `EnsureK8SUnitsTaggedStep`
+
+Verify `intra_channel.py` no longer imports `EnsureCiliumOnCorrectSpaceStep`.
+
+- [ ] **Step 5: Run tests to confirm nothing is broken**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py -v 2>&1 | tail -30
+```
+
+Expected: all tests pass (the reverted tests are removed too).
+
+- [ ] **Step 6: Run linting**
+
+```bash
+cd sunbeam-python && tox -e pep8 2>&1 | tail -20
+```
+
+Expected: clean pass.
+
+- [ ] **Step 7: Commit the revert**
+
+```bash
+git add -A && git commit -m "revert: remove cluster-wide cilium device annotation approach
+
+Reverts f001990c, 2be63d7b, 46273728.
+
+The cluster-wide device pattern matching causes Cilium to bind to
+wrong devices (e.g. OVS uplink NICs), breaking external traffic.
+A per-host CiliumNodeConfig approach will replace this."
+```
+
+---
+
+### Task 2: Add `CiliumNodeConfig` generic resource to `K8SHelper`
+
+**Files:**
+- Modify: `sunbeam-python/sunbeam/core/k8s.py:122-132`
+
+- [ ] **Step 1: Add the class method**
+
+In `sunbeam-python/sunbeam/core/k8s.py`, add after `get_lightkube_l2_advertisement_resource` (around line 132):
+
+```python
+    @classmethod
+    def get_lightkube_cilium_node_config_resource(
+        cls,
+    ) -> Type["l_generic_resource.GenericNamespacedResource"]:
+        """Return lightkube generic resource of type CiliumNodeConfig."""
+        return l_generic_resource.create_namespaced_resource(
+            "cilium.io",
+            "v2",
+            "CiliumNodeConfig",
+            "ciliumnodeconfigs",
+            verbs=["delete", "get", "list", "patch", "post", "put"],
+        )
+```
+
+- [ ] **Step 2: Run linting**
+
+```bash
+cd sunbeam-python && tox -e pep8 2>&1 | tail -20
+```
+
+Expected: clean pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sunbeam-python/sunbeam/core/k8s.py && git commit -m "feat: add CiliumNodeConfig lightkube generic resource to K8SHelper"
+```
+
+---
+
+### Task 3: Extract `_PerHostK8SResourceStep` base class
+
+**Files:**
+- Modify: `sunbeam-python/sunbeam/steps/k8s.py:1506-1690` (EnsureL2AdvertisementByHostStep)
+- Test: `sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py`
+
+This task extracts the shared logic and refactors `EnsureL2AdvertisementByHostStep` to inherit from it. The L2 tests must keep passing with zero behavior change.
+
+- [ ] **Step 1: Run existing L2 tests to establish baseline**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py::TestEnsureL2AdvertisementByHostStep -v 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Write `_PerHostK8SResourceStep` above `EnsureL2AdvertisementByHostStep`**
+
+Insert before the `EnsureL2AdvertisementByHostStep` class in `sunbeam-python/sunbeam/steps/k8s.py`:
+
+```python
+class _PerHostK8SResourceStep(BaseStep):
+    """Base class for steps that manage per-host k8s resources.
+
+    Provides common logic for looking up control nodes, creating a kube client,
+    finding the juju-space interface for each node, and determining which nodes
+    have outdated resources.
+
+    Subclasses must implement:
+      - _get_outdated_resources(nodes, kube) -> (outdated, deleted)
+      - run(context) -> Result
+    """
+
+    class _InterfaceError(SunbeamException):
+        pass
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        deployment: Deployment,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        network: Networks,
+        kube_namespace: str | None = None,
+        fqdn: str | None = None,
+    ):
+        super().__init__(name, description)
+        self.deployment = deployment
+        self.client = client
+        self.jhelper = jhelper
+        self.model = model
+        self.network = network
+        self.kube_namespace = kube_namespace
+        self.fqdn = fqdn
+        self.to_update: list[dict] = []
+        self.to_delete: list[dict] = []
+        self._ifnames: dict[str, str] = {}
+
+    def _get_interface(self, node: dict) -> str:
+        """Get the network interface for the node in the configured space."""
+        name = node["name"]
+        if name in self._ifnames:
+            return self._ifnames[name]
+        machine_id = str(node["machineid"])
+        machine_interfaces = self.jhelper.get_machine_interfaces(
+            self.model, machine_id
+        )
+        LOG.debug("Machine %r interfaces: %r", machine_id, machine_interfaces)
+        network_space = self.deployment.get_space(self.network)
+        for ifname, iface in machine_interfaces.items():
+            if (spaces := iface.space) and network_space in spaces.split():
+                self._ifnames[name] = ifname
+                return ifname
+        raise self._InterfaceError(
+            f"Node {node['name']} has no interface in {self.network.name} space"
+        )
+
+    def _get_outdated_resources(
+        self, nodes: list[dict], kube: "l_client.Client"
+    ) -> tuple[list[str], list[str]]:
+        """Return (outdated, deleted) node name lists.
+
+        Must be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    def is_skip(self, context: StepContext) -> Result:
+        """Determines if the step should be skipped or not."""
+        control = Role.CONTROL.name.lower()
+        region_controller = Role.REGION_CONTROLLER.name.lower()
+        if self.fqdn:
+            node = self.client.cluster.get_node_info(self.fqdn)
+            node_roles = node.get("role", [])
+            if control not in node_roles and region_controller not in node_roles:
+                return Result(ResultType.FAILED, f"{self.fqdn} is not a control node")
+            self.control_nodes = [node]
+        else:
+            self.control_nodes = self.client.cluster.list_nodes_by_role(control)
+
+        try:
+            self.kube = get_kube_client(self.client, self.kube_namespace)
+        except KubeClientError as e:
+            LOG.debug("Failed to create k8s client", exc_info=True)
+            return Result(ResultType.FAILED, str(e))
+
+        try:
+            outdated, deleted = self._get_outdated_resources(
+                self.control_nodes, self.kube
+            )
+        except (l_exceptions.ApiError, self._InterfaceError) as e:
+            LOG.debug("Failed to get outdated resources", exc_info=True)
+            return Result(ResultType.FAILED, str(e))
+
+        if not (outdated or deleted):
+            LOG.debug("No resources to update")
+            return Result(ResultType.SKIPPED)
+
+        for node in self.control_nodes:
+            if node["name"] in outdated:
+                self.to_update.append(node)
+            if node["name"] in deleted:
+                self.to_delete.append(node)
+
+        return Result(ResultType.COMPLETED)
+```
+
+- [ ] **Step 3: Refactor `EnsureL2AdvertisementByHostStep` to inherit from `_PerHostK8SResourceStep`**
+
+Replace the class definition. Remove the duplicated `__init__`, `_get_interface`, and `is_skip` — those now live in the base. Keep L2-specific fields and methods:
+
+```python
+class EnsureL2AdvertisementByHostStep(_PerHostK8SResourceStep):
+    """Ensure IP Pool is advertised by L2Advertisement resources."""
+
+    _APPLICATION = APPLICATION
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        network: Networks,
+        pool: str,
+        fqdn: str | None = None,
+    ):
+        super().__init__(
+            "Ensure L2 advertisement",
+            "Ensuring L2 advertisement",
+            deployment,
+            client,
+            jhelper,
+            model,
+            network,
+            kube_namespace=K8SHelper.get_loadbalancer_namespace(),
+            fqdn=fqdn,
+        )
+        self.pool = pool
+        self.l2_advertisement_resource = (
+            K8SHelper.get_lightkube_l2_advertisement_resource()
+        )
+        self.l2_advertisement_namespace = K8SHelper.get_loadbalancer_namespace()
+
+    def _labels(self, name: str, space: str) -> dict[str, str]:
+        """Return labels for the L2 advertisement."""
+        return {
+            "app.kubernetes.io/managed-by": self.deployment.name,
+            "app.kubernetes.io/instance": self._instance_label(
+                self.network.value.lower(), name
+            ),
+            "app.kubernetes.io/name": self._name_label(self.network.value.lower()),
+            HOSTNAME_LABEL: name,
+            "sunbeam/space": space,
+            "sunbeam/network": self.network.value.lower(),
+        }
+
+    def _l2_advertisement_name(self, node: str) -> str:
+        """Return L2 advertisement name for the node."""
+        return f"{self.network.value.lower()}-{node}"
+
+    def _name_label(self, network: str):
+        """Return name label for the L2 advertisement."""
+        return f"{network}-l2"
+
+    def _instance_label(self, network: str, name: str):
+        """Return instance label for the L2 advertisement."""
+        return self._name_label(network) + "-" + name
+
+    def _get_outdated_resources(
+        self, nodes: list[dict], kube: "l_client.Client"
+    ) -> tuple[list[str], list[str]]:
+        """Get outdated L2 advertisement."""
+        outdated: list[str] = [node["name"] for node in nodes]
+        deleted: list[str] = []
+
+        l2_advertisements = kube.list(
+            self.l2_advertisement_resource,
+            namespace=self.l2_advertisement_namespace,
+            labels={"app.kubernetes.io/name": self._name_label(self.pool)},
+        )
+
+        for l2_ad in l2_advertisements:
+            if l2_ad.metadata is None or l2_ad.metadata.labels is None:
+                LOG.debug("L2 advertisement has no metadata nor labels")
+                continue
+            hostname = l2_ad.metadata.labels.get(HOSTNAME_LABEL)
+
+            if hostname is None:
+                LOG.debug(
+                    "L2 advertisement %s has no hostname label",
+                    l2_ad.metadata.name,
+                )
+                continue
+            if l2_ad.spec is None:
+                LOG.debug("L2 advertisement %r has no spec", hostname)
+                continue
+            if hostname not in outdated:
+                LOG.debug(
+                    "L2 advertisement %s has no matching node",
+                    l2_ad.metadata.name,
+                )
+                deleted.append(hostname)
+                continue
+            if self.pool not in l2_ad.spec.get("ipAddressPools", []):
+                LOG.debug(
+                    "L2 advertisement %s has wrong allocated ip pool",
+                    l2_ad.metadata.name,
+                )
+                continue
+            interface = None
+            for node in nodes:
+                if node["name"] == hostname:
+                    interface = self._get_interface(node)
+            if not interface:
+                LOG.debug(
+                    "L2 advertisement %s has no allocated interface",
+                    l2_ad.metadata.name,
+                )
+                continue
+            if l2_ad.spec.get("interfaces") != [interface]:
+                LOG.debug(
+                    "L2 advertisement %s has wrong allocated interface",
+                    l2_ad.metadata.name,
+                )
+                continue
+            outdated.remove(hostname)
+        return outdated, deleted
+
+    @tenacity.retry(
+        wait=tenacity.wait_fixed(15),
+        stop=tenacity.stop_after_delay(600),
+        retry=tenacity.retry_if_exception_type(tenacity.TryAgain),
+        reraise=True,
+    )
+    def _ensure_l2_advertisement(self, name: str, interface: str):
+        try:
+            self.kube.apply(
+                self.l2_advertisement_resource(
+                    metadata=meta_v1.ObjectMeta(
+                        name=self._l2_advertisement_name(name),
+                        labels=self._labels(
+                            name, self.deployment.get_space(self.network)
+                        ),
+                    ),
+                    spec={
+                        "ipAddressPools": [self.pool],
+                        "interfaces": [interface],
+                        "nodeSelectors": [
+                            {
+                                "matchLabels": {
+                                    HOSTNAME_LABEL: name,
+                                }
+                            }
+                        ],
+                    },
+                ),
+                field_manager=self.deployment.name,
+                force=True,
+            )
+        except l_exceptions.ApiError as e:
+            if e.status.code == 500 and "failed calling webhook" in str(e.status):
+                raise tenacity.TryAgain("Trying to patch again")
+            raise
+
+    def run(self, context: StepContext) -> Result:
+        """Run the step to completion."""
+        node_not_found = []
+
+        for node in self.to_update:
+            name = node["name"]
+            try:
+                interface = self._get_interface(node)
+            except MachineNotFoundException:
+                LOG.debug(
+                    "Failed to get the machine for L2 advertisement on %s",
+                    name,
+                    exc_info=True,
+                )
+                node_not_found.append(name)
+                continue
+
+            try:
+                self._ensure_l2_advertisement(name, interface)
+            except l_exceptions.ApiError:
+                LOG.debug("Failed to update L2 advertisement", exc_info=True)
+                return Result(
+                    ResultType.FAILED,
+                    f"Failed to update L2 advertisement for {name}",
+                )
+
+        if node_not_found:
+            return Result(
+                ResultType.SKIPPED,
+                "Failed to get machines for L2 advertisement on nodes: "
+                + ", ".join(node_not_found),
+            )
+
+        for node in self.to_delete:
+            try:
+                self.kube.delete(
+                    self.l2_advertisement_resource,
+                    self._l2_advertisement_name(node["name"]),
+                    namespace=self.l2_advertisement_namespace,
+                )
+            except l_exceptions.ApiError:
+                LOG.debug("Failed to delete L2 advertisement", exc_info=True)
+                continue
+
+        return Result(ResultType.COMPLETED)
+```
+
+Note: `_get_interface(node, network)` calls in L2 become `_get_interface(node)` — the network is now on `self.network` from the base class.
+
+- [ ] **Step 4: Update L2 test calls to match new `_get_interface` signature**
+
+In `test_k8s.py`, the `TestEnsureL2AdvertisementByHostStep` tests that call `step._get_interface({"name": "node1", "machineid": "1"}, network)` need the second argument removed:
+
+```python
+# Old:
+step._get_interface({"name": "node1"}, network)
+step._get_interface({"name": "node1", "machineid": "1"}, network)
+
+# New:
+step._get_interface({"name": "node1"})
+step._get_interface({"name": "node1", "machineid": "1"})
+```
+
+Update these tests:
+- `test_get_interface_cached` (line ~472): remove `network` arg
+- `test_get_interface_found` (line ~478): remove `network` arg
+- `test_get_interface_not_found` (line ~489): remove `network` arg, remove `network.name` setup
+
+For `test_get_interface_not_found`, the error message now uses `self.network.name`. Since the step fixture uses `network = Mock()`, ensure the mock's `name` attribute is set. Since the `step` fixture passes a Mock as network, and `Mock().name` returns the mock's internal name string, explicitly set `network.name = "test-network"` on the mock passed to the step constructor, or check the error message without the network name.
+
+- [ ] **Step 5: Run L2 tests to verify no regressions**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py::TestEnsureL2AdvertisementByHostStep -v 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py -v 2>&1 | tail -30
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Run linting**
+
+```bash
+cd sunbeam-python && tox -e pep8 2>&1 | tail -20
+```
+
+Expected: clean pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add sunbeam-python/sunbeam/steps/k8s.py sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py && git commit -m "refactor: extract _PerHostK8SResourceStep base class from EnsureL2AdvertisementByHostStep
+
+Shared per-host logic (control node lookup, kube client creation,
+interface-by-space lookup, is_skip skeleton) now lives in the base.
+Prepares for EnsureCiliumDeviceByHostStep which shares the same pattern."
+```
+
+---
+
+### Task 4: Implement `EnsureCiliumDeviceByHostStep`
+
+**Files:**
+- Modify: `sunbeam-python/sunbeam/steps/k8s.py`
+- Test: `sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py`
+
+- [ ] **Step 1: Write the test class skeleton and `test_is_skip_no_changes`**
+
+Add to the end of `sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py`:
+
+```python
+class TestEnsureCiliumDeviceByHostStep:
+    @pytest.fixture
+    def deployment(self, basic_deployment):
+        basic_deployment.name = "test-deployment"
+        basic_deployment.get_space.return_value = "internal"
+        return basic_deployment
+
+    @pytest.fixture
+    def control_nodes(self):
+        return [
+            {"name": "node1", "machineid": "1"},
+            {"name": "node2", "machineid": "2"},
+        ]
+
+    @pytest.fixture
+    def client(self, control_nodes):
+        return Mock(
+            cluster=Mock(
+                list_nodes_by_role=Mock(return_value=control_nodes),
+                get_config=Mock(return_value="{}"),
+            )
+        )
+
+    @pytest.fixture
+    def jhelper(self, basic_jhelper):
+        return basic_jhelper
+
+    @pytest.fixture
+    def step(self, deployment, client, jhelper):
+        step = EnsureCiliumDeviceByHostStep(
+            deployment, client, jhelper, "test-model"
+        )
+        step.kube = Mock()
+        return step
+
+    @pytest.fixture(autouse=True)
+    def setup_patches(self, step):
+        kubeconfig_mocker = patch(
+            "sunbeam.steps.k8s.l_kubeconfig.KubeConfig",
+            Mock(from_dict=Mock(return_value=Mock())),
+        )
+        kubeconfig_mocker.start()
+        kube_mocker = patch(
+            "sunbeam.steps.k8s.l_client.Client",
+            Mock(return_value=Mock(return_value=step.kube)),
+        )
+        kube_mocker.start()
+        yield
+        kubeconfig_mocker.stop()
+        kube_mocker.stop()
+
+    def test_is_skip_no_changes(self, step, step_context):
+        step._get_outdated_resources = Mock(return_value=([], []))
+        result = step.is_skip(step_context)
+        assert result.result_type == ResultType.SKIPPED
+```
+
+Also add the import at the top of the test file:
+
+```python
+from sunbeam.steps.k8s import EnsureCiliumDeviceByHostStep
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py::TestEnsureCiliumDeviceByHostStep::test_is_skip_no_changes -v 2>&1 | tail -10
+```
+
+Expected: FAIL — `ImportError: cannot import name 'EnsureCiliumDeviceByHostStep'`
+
+- [ ] **Step 3: Write the minimal `EnsureCiliumDeviceByHostStep` class**
+
+Add to `sunbeam-python/sunbeam/steps/k8s.py`, after the `_PerHostK8SResourceStep` class and before `EnsureL2AdvertisementByHostStep`:
+
+```python
+class EnsureCiliumDeviceByHostStep(_PerHostK8SResourceStep):
+    """Ensure each control node has a CiliumNodeConfig for its internal-space device.
+
+    Creates or updates a CiliumNodeConfig resource per control node, specifying
+    the exact network interface that corresponds to the internal juju space.
+    After applying a changed config, the cilium pod on that node is restarted
+    to pick up the new device binding.
+    """
+
+    _CILIUM_NAMESPACE = "kube-system"
+    _CILIUM_POD_LABEL = "k8s-app=cilium"
+    _RESTART_TIMEOUT = 300  # seconds
+    _RESTART_POLL_INTERVAL = 5  # seconds
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        fqdn: str | None = None,
+    ):
+        super().__init__(
+            "Ensure Cilium device config",
+            "Ensuring Cilium device config per host",
+            deployment,
+            client,
+            jhelper,
+            model,
+            Networks.INTERNAL,
+            kube_namespace=self._CILIUM_NAMESPACE,
+            fqdn=fqdn,
+        )
+        self.cilium_node_config_resource = (
+            K8SHelper.get_lightkube_cilium_node_config_resource()
+        )
+
+    def _cilium_node_config_name(self, hostname: str) -> str:
+        """Return CiliumNodeConfig resource name for a node."""
+        return f"cilium-devices-{hostname}"
+
+    def _labels(self, hostname: str) -> dict[str, str]:
+        """Return labels for the CiliumNodeConfig resource."""
+        return {
+            "app.kubernetes.io/managed-by": self.deployment.name,
+            HOSTNAME_LABEL: hostname,
+        }
+
+    def _get_outdated_resources(
+        self, nodes: list[dict], kube: "l_client.Client"
+    ) -> tuple[list[str], list[str]]:
+        """Get outdated CiliumNodeConfig resources."""
+        outdated: list[str] = [node["name"] for node in nodes]
+        deleted: list[str] = []
+
+        configs = kube.list(
+            self.cilium_node_config_resource,
+            namespace=self._CILIUM_NAMESPACE,
+            labels={"app.kubernetes.io/managed-by": self.deployment.name},
+        )
+
+        for config in configs:
+            if config.metadata is None or config.metadata.labels is None:
+                LOG.debug("CiliumNodeConfig has no metadata or labels")
+                continue
+            hostname = config.metadata.labels.get(HOSTNAME_LABEL)
+            if hostname is None:
+                LOG.debug(
+                    "CiliumNodeConfig %s has no hostname label",
+                    config.metadata.name,
+                )
+                continue
+            if config.spec is None:
+                LOG.debug("CiliumNodeConfig %r has no spec", hostname)
+                continue
+            if hostname not in outdated:
+                LOG.debug(
+                    "CiliumNodeConfig %s has no matching node",
+                    config.metadata.name,
+                )
+                deleted.append(hostname)
+                continue
+
+            # Validate nodeSelector
+            node_selector = config.spec.get("nodeSelector", {})
+            match_labels = node_selector.get("matchLabels", {})
+            if match_labels.get(HOSTNAME_LABEL) != hostname:
+                LOG.debug(
+                    "CiliumNodeConfig %s has wrong nodeSelector",
+                    config.metadata.name,
+                )
+                continue
+
+            # Validate device
+            defaults = config.spec.get("defaults", {})
+            interface = None
+            for node in nodes:
+                if node["name"] == hostname:
+                    interface = self._get_interface(node)
+            if not interface:
+                LOG.debug(
+                    "CiliumNodeConfig %s: no interface for node",
+                    config.metadata.name,
+                )
+                continue
+            if defaults.get("devices") != interface:
+                LOG.debug(
+                    "CiliumNodeConfig %s has wrong device (got %s, want %s)",
+                    config.metadata.name,
+                    defaults.get("devices"),
+                    interface,
+                )
+                continue
+
+            outdated.remove(hostname)
+        return outdated, deleted
+
+    def _find_cilium_pod(self, node_name: str) -> "core_v1.Pod":
+        """Find the cilium pod running on the given node."""
+        pods = list(
+            self.kube.list(
+                core_v1.Pod,
+                namespace=self._CILIUM_NAMESPACE,
+                labels={"k8s-app": "cilium"},
+            )
+        )
+        for pod in pods:
+            if pod.spec and pod.spec.nodeName == node_name:
+                return pod
+        raise SunbeamException(
+            f"No cilium pod found on node {node_name}"
+        )
+
+    def _wait_for_cilium_ready(self, node_name: str) -> None:
+        """Wait until a Ready cilium pod exists on the given node."""
+        deadline = time.monotonic() + self._RESTART_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                pods = list(
+                    self.kube.list(
+                        core_v1.Pod,
+                        namespace=self._CILIUM_NAMESPACE,
+                        labels={"k8s-app": "cilium"},
+                    )
+                )
+            except l_exceptions.ApiError as e:
+                raise SunbeamException(
+                    f"Failed to list cilium pods during restart wait: {e}"
+                ) from e
+
+            for pod in pods:
+                if pod.spec and pod.spec.nodeName == node_name:
+                    if pod.status and pod.status.conditions:
+                        for condition in pod.status.conditions:
+                            if (
+                                condition.type == "Ready"
+                                and condition.status == "True"
+                            ):
+                                LOG.debug(
+                                    "Cilium pod on %s is Ready", node_name
+                                )
+                                return
+            LOG.debug("Waiting for cilium pod on %s to be Ready", node_name)
+            time.sleep(self._RESTART_POLL_INTERVAL)
+
+        raise SunbeamException(
+            f"Cilium pod on {node_name} did not become Ready "
+            f"within {self._RESTART_TIMEOUT}s"
+        )
+
+    def _restart_cilium_on_node(self, node_name: str) -> None:
+        """Delete the cilium pod on a node and wait for the replacement."""
+        pod = self._find_cilium_pod(node_name)
+        pod_name = pod.metadata.name if pod.metadata else "unknown"
+        LOG.debug("Deleting cilium pod %s on node %s", pod_name, node_name)
+        self.kube.delete(
+            core_v1.Pod, pod_name, namespace=self._CILIUM_NAMESPACE
+        )
+        self._wait_for_cilium_ready(node_name)
+
+    def run(self, context: StepContext) -> Result:
+        """Apply CiliumNodeConfig per node and restart affected cilium pods."""
+        for node in self.to_update:
+            name = node["name"]
+            try:
+                interface = self._get_interface(node)
+            except MachineNotFoundException:
+                LOG.debug(
+                    "Failed to get machine for CiliumNodeConfig on %s",
+                    name,
+                    exc_info=True,
+                )
+                return Result(
+                    ResultType.FAILED,
+                    f"Machine not found for node {name}",
+                )
+
+            try:
+                self.kube.apply(
+                    self.cilium_node_config_resource(
+                        metadata=meta_v1.ObjectMeta(
+                            name=self._cilium_node_config_name(name),
+                            labels=self._labels(name),
+                        ),
+                        spec={
+                            "nodeSelector": {
+                                "matchLabels": {
+                                    HOSTNAME_LABEL: name,
+                                },
+                            },
+                            "defaults": {
+                                "devices": interface,
+                            },
+                        },
+                    ),
+                    field_manager=self.deployment.name,
+                    force=True,
+                )
+            except l_exceptions.ApiError:
+                LOG.debug("Failed to apply CiliumNodeConfig", exc_info=True)
+                return Result(
+                    ResultType.FAILED,
+                    f"Failed to apply CiliumNodeConfig for {name}",
+                )
+
+            try:
+                self._restart_cilium_on_node(name)
+            except SunbeamException as e:
+                return Result(ResultType.FAILED, str(e))
+
+        for node in self.to_delete:
+            name = node["name"]
+            try:
+                self.kube.delete(
+                    self.cilium_node_config_resource,
+                    self._cilium_node_config_name(name),
+                    namespace=self._CILIUM_NAMESPACE,
+                )
+            except l_exceptions.ApiError:
+                LOG.debug(
+                    "Failed to delete CiliumNodeConfig for %s", name,
+                    exc_info=True,
+                )
+                continue
+
+            try:
+                self._restart_cilium_on_node(name)
+            except SunbeamException:
+                LOG.debug(
+                    "Failed to restart cilium on %s after config deletion",
+                    name,
+                    exc_info=True,
+                )
+                continue
+
+        return Result(ResultType.COMPLETED)
+```
+
+- [ ] **Step 4: Run the first test to verify it passes**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py::TestEnsureCiliumDeviceByHostStep::test_is_skip_no_changes -v 2>&1 | tail -10
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Add remaining `is_skip` tests**
+
+Append to `TestEnsureCiliumDeviceByHostStep` in `test_k8s.py`:
+
+```python
+    def test_is_skip_outdated_device(self, step, step_context):
+        step._get_outdated_resources = Mock(return_value=(["node1"], []))
+        result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert len(step.to_update) == 1
+        assert step.to_update[0]["name"] == "node1"
+
+    def test_is_skip_missing_config(self, step, step_context):
+        """Node with no CiliumNodeConfig yet is reported as outdated."""
+        step._get_outdated_resources = Mock(return_value=(["node1", "node2"], []))
+        result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert len(step.to_update) == 2
+
+    def test_is_skip_deleted_node(self, step, step_context):
+        step._get_outdated_resources = Mock(return_value=([], ["node2"]))
+        result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert len(step.to_delete) == 1
+
+    def test_is_skip_single_node_fqdn(self, deployment, client, jhelper, step_context):
+        node_info = {"name": "node1", "machineid": "1", "role": ["control"]}
+        client.cluster.get_node_info = Mock(return_value=node_info)
+        step = EnsureCiliumDeviceByHostStep(
+            deployment, client, jhelper, "test-model", fqdn="node1.maas"
+        )
+        step.kube = Mock()
+        step._get_outdated_resources = Mock(return_value=(["node1"], []))
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
+            result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert step.control_nodes == [node_info]
+
+    def test_is_skip_wrong_node_selector(self, step, control_nodes, jhelper):
+        """Config with right label/device but wrong nodeSelector is outdated."""
+        jhelper.get_machine_interfaces.return_value = {
+            "eth0": Mock(space="internal"),
+        }
+        wrong_selector_config = Mock()
+        wrong_selector_config.metadata = Mock(
+            name="cilium-devices-node1",
+            labels={
+                "app.kubernetes.io/managed-by": "test-deployment",
+                "sunbeam/hostname": "node1",
+            },
+        )
+        wrong_selector_config.spec = {
+            "nodeSelector": {"matchLabels": {"sunbeam/hostname": "wrong-node"}},
+            "defaults": {"devices": "eth0"},
+        }
+        step.kube.list = Mock(return_value=[wrong_selector_config])
+        outdated, deleted = step._get_outdated_resources(control_nodes, step.kube)
+        assert "node1" in outdated
+```
+
+- [ ] **Step 6: Run the is_skip tests**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py::TestEnsureCiliumDeviceByHostStep -k "is_skip" -v 2>&1 | tail -20
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Add `run` tests**
+
+Append to `TestEnsureCiliumDeviceByHostStep`:
+
+```python
+    def test_run_creates_config(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        step.kube.apply = Mock()
+
+        cilium_pod = Mock()
+        cilium_pod.metadata = Mock(name="cilium-abc")
+        cilium_pod.spec = Mock(nodeName="node1")
+        cilium_pod.status = Mock(
+            conditions=[Mock(type="Ready", status="True")]
+        )
+        step.kube.list = Mock(return_value=[cilium_pod])
+        step.kube.delete = Mock()
+
+        result = step.run(None)
+
+        step.kube.apply.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_updates_config(self, step):
+        step.to_update = [
+            {"name": "node1", "machineid": "1"},
+            {"name": "node2", "machineid": "2"},
+        ]
+        step.to_delete = []
+        step._get_interface = Mock(side_effect=["eth0", "eth1"])
+        step.kube.apply = Mock()
+
+        pod1 = Mock()
+        pod1.metadata = Mock(name="cilium-aaa")
+        pod1.spec = Mock(nodeName="node1")
+        pod1.status = Mock(conditions=[Mock(type="Ready", status="True")])
+        pod2 = Mock()
+        pod2.metadata = Mock(name="cilium-bbb")
+        pod2.spec = Mock(nodeName="node2")
+        pod2.status = Mock(conditions=[Mock(type="Ready", status="True")])
+        step.kube.list = Mock(return_value=[pod1, pod2])
+        step.kube.delete = Mock()
+
+        result = step.run(None)
+
+        assert step.kube.apply.call_count == 2
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_deletes_stale_config(self, step):
+        step.to_update = []
+        step.to_delete = [{"name": "node2", "machineid": "2"}]
+        step.kube.delete = Mock()
+
+        cilium_pod = Mock()
+        cilium_pod.metadata = Mock(name="cilium-xyz")
+        cilium_pod.spec = Mock(nodeName="node2")
+        cilium_pod.status = Mock(
+            conditions=[Mock(type="Ready", status="True")]
+        )
+        step.kube.list = Mock(return_value=[cilium_pod])
+
+        result = step.run(None)
+
+        assert step.kube.delete.call_count == 2  # config + pod
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_api_error(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        api_error = ApiError.__new__(ApiError)
+        api_error.status = Mock(code=500)
+        step.kube.apply = Mock(side_effect=api_error)
+
+        result = step.run(None)
+
+        assert result.result_type == ResultType.FAILED
+        assert "Failed to apply CiliumNodeConfig for node1" in result.message
+
+    def test_run_no_interface_found(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(
+            side_effect=MachineNotFoundException("not found")
+        )
+
+        result = step.run(None)
+
+        assert result.result_type == ResultType.FAILED
+
+    def test_run_cilium_pod_not_found(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        step.kube.apply = Mock()
+        step.kube.list = Mock(return_value=[])  # no cilium pods
+
+        result = step.run(None)
+
+        assert result.result_type == ResultType.FAILED
+        assert "No cilium pod found on node node1" in result.message
+
+    def test_run_restart_timeout(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        step.kube.apply = Mock()
+
+        # _find_cilium_pod succeeds
+        cilium_pod = Mock()
+        cilium_pod.metadata = Mock(name="cilium-abc")
+        cilium_pod.spec = Mock(nodeName="node1")
+        # But replacement never becomes Ready
+        not_ready_pod = Mock()
+        not_ready_pod.spec = Mock(nodeName="node1")
+        not_ready_pod.status = Mock(
+            conditions=[Mock(type="Ready", status="False")]
+        )
+
+        call_count = [0]
+        def list_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call: _find_cilium_pod
+                return [cilium_pod]
+            # Subsequent calls: _wait_for_cilium_ready
+            return [not_ready_pod]
+
+        step.kube.list = Mock(side_effect=list_side_effect)
+        step.kube.delete = Mock()
+
+        with (
+            patch("sunbeam.steps.k8s.time.monotonic", side_effect=[0.0, 301.0]),
+            patch("sunbeam.steps.k8s.time.sleep"),
+        ):
+            result = step.run(None)
+
+        assert result.result_type == ResultType.FAILED
+        assert "did not become Ready" in result.message
+```
+
+- [ ] **Step 8: Run all cilium tests**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py::TestEnsureCiliumDeviceByHostStep -v 2>&1 | tail -25
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Run full test suite and linting**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/sunbeam/steps/test_k8s.py -v 2>&1 | tail -30
+```
+
+```bash
+cd sunbeam-python && tox -e pep8 2>&1 | tail -20
+```
+
+Expected: all pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add sunbeam-python/sunbeam/steps/k8s.py sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py && git commit -m "feat: add EnsureCiliumDeviceByHostStep for per-host CiliumNodeConfig
+
+Creates a CiliumNodeConfig resource per control node, specifying
+the exact internal-space NIC. Validates nodeSelector, device, and
+hostname label to detect drift. Restarts only affected cilium pods
+and waits for readiness before proceeding."
+```
+
+---
+
+### Task 5: Integrate into command plans
+
+**Files:**
+- Modify: `sunbeam-python/sunbeam/provider/local/commands.py`
+- Modify: `sunbeam-python/sunbeam/provider/maas/commands.py`
+- Modify: `sunbeam-python/sunbeam/steps/upgrades/intra_channel.py`
+
+- [ ] **Step 1: Add import to local commands**
+
+In `sunbeam-python/sunbeam/provider/local/commands.py`, add `EnsureCiliumDeviceByHostStep` to the import from `sunbeam.steps.k8s` (around line 155-164):
+
+```python
+from sunbeam.steps.k8s import (
+    ...
+    EnsureCiliumDeviceByHostStep,
+    EnsureDefaultL2AdvertisementMutedStep,
+    ...
+)
+```
+
+- [ ] **Step 2: Add to local bootstrap plan**
+
+In `sunbeam-python/sunbeam/provider/local/commands.py`, before the `EnsureL2AdvertisementByHostStep` call (around line 312), add:
+
+```python
+            EnsureCiliumDeviceByHostStep(
+                deployment,
+                client,
+                jhelper,
+                deployment.openstack_machines_model,
+                fqdn,
+            ),
+```
+
+- [ ] **Step 3: Add to local add-node plan**
+
+In `sunbeam-python/sunbeam/provider/local/commands.py`, before the `EnsureL2AdvertisementByHostStep` call (around line 1520), add:
+
+```python
+        plan4.append(
+            EnsureCiliumDeviceByHostStep(
+                deployment,
+                client,
+                jhelper,
+                deployment.openstack_machines_model,
+                name,
+            ),
+        )
+```
+
+- [ ] **Step 4: Add to local resize plan**
+
+In `sunbeam-python/sunbeam/provider/local/commands.py`, before the `EnsureL2AdvertisementByHostStep` call (around line 1885), add:
+
+```python
+            EnsureCiliumDeviceByHostStep(
+                deployment,
+                client,
+                jhelper,
+                deployment.openstack_machines_model,
+            ),
+```
+
+- [ ] **Step 5: Add import to MAAS commands**
+
+In `sunbeam-python/sunbeam/provider/maas/commands.py`, add `EnsureCiliumDeviceByHostStep` to the import from `sunbeam.steps.k8s` (around line 160-169):
+
+```python
+from sunbeam.steps.k8s import (
+    ...
+    EnsureCiliumDeviceByHostStep,
+    EnsureDefaultL2AdvertisementMutedStep,
+    ...
+)
+```
+
+- [ ] **Step 6: Add to MAAS bootstrap plan**
+
+In `sunbeam-python/sunbeam/provider/maas/commands.py`, before the first `EnsureL2AdvertisementByHostStep` call (around line 752), add:
+
+```python
+    plan2.append(
+        EnsureCiliumDeviceByHostStep(
+            deployment,
+            client,
+            jhelper,
+            deployment.openstack_machines_model,
+        ),
+    )
+```
+
+- [ ] **Step 7: Add to MAAS remove-node plan**
+
+In `sunbeam-python/sunbeam/provider/maas/commands.py`, before the `EnsureL2AdvertisementByHostStep` calls (around line 1678), add:
+
+```python
+        EnsureCiliumDeviceByHostStep(
+            deployment,
+            client,
+            jhelper,
+            deployment.openstack_machines_model,
+        ),
+```
+
+- [ ] **Step 8: Update upgrade steps**
+
+In `sunbeam-python/sunbeam/steps/upgrades/intra_channel.py`:
+
+Update the import (around line 32-37) — remove `EnsureCiliumOnCorrectSpaceStep`, add `EnsureCiliumDeviceByHostStep`:
+
+```python
+from sunbeam.steps.k8s import (
+    DeployK8SApplicationStep,
+    EnsureCiliumDeviceByHostStep,
+    EnsureDefaultL2AdvertisementMutedStep,
+    EnsureL2AdvertisementByHostStep,
+)
+```
+
+Replace the `EnsureCiliumOnCorrectSpaceStep(...)` call in the MAAS branch (around line 459) with:
+
+```python
+                    EnsureCiliumDeviceByHostStep(
+                        self.deployment,
+                        self.client,
+                        self.jhelper,
+                        self.deployment.openstack_machines_model,
+                    ),
+```
+
+Replace the `EnsureCiliumOnCorrectSpaceStep(...)` call in the local branch (around line 508) with:
+
+```python
+                    EnsureCiliumDeviceByHostStep(
+                        self.deployment,
+                        self.client,
+                        self.jhelper,
+                        self.deployment.openstack_machines_model,
+                    ),
+```
+
+- [ ] **Step 9: Run linting**
+
+```bash
+cd sunbeam-python && tox -e pep8 2>&1 | tail -20
+```
+
+Expected: clean pass.
+
+- [ ] **Step 10: Run full test suite**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/ -v 2>&1 | tail -30
+```
+
+Expected: all pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add sunbeam-python/sunbeam/provider/local/commands.py sunbeam-python/sunbeam/provider/maas/commands.py sunbeam-python/sunbeam/steps/upgrades/intra_channel.py && git commit -m "feat: integrate EnsureCiliumDeviceByHostStep into all command plans
+
+Placed before EnsureL2AdvertisementByHostStep in local bootstrap,
+add-node, resize plans; MAAS bootstrap and remove-node plans; and
+upgrade steps (replacing EnsureCiliumOnCorrectSpaceStep)."
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd sunbeam-python && python -m pytest tests/unit/ -v 2>&1 | tail -40
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run linting and type checks**
+
+```bash
+cd sunbeam-python && tox -e pep8 2>&1 | tail -20
+```
+
+```bash
+cd sunbeam-python && tox -e mypy 2>&1 | tail -20
+```
+
+Expected: both clean.
+
+- [ ] **Step 3: Verify no stale references**
+
+```bash
+cd sunbeam-python && grep -rn "CILIUM_DEVICES_ANNOTATION\|EnsureCiliumOnCorrectSpaceStep\|_get_cluster_ips" sunbeam/ tests/ || echo "No stale references"
+```
+
+Expected: "No stale references"
+
+- [ ] **Step 4: Review the diff**
+
+```bash
+git diff --stat HEAD~5
+```
+
+Verify only the expected files are modified.

--- a/docs/agents/specs/cilium-per-host-device-config-design.md
+++ b/docs/agents/specs/cilium-per-host-device-config-design.md
@@ -1,0 +1,220 @@
+# Per-Host Cilium Device Configuration via CiliumNodeConfig
+
+## Problem
+
+The cluster-wide `k8sd/v1alpha1/cilium/devices` annotation uses generic device
+name patterns (e.g., `eth+`, `bond+`, `br-bond+`) to tell Cilium which network
+interfaces to use. Because the pattern matching is broad, Cilium binds itself to
+wrong devices.
+
+Excluding OVS bridges (`!br-ex`, `!br-int`) is insufficient: Cilium still
+matches the physical NIC that serves as the OVS uplink port inside the bridge.
+For example, `enp1s0f1` is the physnet1 OVS uplink inside `br-ex`, and it gets
+matched by the `enp+` pattern. Cilium attaches BPF programs
+(`cil_from_netdev`/`cil_to_netdev`) to that NIC in the TC ingress chain, running
+before OVS's `rx_handler`. When Cilium reprograms those BPF programs (e.g.,
+during `UpdatePolicyMaps` after a pod event), external traffic — such as VLAN
+packets destined for floating IPs — gets dropped.
+
+The exclusion-list approach is a losing game: every hardware configuration can
+have different NIC names serving as OVS uplinks, and there is no reliable pattern
+to exclude them all. A surgical approach is needed: tell Cilium exactly which
+device to use on each host, rather than trying to enumerate what to avoid.
+
+## Solution
+
+Replace the cluster-wide cilium devices annotation with per-host
+`CiliumNodeConfig` resources that specify the exact interface name for each
+control node. The interface is determined by querying juju for each machine's
+network interfaces and matching against the internal space.
+
+## Reverts
+
+Revert the following commits (newest-first):
+
+1. `f001990c` — fix: stop cilium greedy match on br+
+2. `2be63d7b` — fix: exclude well-known ovs bridges / devices
+3. `46273728` — feat: bind k8s cluster endpoint to internal space with Cilium
+   device detection
+
+This removes:
+
+- `CILIUM_DEVICES_ANNOTATION_DEFAULT` and `CILIUM_DEVICES_ANNOTATION_KEY`
+- The `cluster-annotations` cilium devices config in `_get_k8s_config_tfvars()`
+- The comma-separated validation logic for cilium devices
+- The `"cluster"` endpoint binding to `Networks.INTERNAL` in `extra_tfvars()`
+- `EnsureCiliumOnCorrectSpaceStep` class
+- The rename of `_get_management_ips` → `_get_cluster_ips` in
+  `EnsureK8SUnitsTaggedStep`
+- All references in `intra_channel.py`
+- Associated tests
+
+The cluster endpoint stays on management.
+
+## Base Class: `_PerHostK8SResourceStep`
+
+Extract the common per-host logic shared between `EnsureL2AdvertisementByHostStep`
+and the new cilium step into `_PerHostK8SResourceStep(BaseStep)` (private,
+underscore-prefixed). This deduplicates ~60-70 lines.
+
+### Provides
+
+- **Constructor**: `deployment`, `client`, `jhelper`, `model`, `network`,
+  `fqdn` (optional). Initializes `to_update: list[dict]`,
+  `to_delete: list[dict]`, `_ifnames: dict[str, str]` cache.
+- **`_get_interface(node)`**: Looks up machine interfaces via
+  `jhelper.get_machine_interfaces()`, matches by the step's `network` space.
+  Caches results in `_ifnames`. Raises a step-specific error (defined by
+  subclass) if no matching interface found.
+- **`is_skip(context)`**: Control node lookup (single node if `fqdn` provided,
+  all control nodes otherwise), kube client creation, calls abstract
+  `_get_outdated_resources(nodes, kube)`, populates `to_update`/`to_delete`,
+  returns SKIPPED if empty.
+
+### Subclasses must implement
+
+- **`_get_outdated_resources(nodes, kube)`** → `(outdated, deleted)` lists
+- **`run(context)`** — resource-specific apply/delete logic
+
+### Refactor `EnsureL2AdvertisementByHostStep`
+
+Refactor to inherit from `_PerHostK8SResourceStep` instead of `BaseStep`.
+Moves `_get_interface`, control node lookup, and kube client creation into the
+base. L2-specific logic (`_ensure_l2_advertisement`, `_labels`, pool handling,
+tenacity retry on webhook failures) stays in the subclass.
+
+## New Step: `EnsureCiliumDeviceByHostStep`
+
+Inherits from `_PerHostK8SResourceStep` with
+`network=Networks.INTERNAL`.
+
+### `_get_outdated_resources(nodes, kube)`
+
+Lists existing `CiliumNodeConfig` resources labeled with
+`app.kubernetes.io/managed-by: <deployment>`. For each, checks:
+
+- Hostname label matches a known node
+- `spec.nodeSelector.matchLabels` contains exactly
+  `sunbeam/hostname: <hostname>` (guards against over-broad or empty
+  selectors that could silently misconfigure other nodes)
+- `spec.defaults.devices` matches the current internal-space interface for that
+  node
+
+A resource that has the right metadata label and device but a wrong or missing
+`nodeSelector` is considered outdated and will be re-applied.
+
+Returns `(outdated, deleted)` lists.
+
+### `run(context)`
+
+- For each node in `to_update`: look up interface, apply `CiliumNodeConfig` via
+  lightkube, then delete the cilium pod on that node to trigger restart
+- For each node in `to_delete`: delete the `CiliumNodeConfig` resource and
+  delete the cilium pod
+- Returns COMPLETED or FAILED
+
+### CiliumNodeConfig Resource
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNodeConfig
+metadata:
+  name: cilium-devices-<hostname>
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/managed-by: <deployment-name>
+    kubernetes.io/hostname: <hostname>
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: <hostname>
+  defaults:
+    devices: "<interface-name>"
+```
+
+Uses `cilium.io/v2` (Canonical K8s 1.32 LTS ships Cilium 1.17.1; `v2alpha1`
+is deprecated since Cilium 1.17).
+
+### Cilium Pod Restart
+
+After applying a config change for a node, restart the cilium agent on that node:
+
+1. **Find** the cilium pod on the affected node: filter by `spec.nodeName` in
+   `kube-system` namespace, label `k8s-app=cilium`. If no pod is found, return
+   FAILED (config was applied but cannot take effect without a running agent).
+2. **Delete** the pod. The DaemonSet controller recreates it with the new
+   config.
+3. **Wait for readiness**: poll until a new cilium pod exists on that node and
+   reports Ready (`status.conditions` has `type=Ready, status=True`). Use a
+   timeout consistent with the existing `_ROLLOUT_TIMEOUT` (300s) with 5-second
+   polling intervals. If the timeout expires, return FAILED.
+
+Only pods on modified nodes are restarted. The readiness wait ensures the
+datapath is operational before the plan proceeds to MetalLB/L2 steps.
+
+## Lightkube Generic Resource
+
+Define a lightkube generic resource for `CiliumNodeConfig` via a `K8SHelper`
+class method (same pattern as `get_lightkube_l2_advertisement_resource()`),
+using `lightkube.generic_resource.create_namespaced_resource` with:
+
+- group: `cilium.io`
+- version: `v2`
+- kind: `CiliumNodeConfig`
+- plural: `ciliumnodeconfigs`
+
+## Integration into Command Plans
+
+`EnsureCiliumDeviceByHostStep` is placed **before**
+`EnsureL2AdvertisementByHostStep` in every plan (cilium must be correctly
+configured before metallb).
+
+### MAAS commands (`sunbeam-python/sunbeam/provider/maas/commands.py`)
+
+- Bootstrap plan — before `EnsureL2AdvertisementByHostStep`, all control nodes
+- Remove-node plan — all control nodes (cleans up departed node's config)
+
+### Local commands (`sunbeam-python/sunbeam/provider/local/commands.py`)
+
+- Bootstrap plan — same positioning
+- Add-node — with `fqdn`
+- Resize plan — with `fqdn`
+
+### Upgrade steps (`sunbeam-python/sunbeam/steps/upgrades/intra_channel.py`)
+
+- Replaces `EnsureCiliumOnCorrectSpaceStep` references
+- Operates on all control nodes (no `fqdn`)
+
+## Tests
+
+Existing `TestEnsureL2AdvertisementByHostStep` tests must keep passing after the
+refactor to `_PerHostK8SResourceStep`. No new tests needed for the base class
+itself — it is covered through its concrete subclasses.
+
+`TestEnsureCiliumDeviceByHostStep` in
+`tests/unit/sunbeam/steps/test_k8s.py`:
+
+- `test_is_skip_no_changes` — all configs up to date, returns SKIPPED
+- `test_is_skip_outdated_device` — device mismatch, returns COMPLETED
+- `test_is_skip_missing_config` — node has no config yet, returns COMPLETED
+- `test_is_skip_deleted_node` — config exists for removed node, returns
+  COMPLETED
+- `test_is_skip_single_node_fqdn` — fqdn mode operates on single node only
+- `test_is_skip_wrong_node_selector` — config has correct label/device but
+  wrong or empty `nodeSelector`, returns COMPLETED (outdated)
+- `test_run_creates_config` — applies CiliumNodeConfig, deletes cilium pod,
+  waits for Ready replacement
+- `test_run_updates_config` — updates existing config, restarts affected pod
+  only
+- `test_run_deletes_stale_config` — removes config for departed node, deletes
+  pod
+- `test_run_api_error` — lightkube API failure returns FAILED
+- `test_run_no_interface_found` — no interface in internal space, returns FAILED
+- `test_run_cilium_pod_not_found` — no cilium pod on target node, returns
+  FAILED
+- `test_run_restart_timeout` — replacement pod never becomes Ready, returns
+  FAILED
+
+Mocking: `jhelper.get_machine_interfaces`, `client.cluster.list_nodes_by_role`,
+lightkube client operations — same fixtures as
+`TestEnsureL2AdvertisementByHostStep`.

--- a/sunbeam-python/sunbeam/core/k8s.py
+++ b/sunbeam-python/sunbeam/core/k8s.py
@@ -132,6 +132,19 @@ class K8SHelper:
         )
 
     @classmethod
+    def get_lightkube_cilium_node_config_resource(
+        cls,
+    ) -> Type["l_generic_resource.GenericNamespacedResource"]:
+        """Return lightkube generic resource of type CiliumNodeConfig."""
+        return l_generic_resource.create_namespaced_resource(
+            "cilium.io",
+            "v2",
+            "CiliumNodeConfig",
+            "ciliumnodeconfigs",
+            verbs=["delete", "get", "list", "patch", "post", "put"],
+        )
+
+    @classmethod
     def get_loadbalancer_namespace(cls) -> str:
         """Return namespace for loadbalancer."""
         return "metallb-system"

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -155,6 +155,7 @@ from sunbeam.steps.k8s import (
     CordonK8SUnitStep,
     DeployK8SApplicationStep,
     DrainK8SUnitStep,
+    EnsureCiliumDeviceByHostStep,
     EnsureDefaultL2AdvertisementMutedStep,
     EnsureK8SUnitsTaggedStep,
     EnsureL2AdvertisementByHostStep,
@@ -303,6 +304,13 @@ def get_k8s_plans(
                 deployment, client, jhelper, deployment.openstack_machines_model
             ),
             EnsureK8SUnitsTaggedStep(
+                deployment,
+                client,
+                jhelper,
+                deployment.openstack_machines_model,
+                fqdn,
+            ),
+            EnsureCiliumDeviceByHostStep(
                 deployment,
                 client,
                 jhelper,
@@ -1517,6 +1525,15 @@ def join(  # noqa: C901
         )
         plan4.append(EnsureDefaultL2AdvertisementMutedStep(deployment, client, jhelper))
         plan4.append(
+            EnsureCiliumDeviceByHostStep(
+                deployment,
+                client,
+                jhelper,
+                deployment.openstack_machines_model,
+                name,
+            ),
+        )
+        plan4.append(
             EnsureL2AdvertisementByHostStep(
                 deployment,
                 client,
@@ -1881,6 +1898,12 @@ def remove(ctx: click.Context, name: str, force: bool, show_hints: bool) -> None
             ),
             RemoveK8SUnitsStep(
                 client, name, jhelper, deployment.openstack_machines_model
+            ),
+            EnsureCiliumDeviceByHostStep(
+                deployment,
+                client,
+                jhelper,
+                deployment.openstack_machines_model,
             ),
             EnsureL2AdvertisementByHostStep(
                 deployment,

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -160,6 +160,7 @@ from sunbeam.steps.k8s import (
     CordonK8SUnitStep,
     DestroyK8SApplicationStep,
     DrainK8SUnitStep,
+    EnsureCiliumDeviceByHostStep,
     EnsureDefaultL2AdvertisementMutedStep,
     EnsureK8SUnitsTaggedStep,
     EnsureL2AdvertisementByHostStep,
@@ -748,6 +749,14 @@ def deploy(
     )
     plan2.append(EnsureDefaultL2AdvertisementMutedStep(deployment, client, jhelper))
     plan2.append(MaasCreateLoadBalancerIPPoolsStep(deployment, client, maas_client))
+    plan2.append(
+        EnsureCiliumDeviceByHostStep(
+            deployment,
+            client,
+            jhelper,
+            deployment.openstack_machines_model,
+        ),
+    )
     plan2.append(
         EnsureL2AdvertisementByHostStep(
             deployment,
@@ -1675,6 +1684,12 @@ def remove_node(ctx: click.Context, name: str, force: bool, show_hints: bool) ->
             client, name, jhelper, deployment.openstack_machines_model, remove_pvc=True
         ),
         RemoveK8SUnitsStep(client, name, jhelper, deployment.openstack_machines_model),
+        EnsureCiliumDeviceByHostStep(
+            deployment,
+            client,
+            jhelper,
+            deployment.openstack_machines_model,
+        ),
         EnsureL2AdvertisementByHostStep(
             deployment,
             client,

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import copy
-import datetime
 import ipaddress
 import json
 import logging
 import subprocess
-import time
 import typing
 
 import jubilant
@@ -103,22 +101,6 @@ K8S_DESTROY_TIMEOUT = 900
 K8S_UNIT_TIMEOUT = 1800  # 30 minutes, adding / removing units can take a long time
 K8S_ENABLE_ADDONS_TIMEOUT = 300  # 5 minutes
 K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
-CILIUM_DEVICES_ANNOTATION_KEY = "k8sd/v1alpha1/cilium/devices"
-CILIUM_DEVICES_ANNOTATION_DEFAULT = ",".join(
-    (
-        "!br-ex",
-        "!br-int",
-        "!br-phys+",
-        "br-bond+",
-        "bond+",
-        "eth+",
-        "eno+",
-        "ens+",
-        "enp+",
-        "em+",
-        "vlan+",
-    )
-)
 
 COREDNS_HPA = {
     "enabled": True,
@@ -281,16 +263,6 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
         """Return application timeout."""
         return K8S_APP_TIMEOUT
 
-    def is_skip(self, context: StepContext) -> Result:
-        """Determines if the step should be skipped or not."""
-        try:
-            # note(gboutry): validate in the is_skip phase to avoid
-            # failing in the middle of the plan.
-            self._get_k8s_config_tfvars()
-        except SunbeamException as e:
-            return Result(ResultType.FAILED, str(e))
-        return Result(ResultType.COMPLETED)
-
     def _get_loadbalancer_range(self) -> str | None:
         """Return loadbalancer range stored in cluster db."""
         variables = load_answers(self.client, self._ADDONS_CONFIG)
@@ -300,28 +272,11 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
         config_tfvars: dict[str, bool | str | None] = {
             "load-balancer-enabled": True,
             "load-balancer-l2-mode": True,
-            "cluster-annotations": (
-                CILIUM_DEVICES_ANNOTATION_KEY + "=" + CILIUM_DEVICES_ANNOTATION_DEFAULT
-            ),
         }
 
         charm_manifest = self.manifest.core.software.charms.get("k8s")
         if charm_manifest and charm_manifest.config:
             config_tfvars.update(charm_manifest.config)
-
-        cluster_annotations = str(config_tfvars.get("cluster-annotations", ""))
-        prefix = CILIUM_DEVICES_ANNOTATION_KEY + "="
-        if prefix in cluster_annotations:
-            after_key = cluster_annotations.split(prefix, 1)[1]
-            tokens = after_key.split()
-            # First token is the devices value; remaining tokens without "="
-            # are stray space-separated device values
-            stray = [t for t in tokens[1:] if "=" not in t]
-            if stray:
-                raise SunbeamException(
-                    "Cilium devices annotation value must be comma-separated,"
-                    f" not space-separated: {prefix}{after_key.strip()}"
-                )
 
         lb_range = self._get_loadbalancer_range()
         if lb_range:
@@ -340,10 +295,6 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
         tfvars = {
             "endpoint_bindings": [
                 {"space": self.deployment.get_space(Networks.MANAGEMENT)},
-                {
-                    "endpoint": "cluster",
-                    "space": self.deployment.get_space(Networks.INTERNAL),
-                },
             ],
             "k8s_config": self._get_k8s_config_tfvars(),
         }
@@ -373,12 +324,12 @@ def _get_machines_space_ips(
 class EnsureK8SUnitsTaggedStep(BaseStep):
     """Ensure K8S units get properly tagged.
 
-    This step ensures that every k8s node is tagged with the
+    This step ensures that evey k8s nodes is tagged with the
     HOSTNAME_LABEL, to ensure sunbeam can query the correct nodes
     afterwards.
-    Match is done on the IP addresses from the space configured as
-    Networks.INTERNAL. Node IP in k8s is guaranteed by the cluster
-    space binding.
+    Match is done on management ip address. Node IP in k8s is guaranteed by
+    the cluster space binding, which is always bound to the management
+    space.
     """
 
     def __init__(
@@ -399,16 +350,18 @@ class EnsureK8SUnitsTaggedStep(BaseStep):
         self.fqdn = fqdn
         self.to_update: dict[str, str] = {}
 
-    def _get_cluster_ips(
+    def _get_management_ips(
         self, juju_machine: "jubilant.statustypes.MachineStatus"
     ) -> list[str]:
-        cluster_space = self.deployment.get_space(Networks.INTERNAL)
-        cluster_networks = self.jhelper.get_space_networks(self.model, cluster_space)
+        management_space = self.deployment.get_space(Networks.MANAGEMENT)
+        management_networks = self.jhelper.get_space_networks(
+            self.model, management_space
+        )
 
         return _get_machines_space_ips(
             juju_machine.network_interfaces,
-            cluster_space,
-            cluster_networks,
+            management_space,
+            management_networks,
         )
 
     @tenacity.retry(
@@ -484,18 +437,18 @@ class EnsureK8SUnitsTaggedStep(BaseStep):
                 raise SunbeamException(
                     f"{sunbeam_name!r} not found in Juju, expected id {machine_id!r}"
                 )
-            cluster_ips = self._get_cluster_ips(juju_machine)
-            if not cluster_ips:
-                LOG.debug("No cluster IPs found for machine %s", machine_id)
-                raise SunbeamException(f"{sunbeam_name!r} has no cluster IPs")
+            management_ips = self._get_management_ips(juju_machine)
+            if not management_ips:
+                LOG.debug("No management IPs found for machine %s", machine_id)
+                raise SunbeamException(f"{sunbeam_name!r} has no management IPs")
 
             try:
-                k8s_node = self._find_matching_k8s_node(sunbeam_name, cluster_ips)
+                k8s_node = self._find_matching_k8s_node(sunbeam_name, management_ips)
             except ValueError:
                 LOG.debug(
-                    "No matching k8s node found for %s, cluster IPs %s",
+                    "No matching k8s node found for %s, management IPs %s",
                     sunbeam_name,
-                    cluster_ips,
+                    management_ips,
                 )
                 raise SunbeamException(f"{sunbeam_name} has no matching k8s node")
             except K8SError as e:
@@ -584,214 +537,6 @@ class EnsureK8SUnitsTaggedStep(BaseStep):
                 )
 
         return Result(ResultType.COMPLETED)
-
-
-class EnsureCiliumOnCorrectSpaceStep(BaseStep):
-    """Ensure Cilium DaemonSet is bound to the correct (internal) space.
-
-    After a cluster refresh that changes the k8s 'cluster' endpoint binding from
-    the management space to the internal space, k8sd reconfigures the node's
-    InternalIP to the internal-space address. However, the Cilium DaemonSet pods
-    do not automatically restart and remain attached to the old network interface.
-
-    This step detects that mismatch by comparing each k8s node's live InternalIP
-    against the subnets of the configured internal space. If any node's InternalIP
-    falls outside those subnets, the step triggers a rolling restart of the Cilium
-    DaemonSet (equivalent to ``kubectl rollout restart ds/cilium -n kube-system``).
-
-    The step is a no-op when management and internal spaces are the same, or when
-    all nodes are already on the correct space.
-    """
-
-    _CILIUM_DAEMONSET = "cilium"
-    _CILIUM_NAMESPACE = "kube-system"
-    _ROLLOUT_TIMEOUT = 300  # seconds
-
-    def __init__(
-        self,
-        deployment: Deployment,
-        client: Client,
-        jhelper: JujuHelper,
-        model: str,
-    ):
-        super().__init__(
-            "Ensure Cilium on correct space",
-            "Checking Cilium is bound to the correct network space",
-        )
-        self.deployment = deployment
-        self.client = client
-        self.jhelper = jhelper
-        self.model = model
-        self.needs_restart = False
-
-    def _get_internal_space_networks(
-        self,
-    ) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
-        internal_space = self.deployment.get_space(Networks.INTERNAL)
-        return self.jhelper.get_space_networks(self.model, internal_space)
-
-    def _node_internal_ip_in_space(
-        self,
-        node: "core_v1.Node",
-        internal_networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
-    ) -> bool:
-        """Return True if any node InternalIP falls within the internal space.
-
-        Evaluates all InternalIP entries to support dual-stack nodes.
-        """
-        if node.status is None or node.status.addresses is None:
-            return True  # can't determine; skip this node
-        found_internal_ip = False
-        for address in node.status.addresses:
-            if address.type == "InternalIP":
-                found_internal_ip = True
-                try:
-                    ip = ipaddress.ip_address(address.address)
-                except ValueError:
-                    LOG.debug("Invalid InternalIP %s on node", address.address)
-                    continue
-                if any(ip in net for net in internal_networks):
-                    return True
-        if not found_internal_ip:
-            return True  # no InternalIP found; skip this node
-        return False
-
-    def is_skip(self, context: StepContext) -> Result:
-        """Determines if the step should be skipped or not.
-
-        :return: ResultType.SKIPPED if Cilium is already on the correct space
-                 or management and internal spaces are the same,
-                 ResultType.COMPLETED if Cilium needs a restart,
-                 ResultType.FAILED on error.
-        """
-        # Reset restart flag to ensure this check is idempotent across calls.
-        self.needs_restart = False
-        management_space = self.deployment.get_space(Networks.MANAGEMENT)
-        internal_space = self.deployment.get_space(Networks.INTERNAL)
-        if management_space == internal_space:
-            LOG.debug(
-                "Management and internal spaces are identical (%s), skipping",
-                internal_space,
-            )
-            return Result(ResultType.SKIPPED)
-
-        try:
-            self.kube = get_kube_client(self.client)
-        except KubeClientError as e:
-            LOG.debug("Failed to create k8s client", exc_info=True)
-            return Result(ResultType.FAILED, str(e))
-
-        try:
-            internal_networks = self._get_internal_space_networks()
-        except JujuException as e:
-            LOG.debug("Failed to get internal space networks", exc_info=True)
-            return Result(ResultType.FAILED, str(e))
-
-        try:
-            k8s_nodes = list_nodes(
-                self.kube, labels={DEPLOYMENT_LABEL: self.deployment.name}
-            )
-        except K8SError as e:
-            LOG.debug("Failed to list k8s nodes", exc_info=True)
-            return Result(ResultType.FAILED, str(e))
-
-        for node in k8s_nodes:
-            node_name = node.metadata.name if node.metadata else "<unknown>"
-            if not self._node_internal_ip_in_space(node, internal_networks):
-                LOG.debug(
-                    "Node %s has InternalIP outside internal space — "
-                    "Cilium restart required",
-                    node_name,
-                )
-                self.needs_restart = True
-                break
-
-        if not self.needs_restart:
-            LOG.debug("All k8s nodes have InternalIP in the internal space, skipping")
-            return Result(ResultType.SKIPPED)
-
-        return Result(ResultType.COMPLETED)
-
-    def run(self, context: StepContext) -> Result:
-        """Restart the Cilium DaemonSet so it rebinds to the correct interface."""
-        restart_annotation = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
-        patch = {
-            "spec": {
-                "template": {
-                    "metadata": {
-                        "annotations": {
-                            "kubectl.kubernetes.io/restartedAt": restart_annotation,
-                        }
-                    }
-                }
-            }
-        }
-        LOG.debug("Patching Cilium DaemonSet with restartedAt=%s", restart_annotation)
-        try:
-            self.kube.patch(
-                apps_v1.DaemonSet,
-                self._CILIUM_DAEMONSET,
-                patch,
-                namespace=self._CILIUM_NAMESPACE,
-            )
-        except l_exceptions.ApiError as e:
-            LOG.debug("Failed to patch Cilium DaemonSet", exc_info=True)
-            return Result(
-                ResultType.FAILED,
-                f"Failed to restart Cilium DaemonSet: {e}",
-            )
-
-        LOG.debug("Waiting for Cilium DaemonSet rollout to complete")
-        try:
-            self._wait_for_rollout()
-        except SunbeamException as e:
-            return Result(ResultType.FAILED, str(e))
-
-        return Result(ResultType.COMPLETED)
-
-    def _wait_for_rollout(self) -> None:
-        """Wait until the Cilium DaemonSet rollout is complete.
-
-        Polls the DaemonSet status until both updatedNumberScheduled and
-        numberAvailable equal desiredNumberScheduled (for a non-zero desired
-        count), or until _ROLLOUT_TIMEOUT seconds elapse.
-        """
-        deadline = time.monotonic() + self._ROLLOUT_TIMEOUT
-        while time.monotonic() < deadline:
-            try:
-                ds = self.kube.get(
-                    apps_v1.DaemonSet,
-                    self._CILIUM_DAEMONSET,
-                    namespace=self._CILIUM_NAMESPACE,
-                )
-            except l_exceptions.ApiError as e:
-                raise SunbeamException(
-                    f"Failed to get Cilium DaemonSet during rollout wait: {e}"
-                ) from e
-
-            ds_status = ds.status
-            if ds_status is None:
-                time.sleep(5)
-                continue
-
-            desired = ds_status.desiredNumberScheduled or 0
-            updated = ds_status.updatedNumberScheduled or 0
-            available = ds_status.numberAvailable or 0
-            LOG.debug(
-                "Cilium rollout: desired=%d updated=%d available=%d",
-                desired,
-                updated,
-                available,
-            )
-            if desired > 0 and updated == desired and available == desired:
-                LOG.debug("Cilium DaemonSet rollout complete")
-                return
-
-            time.sleep(5)
-
-        raise SunbeamException(
-            f"Cilium DaemonSet rollout did not complete within {self._ROLLOUT_TIMEOUT}s"
-        )
 
 
 class RemoveK8SUnitsStep(RemoveMachineUnitsStep):

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -6,6 +6,7 @@ import ipaddress
 import json
 import logging
 import subprocess
+import time
 import typing
 
 import jubilant
@@ -324,7 +325,7 @@ def _get_machines_space_ips(
 class EnsureK8SUnitsTaggedStep(BaseStep):
     """Ensure K8S units get properly tagged.
 
-    This step ensures that evey k8s nodes is tagged with the
+    This step ensures that every k8s node is tagged with the
     HOSTNAME_LABEL, to ensure sunbeam can query the correct nodes
     afterwards.
     Match is done on management ip address. Node IP in k8s is guaranteed by
@@ -1248,13 +1249,418 @@ class DestroyK8SApplicationStep(DestroyMachineApplicationStep):
         return K8S_DESTROY_TIMEOUT
 
 
-class EnsureL2AdvertisementByHostStep(BaseStep):
+class _PerHostK8SResourceStep(BaseStep):
+    """Base class for steps that manage per-host k8s resources.
+
+    Provides common logic for looking up control nodes, creating a kube client,
+    finding the juju-space interface for each node, and determining which nodes
+    have outdated resources.
+
+    Subclasses must implement:
+      - _get_outdated_resources(nodes, kube) -> (outdated, deleted)
+      - run(context) -> Result
+    """
+
+    class _InterfaceError(SunbeamException):
+        pass
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        deployment: Deployment,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        network: Networks,
+        kube_namespace: str | None = None,
+        fqdn: str | None = None,
+    ):
+        super().__init__(name, description)
+        self.deployment = deployment
+        self.client = client
+        self.jhelper = jhelper
+        self.model = model
+        self.network = network
+        self.kube_namespace = kube_namespace
+        self.fqdn = fqdn
+        self.to_update: list[dict] = []
+        self.to_delete: list[dict] = []
+        self._ifnames: dict[str, str] = {}
+
+    def _get_interface(self, node: dict) -> str:
+        """Get the network interface for the node in the configured space."""
+        name = node["name"]
+        if name in self._ifnames:
+            return self._ifnames[name]
+        machine_id = str(node["machineid"])
+        machine_interfaces = self.jhelper.get_machine_interfaces(self.model, machine_id)
+        LOG.debug("Machine %r interfaces: %r", machine_id, machine_interfaces)
+        network_space = self.deployment.get_space(self.network)
+        for ifname, iface in machine_interfaces.items():
+            if (spaces := iface.space) and network_space in spaces.split():
+                self._ifnames[name] = ifname
+                return ifname
+        raise self._InterfaceError(
+            f"Node {node['name']} has no interface in {self.network.name} space"
+        )
+
+    def _get_outdated_resources(
+        self, nodes: list[dict], kube: "l_client.Client"
+    ) -> tuple[list[str], list[str]]:
+        """Return (outdated, deleted) node name lists.
+
+        Must be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    def is_skip(self, context: StepContext) -> Result:
+        """Determines if the step should be skipped or not."""
+        self.to_update = []
+        self.to_delete = []
+        control = Role.CONTROL.name.lower()
+        region_controller = Role.REGION_CONTROLLER.name.lower()
+        if self.fqdn:
+            node = self.client.cluster.get_node_info(self.fqdn)
+            node_roles = node.get("role", [])
+            if control not in node_roles and region_controller not in node_roles:
+                return Result(ResultType.FAILED, f"{self.fqdn} is not a control node")
+            self.control_nodes = [node]
+        else:
+            self.control_nodes = self.client.cluster.list_nodes_by_role(control)
+
+        try:
+            self.kube = get_kube_client(self.client, self.kube_namespace)
+        except KubeClientError as e:
+            LOG.debug("Failed to create k8s client", exc_info=True)
+            return Result(ResultType.FAILED, str(e))
+
+        try:
+            outdated, deleted = self._get_outdated_resources(
+                self.control_nodes, self.kube
+            )
+        except (l_exceptions.ApiError, self._InterfaceError) as e:
+            LOG.debug("Failed to get outdated resources", exc_info=True)
+            return Result(ResultType.FAILED, str(e))
+
+        if self.fqdn:
+            # Single-node mode (join/bootstrap): only create/update for the
+            # target node.  Defer deletion of stale resources to full
+            # reconciliation (refresh, where fqdn is None).
+            deleted = []
+
+        if not (outdated or deleted):
+            LOG.debug("No resources to update")
+            return Result(ResultType.SKIPPED)
+
+        for node in self.control_nodes:
+            if node["name"] in outdated:
+                self.to_update.append(node)
+
+        # Deleted hostnames correspond to nodes no longer in control_nodes,
+        # so we build synthetic entries with just the name for cleanup.
+        for hostname in deleted:
+            self.to_delete.append({"name": hostname})
+
+        return Result(ResultType.COMPLETED)
+
+
+class EnsureCiliumDeviceByHostStep(_PerHostK8SResourceStep):
+    """Ensure each control node has a CiliumNodeConfig for its internal-space device."""
+
+    _CILIUM_NAMESPACE = "kube-system"
+    _RESTART_TIMEOUT = 300
+    _RESTART_POLL_INTERVAL = 5
+    _RESTART_PENDING_ANNOTATION = "sunbeam/restart-pending"
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        jhelper: JujuHelper,
+        model: str,
+        fqdn: str | None = None,
+    ):
+        super().__init__(
+            "Ensure Cilium device config",
+            "Ensuring Cilium device config per host",
+            deployment,
+            client,
+            jhelper,
+            model,
+            Networks.INTERNAL,
+            kube_namespace=self._CILIUM_NAMESPACE,
+            fqdn=fqdn,
+        )
+        self.cilium_node_config_resource = (
+            K8SHelper.get_lightkube_cilium_node_config_resource()
+        )
+
+    def _cilium_node_config_name(self, hostname: str) -> str:
+        return f"cilium-devices-{hostname}"
+
+    def _labels(self, hostname: str) -> dict[str, str]:
+        return {
+            "app.kubernetes.io/managed-by": self.deployment.name,
+            HOSTNAME_LABEL: hostname,
+        }
+
+    def _get_outdated_resources(
+        self, nodes: list[dict], kube: "l_client.Client"
+    ) -> tuple[list[str], list[str]]:
+        node_names = {node["name"] for node in nodes}
+        outdated: list[str] = [node["name"] for node in nodes]
+        deleted: list[str] = []
+
+        configs = kube.list(
+            self.cilium_node_config_resource,
+            namespace=self._CILIUM_NAMESPACE,
+            labels={"app.kubernetes.io/managed-by": self.deployment.name},
+        )
+
+        for config in configs:
+            if config.metadata is None or config.metadata.labels is None:
+                LOG.debug("CiliumNodeConfig has no metadata or labels")
+                continue
+            hostname = config.metadata.labels.get(HOSTNAME_LABEL)
+            if hostname is None:
+                LOG.debug(
+                    "CiliumNodeConfig %s has no hostname label",
+                    config.metadata.name,
+                )
+                continue
+            if config.spec is None:
+                LOG.debug("CiliumNodeConfig %r has no spec", hostname)
+                continue
+            if hostname not in node_names:
+                LOG.debug(
+                    "CiliumNodeConfig %s has no matching node",
+                    config.metadata.name,
+                )
+                deleted.append(hostname)
+                continue
+
+            # Validate nodeSelector
+            node_selector = config.spec.get("nodeSelector", {})
+            match_labels = node_selector.get("matchLabels", {})
+            if match_labels.get(HOSTNAME_LABEL) != hostname:
+                LOG.debug(
+                    "CiliumNodeConfig %s has wrong nodeSelector",
+                    config.metadata.name,
+                )
+                continue
+
+            # Validate device
+            defaults = config.spec.get("defaults", {})
+            interface = None
+            for node in nodes:
+                if node["name"] == hostname:
+                    interface = self._get_interface(node)
+            if not interface:
+                LOG.debug(
+                    "CiliumNodeConfig %s: no interface for node",
+                    config.metadata.name,
+                )
+                continue
+            if defaults.get("devices") != interface:
+                LOG.debug(
+                    "CiliumNodeConfig %s has wrong device (got %s, want %s)",
+                    config.metadata.name,
+                    defaults.get("devices"),
+                    interface,
+                )
+                continue
+
+            # Check if a previous restart failed and needs retry
+            annotations = (
+                config.metadata.annotations if config.metadata.annotations else {}
+            )
+            if annotations.get(self._RESTART_PENDING_ANNOTATION) == "true":
+                LOG.debug(
+                    "CiliumNodeConfig %s has pending restart",
+                    config.metadata.name,
+                )
+                continue
+
+            outdated.remove(hostname)
+        return outdated, deleted
+
+    def _find_cilium_pod(self, node_name: str) -> "core_v1.Pod":
+        pods = list(
+            self.kube.list(
+                core_v1.Pod,
+                namespace=self._CILIUM_NAMESPACE,
+                labels={"k8s-app": "cilium"},
+            )
+        )
+        for pod in pods:
+            if pod.spec and pod.spec.nodeName == node_name:
+                return pod
+        raise SunbeamException(f"No cilium pod found on node {node_name}")
+
+    def _wait_for_cilium_ready(self, node_name: str, deleted_pod_name: str) -> None:
+        """Wait until a NEW Ready cilium pod exists on the given node.
+
+        Skips pods matching ``deleted_pod_name`` so the terminating pod
+        cannot satisfy the readiness check.
+        """
+        deadline = time.monotonic() + self._RESTART_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                pods = list(
+                    self.kube.list(
+                        core_v1.Pod,
+                        namespace=self._CILIUM_NAMESPACE,
+                        labels={"k8s-app": "cilium"},
+                    )
+                )
+            except l_exceptions.ApiError as e:
+                raise SunbeamException(
+                    f"Failed to list cilium pods during restart wait: {e}"
+                ) from e
+
+            for pod in pods:
+                if pod.spec and pod.spec.nodeName == node_name:
+                    pod_name = (
+                        pod.metadata.name
+                        if pod.metadata and pod.metadata.name
+                        else None
+                    )
+                    if pod_name == deleted_pod_name:
+                        continue  # skip the terminating pod
+                    if pod.status and pod.status.conditions:
+                        for condition in pod.status.conditions:
+                            if condition.type == "Ready" and condition.status == "True":
+                                LOG.debug(
+                                    "New cilium pod %s on %s is Ready",
+                                    pod_name,
+                                    node_name,
+                                )
+                                return
+            LOG.debug("Waiting for cilium pod on %s to be Ready", node_name)
+            time.sleep(self._RESTART_POLL_INTERVAL)
+
+        raise SunbeamException(
+            f"Cilium pod on {node_name} did not become Ready "
+            f"within {self._RESTART_TIMEOUT}s"
+        )
+
+    def _restart_cilium_on_node(self, node_name: str) -> None:
+        pod = self._find_cilium_pod(node_name)
+        pod_name = (
+            pod.metadata.name if pod.metadata and pod.metadata.name else "unknown"
+        )
+        LOG.debug("Deleting cilium pod %s on node %s", pod_name, node_name)
+        self.kube.delete(core_v1.Pod, pod_name, namespace=self._CILIUM_NAMESPACE)
+        self._wait_for_cilium_ready(node_name, deleted_pod_name=pod_name)
+
+    def run(self, context: StepContext) -> Result:
+        """Apply or delete CiliumNodeConfig resources and restart cilium pods."""
+        for node in self.to_update:
+            name = node["name"]
+            try:
+                interface = self._get_interface(node)
+            except MachineNotFoundException:
+                LOG.debug(
+                    "Failed to get machine for CiliumNodeConfig on %s",
+                    name,
+                    exc_info=True,
+                )
+                return Result(
+                    ResultType.FAILED,
+                    f"Machine not found for node {name}",
+                )
+
+            try:
+                self.kube.apply(
+                    self.cilium_node_config_resource(
+                        metadata=meta_v1.ObjectMeta(
+                            name=self._cilium_node_config_name(name),
+                            labels=self._labels(name),
+                            annotations={
+                                self._RESTART_PENDING_ANNOTATION: "true",
+                            },
+                        ),
+                        spec={
+                            "nodeSelector": {
+                                "matchLabels": {
+                                    HOSTNAME_LABEL: name,
+                                },
+                            },
+                            "defaults": {
+                                "devices": interface,
+                            },
+                        },
+                    ),
+                    field_manager=self.deployment.name,
+                    force=True,
+                )
+            except l_exceptions.ApiError:
+                LOG.debug("Failed to apply CiliumNodeConfig", exc_info=True)
+                return Result(
+                    ResultType.FAILED,
+                    f"Failed to apply CiliumNodeConfig for {name}",
+                )
+
+            try:
+                self._restart_cilium_on_node(name)
+            except SunbeamException as e:
+                return Result(ResultType.FAILED, str(e))
+
+            # Clear restart-pending after successful restart
+            try:
+                self.kube.patch(
+                    self.cilium_node_config_resource,
+                    self._cilium_node_config_name(name),
+                    {
+                        "metadata": {
+                            "annotations": {
+                                self._RESTART_PENDING_ANNOTATION: "false",
+                            }
+                        }
+                    },
+                    namespace=self._CILIUM_NAMESPACE,
+                )
+            except l_exceptions.ApiError:
+                LOG.debug(
+                    "Failed to clear restart-pending annotation for %s",
+                    name,
+                    exc_info=True,
+                )
+
+        for node in self.to_delete:
+            name = node["name"]
+            try:
+                self.kube.delete(
+                    self.cilium_node_config_resource,
+                    self._cilium_node_config_name(name),
+                    namespace=self._CILIUM_NAMESPACE,
+                )
+            except l_exceptions.ApiError:
+                LOG.debug(
+                    "Failed to delete CiliumNodeConfig for %s",
+                    name,
+                    exc_info=True,
+                )
+                continue
+
+            try:
+                self._restart_cilium_on_node(name)
+            except SunbeamException:
+                LOG.debug(
+                    "Failed to restart cilium on %s after config deletion",
+                    name,
+                    exc_info=True,
+                )
+                continue
+
+        return Result(ResultType.COMPLETED)
+
+
+class EnsureL2AdvertisementByHostStep(_PerHostK8SResourceStep):
     """Ensure IP Pool is advertised by L2Advertisement resources."""
 
     _APPLICATION = APPLICATION
-
-    class _L2AdvertisementError(SunbeamException):
-        pass
 
     def __init__(
         self,
@@ -1266,21 +1672,22 @@ class EnsureL2AdvertisementByHostStep(BaseStep):
         pool: str,
         fqdn: str | None = None,
     ):
-        super().__init__("Ensure L2 advertisement", "Ensuring L2 advertisement")
-        self.deployment = deployment
-        self.client = client
-        self.jhelper = jhelper
-        self.model = model
-        self.network = network
+        super().__init__(
+            "Ensure L2 advertisement",
+            "Ensuring L2 advertisement",
+            deployment,
+            client,
+            jhelper,
+            model,
+            network,
+            kube_namespace=K8SHelper.get_loadbalancer_namespace(),
+            fqdn=fqdn,
+        )
         self.pool = pool
-        self.fqdn = fqdn
         self.l2_advertisement_resource = (
             K8SHelper.get_lightkube_l2_advertisement_resource()
         )
         self.l2_advertisement_namespace = K8SHelper.get_loadbalancer_namespace()
-        self.to_update: list[dict] = []
-        self.to_delete: list[dict] = []
-        self._ifnames: dict[str, str] = {}
 
     def _labels(self, name: str, space: str) -> dict[str, str]:
         """Return labels for the L2 advertisement."""
@@ -1307,10 +1714,11 @@ class EnsureL2AdvertisementByHostStep(BaseStep):
         """Return instance label for the L2 advertisement."""
         return self._name_label(network) + "-" + name
 
-    def _get_outdated_l2_advertisement(
+    def _get_outdated_resources(
         self, nodes: list[dict], kube: "l_client.Client"
     ) -> tuple[list[str], list[str]]:
         """Get outdated L2 advertisement."""
+        node_names = {node["name"] for node in nodes}
         outdated: list[str] = [node["name"] for node in nodes]
         deleted: list[str] = []
 
@@ -1335,7 +1743,7 @@ class EnsureL2AdvertisementByHostStep(BaseStep):
             if l2_ad.spec is None:
                 LOG.debug("L2 advertisement %r has no spec", hostname)
                 continue
-            if hostname not in outdated:
+            if hostname not in node_names:
                 LOG.debug(
                     "L2 advertisement %s has no matching node",
                     l2_ad.metadata.name,
@@ -1351,7 +1759,7 @@ class EnsureL2AdvertisementByHostStep(BaseStep):
             interface = None
             for node in nodes:
                 if node["name"] == hostname:
-                    interface = self._get_interface(node, self.network)
+                    interface = self._get_interface(node)
             if not interface:
                 LOG.debug(
                     "L2 advertisement %s has no allocated interface",
@@ -1366,73 +1774,6 @@ class EnsureL2AdvertisementByHostStep(BaseStep):
                 continue
             outdated.remove(hostname)
         return outdated, deleted
-
-    def _get_interface(
-        self,
-        node: dict,
-        network: Networks,
-    ) -> str:
-        """Get interface for the node depending on the pool."""
-        name = node["name"]
-        if name in self._ifnames:
-            return self._ifnames[name]
-        machine_id = str(node["machineid"])
-        machine_interfaces = self.jhelper.get_machine_interfaces(self.model, machine_id)
-        LOG.debug("Machine %r interfaces: %r", machine_id, machine_interfaces)
-        network_space = self.deployment.get_space(network)
-        for ifname, iface in machine_interfaces.items():
-            if (spaces := iface.space) and network_space in spaces.split():
-                self._ifnames[name] = ifname
-                return ifname
-        raise self._L2AdvertisementError(
-            f"Node {node['name']} has no interface in {network.name} space"
-        )
-
-    def is_skip(self, context: StepContext) -> Result:
-        """Determines if the step should be skipped or not.
-
-        :return: ResultType.SKIPPED if the Step should be skipped,
-                 ResultType.COMPLETED or ResultType.FAILED otherwise
-        """
-        control = Role.CONTROL.name.lower()
-        region_controller = Role.REGION_CONTROLLER.name.lower()
-        if self.fqdn:
-            node = self.client.cluster.get_node_info(self.fqdn)
-            node_roles = node.get("role", [])
-            if control not in node_roles and region_controller not in node_roles:
-                return Result(ResultType.FAILED, f"{self.fqdn} is not a control node")
-            self.control_nodes = [node]
-        else:
-            self.control_nodes = self.client.cluster.list_nodes_by_role(control)
-
-        try:
-            self.kube = get_kube_client(
-                self.client,
-                self.l2_advertisement_namespace,
-            )
-        except KubeClientError as e:
-            LOG.debug("Failed to create k8s client", exc_info=True)
-            return Result(ResultType.FAILED, str(e))
-
-        try:
-            outdated, deleted = self._get_outdated_l2_advertisement(
-                self.control_nodes, self.kube
-            )
-        except (l_exceptions.ApiError, self._L2AdvertisementError) as e:
-            LOG.debug("Failed to get outdated L2 advertisement", exc_info=True)
-            return Result(ResultType.FAILED, str(e))
-
-        if not (outdated or deleted):
-            LOG.debug("No L2 advertisement to update")
-            return Result(ResultType.SKIPPED)
-
-        for node in self.control_nodes:
-            if node["name"] in outdated:
-                self.to_update.append(node)
-            if node["name"] in deleted:
-                self.to_delete.append(node)
-
-        return Result(ResultType.COMPLETED)
 
     @tenacity.retry(
         wait=tenacity.wait_fixed(15),
@@ -1482,7 +1823,7 @@ class EnsureL2AdvertisementByHostStep(BaseStep):
         for node in self.to_update:
             name = node["name"]
             try:
-                interface = self._get_interface(node, self.network)
+                interface = self._get_interface(node)
             except MachineNotFoundException:
                 LOG.debug(
                     "Failed to get the machine for L2 advertisement on %s",

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -31,7 +31,6 @@ from sunbeam.steps.cinder_volume import DeployCinderVolumeApplicationStep
 from sunbeam.steps.hypervisor import ReapplyHypervisorTerraformPlanStep
 from sunbeam.steps.k8s import (
     DeployK8SApplicationStep,
-    EnsureCiliumOnCorrectSpaceStep,
     EnsureDefaultL2AdvertisementMutedStep,
     EnsureL2AdvertisementByHostStep,
 )
@@ -456,12 +455,6 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                         self.manifest,
                         self.deployment.openstack_machines_model,
                     ),
-                    EnsureCiliumOnCorrectSpaceStep(
-                        self.deployment,
-                        self.client,
-                        self.jhelper,
-                        self.deployment.openstack_machines_model,
-                    ),
                     EnsureDefaultL2AdvertisementMutedStep(
                         self.deployment, self.client, self.jhelper
                     ),
@@ -504,12 +497,6 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                         self.manifest,
                         self.deployment.openstack_machines_model,
                         refresh=True,
-                    ),
-                    EnsureCiliumOnCorrectSpaceStep(
-                        self.deployment,
-                        self.client,
-                        self.jhelper,
-                        self.deployment.openstack_machines_model,
                     ),
                 ]
             )

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -31,6 +31,7 @@ from sunbeam.steps.cinder_volume import DeployCinderVolumeApplicationStep
 from sunbeam.steps.hypervisor import ReapplyHypervisorTerraformPlanStep
 from sunbeam.steps.k8s import (
     DeployK8SApplicationStep,
+    EnsureCiliumDeviceByHostStep,
     EnsureDefaultL2AdvertisementMutedStep,
     EnsureL2AdvertisementByHostStep,
 )
@@ -455,6 +456,12 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                         self.manifest,
                         self.deployment.openstack_machines_model,
                     ),
+                    EnsureCiliumDeviceByHostStep(
+                        self.deployment,
+                        self.client,
+                        self.jhelper,
+                        self.deployment.openstack_machines_model,
+                    ),
                     EnsureDefaultL2AdvertisementMutedStep(
                         self.deployment, self.client, self.jhelper
                     ),
@@ -497,6 +504,12 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                         self.manifest,
                         self.deployment.openstack_machines_model,
                         refresh=True,
+                    ),
+                    EnsureCiliumDeviceByHostStep(
+                        self.deployment,
+                        self.client,
+                        self.jhelper,
+                        self.deployment.openstack_machines_model,
                     ),
                 ]
             )

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -1555,15 +1555,8 @@ class TestMaasDeployK8SApplicationStep:
         step.ranges = "10.0.0.0/28"
         step.client.cluster.get_config.return_value = "{}"
         expected_tfvars = {
-            "endpoint_bindings": [
-                {"space": "data"},
-                {"endpoint": "cluster", "space": "internal_space"},
-            ],
+            "endpoint_bindings": [{"space": "data"}],
             "k8s_config": {
-                "cluster-annotations": (
-                    "k8sd/v1alpha1/cilium/devices="
-                    "!br-ex,!br-int,!br-phys+,br-bond+,bond+,eth+,eno+,ens+,enp+,em+,vlan+"
-                ),
                 "load-balancer-cidrs": "10.0.0.0/28",
                 "load-balancer-enabled": True,
                 "load-balancer-l2-mode": True,

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -13,8 +13,7 @@ import tenacity
 from lightkube import ApiError
 
 from sunbeam.clusterd.service import ConfigItemNotFoundException
-from sunbeam.core.common import ResultType, SunbeamException
-from sunbeam.core.deployment import Networks
+from sunbeam.core.common import ResultType
 from sunbeam.core.juju import (
     ActionFailedException,
     ApplicationNotFoundException,
@@ -23,14 +22,10 @@ from sunbeam.core.juju import (
     MachineNotFoundException,
 )
 from sunbeam.steps.k8s import (
-    CILIUM_DEVICES_ANNOTATION_DEFAULT,
-    CILIUM_DEVICES_ANNOTATION_KEY,
     CREDENTIAL_SUFFIX,
     K8S_CLOUD_SUFFIX,
     AddK8SCloudStep,
     AddK8SCredentialStep,
-    DeployK8SApplicationStep,
-    EnsureCiliumOnCorrectSpaceStep,
     EnsureDefaultL2AdvertisementMutedStep,
     EnsureK8SUnitsTaggedStep,
     EnsureL2AdvertisementByHostStep,
@@ -65,13 +60,7 @@ def deployment_with_space():
     """Deployment mock with space configuration."""
     deployment = Mock()
     deployment.name = "test-deployment"
-
-    def get_space(network):
-        if network == Networks.INTERNAL:
-            return "internal"
-        return "management"
-
-    deployment.get_space.side_effect = get_space
+    deployment.get_space.return_value = "management"
     return deployment
 
 
@@ -908,12 +897,12 @@ class TestEnsureK8SUnitsTaggedStep:
         jhelper.get_machines.return_value = {
             "1": Mock(
                 network_interfaces={
-                    "eth0": Mock(space="internal", ip_addresses=["10.0.0.1"])
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.1"])
                 }
             ),
             "2": Mock(
                 network_interfaces={
-                    "eth0": Mock(space="internal", ip_addresses=["10.0.0.2"])
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.2"])
                 }
             ),
         }
@@ -940,12 +929,12 @@ class TestEnsureK8SUnitsTaggedStep:
         jhelper.get_machines.return_value = {
             "1": Mock(
                 network_interfaces={
-                    "eth0": Mock(space="internal", ip_addresses=["10.0.0.1"])
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.1"])
                 }
             ),
             "2": Mock(
                 network_interfaces={
-                    "eth0": Mock(space="internal", ip_addresses=["10.0.0.2"])
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.2"])
                 }
             ),
         }
@@ -975,12 +964,12 @@ class TestEnsureK8SUnitsTaggedStep:
         jhelper.get_machines.return_value = {
             "1": Mock(
                 network_interfaces={
-                    "eth0": Mock(space="internal", ip_addresses=["10.0.0.1"])
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.1"])
                 }
             ),
             "2": Mock(
                 network_interfaces={
-                    "eth0": Mock(space="internal", ip_addresses=["10.0.0.2"])
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.2"])
                 }
             ),
         }
@@ -1004,12 +993,12 @@ class TestEnsureK8SUnitsTaggedStep:
         jhelper.get_machines.return_value = {
             "1": Mock(
                 network_interfaces={
-                    "eth0": Mock(space="internal", ip_addresses=["10.0.0.1"])
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.1"])
                 }
             ),
             "2": Mock(
                 network_interfaces={
-                    "eth0": Mock(space="internal", ip_addresses=["10.0.0.2"])
+                    "eth0": Mock(space="management", ip_addresses=["10.0.0.2"])
                 }
             ),
         }
@@ -1064,172 +1053,6 @@ class TestEnsureK8SUnitsTaggedStep:
             result = step.run(None)
         step.kube.apply.assert_called_once()
         assert result.result_type == ResultType.FAILED
-
-
-class TestDeployK8SApplicationStep:
-    @pytest.fixture
-    def deployment(self, deployment_with_space):
-        deployment_with_space.openstack_machines_model = "test-model"
-        return deployment_with_space
-
-    @pytest.fixture
-    def client(self, basic_client):
-        return basic_client
-
-    @pytest.fixture
-    def jhelper(self, basic_jhelper):
-        return basic_jhelper
-
-    @pytest.fixture
-    def manifest(self, basic_manifest):
-        basic_manifest.core.software.charms.get.return_value = None
-        return basic_manifest
-
-    @pytest.fixture
-    def step(self, deployment, client, jhelper, manifest):
-        tfhelper = Mock()
-        step = DeployK8SApplicationStep(
-            deployment,
-            client,
-            tfhelper,
-            jhelper,
-            manifest,
-            "test-model",
-        )
-        step.client = client
-        client.cluster.get_config.return_value = "{}"
-        return step
-
-    def test_extra_tfvars(self, step):
-        tfvars = step.extra_tfvars()
-        assert tfvars["endpoint_bindings"] == [
-            {"space": "management"},
-            {"endpoint": "cluster", "space": "internal"},
-        ]
-
-    def test_get_k8s_config_tfvars_default(self, step):
-        config = step._get_k8s_config_tfvars()
-        expected_annotation = (
-            CILIUM_DEVICES_ANNOTATION_KEY + "=" + CILIUM_DEVICES_ANNOTATION_DEFAULT
-        )
-        assert config["cluster-annotations"] == expected_annotation
-        assert config["load-balancer-enabled"] is True
-        assert config["load-balancer-l2-mode"] is True
-
-    def test_get_k8s_config_tfvars_manifest_override(self, step, manifest):
-        charm_manifest = Mock()
-        charm_manifest.config = {
-            "cluster-annotations": "k8sd/v1alpha1/cilium/devices=custom-device+",
-        }
-        manifest.core.software.charms.get.return_value = charm_manifest
-        config = step._get_k8s_config_tfvars()
-        assert (
-            config["cluster-annotations"]
-            == "k8sd/v1alpha1/cilium/devices=custom-device+"
-        )
-
-    def test_get_k8s_config_tfvars_manifest_override_space_separated_rejected(
-        self, step, manifest
-    ):
-        from sunbeam.core.common import SunbeamException
-
-        charm_manifest = Mock()
-        charm_manifest.config = {
-            "cluster-annotations": "k8sd/v1alpha1/cilium/devices=br+ bond+",
-        }
-        manifest.core.software.charms.get.return_value = charm_manifest
-        with pytest.raises(SunbeamException, match="comma-separated"):
-            step._get_k8s_config_tfvars()
-
-    def test_get_k8s_config_tfvars_manifest_override_multi_annotation(
-        self, step, manifest
-    ):
-        charm_manifest = Mock()
-        charm_manifest.config = {
-            "cluster-annotations": (
-                "k8sd/v1alpha1/cilium/devices=br+,bond+ other/key=value"
-            ),
-        }
-        manifest.core.software.charms.get.return_value = charm_manifest
-        config = step._get_k8s_config_tfvars()
-        assert (
-            config["cluster-annotations"]
-            == "k8sd/v1alpha1/cilium/devices=br+,bond+ other/key=value"
-        )
-
-    def test_get_k8s_config_tfvars_manifest_override_cilium_not_first(
-        self, step, manifest
-    ):
-        charm_manifest = Mock()
-        charm_manifest.config = {
-            "cluster-annotations": (
-                "other/key=value k8sd/v1alpha1/cilium/devices=br+,bond+"
-            ),
-        }
-        manifest.core.software.charms.get.return_value = charm_manifest
-        config = step._get_k8s_config_tfvars()
-        assert (
-            config["cluster-annotations"]
-            == "other/key=value k8sd/v1alpha1/cilium/devices=br+,bond+"
-        )
-
-    def test_get_k8s_config_tfvars_manifest_override_space_sep_with_trailing_annotation(
-        self, step, manifest
-    ):
-        from sunbeam.core.common import SunbeamException
-
-        charm_manifest = Mock()
-        charm_manifest.config = {
-            "cluster-annotations": (
-                "k8sd/v1alpha1/cilium/devices=br+ bond+ other/key=value"
-            ),
-        }
-        manifest.core.software.charms.get.return_value = charm_manifest
-        with pytest.raises(SunbeamException, match="comma-separated"):
-            step._get_k8s_config_tfvars()
-
-    def test_get_k8s_config_tfvars_manifest_override_no_cilium_key(
-        self, step, manifest
-    ):
-        charm_manifest = Mock()
-        charm_manifest.config = {
-            "cluster-annotations": "some/other=annotation",
-        }
-        manifest.core.software.charms.get.return_value = charm_manifest
-        config = step._get_k8s_config_tfvars()
-        assert config["cluster-annotations"] == "some/other=annotation"
-
-    def test_get_k8s_config_tfvars_manifest_override_empty(self, step, manifest):
-        charm_manifest = Mock()
-        charm_manifest.config = {
-            "cluster-annotations": "",
-        }
-        manifest.core.software.charms.get.return_value = charm_manifest
-        config = step._get_k8s_config_tfvars()
-        assert config["cluster-annotations"] == ""
-
-    def test_is_skip_valid(self, step, step_context):
-        result = step.is_skip(step_context)
-        assert result.result_type == ResultType.COMPLETED
-
-    def test_is_skip_invalid_annotations(self, step, manifest, step_context):
-        charm_manifest = Mock()
-        charm_manifest.config = {
-            "cluster-annotations": "k8sd/v1alpha1/cilium/devices=br+ bond+",
-        }
-        manifest.core.software.charms.get.return_value = charm_manifest
-        result = step.is_skip(step_context)
-        assert result.result_type == ResultType.FAILED
-        assert "comma-separated" in result.message
-
-    def test_get_k8s_config_tfvars_with_lb_range(self, step):
-        step._get_loadbalancer_range = Mock(return_value="10.0.0.0/28")
-        config = step._get_k8s_config_tfvars()
-        assert config["load-balancer-cidrs"] == "10.0.0.0/28"
-
-    def test_get_k8s_config_tfvars_with_node_labels(self, step):
-        config = step._get_k8s_config_tfvars()
-        assert "sunbeam/deployment=" in config["node-labels"]
 
 
 class TestGetKubeClient:
@@ -1615,182 +1438,3 @@ class TestPatchServiceExternalTrafficStep:
             kube_mock.patch.side_effect = api_error
             result = step.run(None)
         assert result.result_type == ResultType.FAILED
-
-
-class TestEnsureCiliumOnCorrectSpaceStep:
-    @pytest.fixture
-    def deployment(self, deployment_with_space):
-        return deployment_with_space
-
-    @pytest.fixture
-    def client(self, basic_client):
-        return basic_client
-
-    @pytest.fixture
-    def jhelper(self, jhelper_with_networks):
-        return jhelper_with_networks
-
-    @pytest.fixture
-    def step(self, deployment, client, jhelper):
-        step = EnsureCiliumOnCorrectSpaceStep(deployment, client, jhelper, "test-model")
-        step.kube = Mock()
-        return step
-
-    # --- is_skip tests ---
-
-    def test_is_skip_same_management_and_internal_space(
-        self, client, jhelper, step_context
-    ):
-        """When management == internal space, step must be skipped."""
-        deployment = Mock()
-        deployment.name = "test-deployment"
-        deployment.get_space.return_value = "shared-space"  # same for both
-        step = EnsureCiliumOnCorrectSpaceStep(deployment, client, jhelper, "test-model")
-        result = step.is_skip(step_context)
-        assert result.result_type == ResultType.SKIPPED
-
-    def test_is_skip_kube_client_error(self, step, step_context):
-        """KubeClientError during k8s client creation should fail the step."""
-        with patch(
-            "sunbeam.steps.k8s.get_kube_client", side_effect=KubeClientError("fail")
-        ):
-            result = step.is_skip(step_context)
-        assert result.result_type == ResultType.FAILED
-
-    def test_is_skip_juju_exception_getting_networks(self, step, jhelper, step_context):
-        from sunbeam.core.juju import JujuException
-
-        jhelper.get_space_networks.side_effect = JujuException("no space")
-        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
-            result = step.is_skip(step_context)
-        assert result.result_type == ResultType.FAILED
-
-    def test_is_skip_k8s_list_nodes_error(self, step, jhelper, step_context):
-        jhelper.get_space_networks.return_value = [ipaddress.ip_network("10.0.0.0/8")]
-        step.kube.list.side_effect = ApiError.__new__(ApiError)
-        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
-            result = step.is_skip(step_context)
-        assert result.result_type == ResultType.FAILED
-
-    def test_is_skip_all_nodes_on_correct_space(self, step, jhelper, step_context):
-        """All nodes' InternalIPs in the internal subnet → skip."""
-        jhelper.get_space_networks.return_value = [ipaddress.ip_network("10.0.0.0/8")]
-        step.kube.list.return_value = [
-            _to_kube_object(
-                {"name": "node1"},
-                status={"addresses": [Mock(type="InternalIP", address="10.0.0.1")]},
-            ),
-            _to_kube_object(
-                {"name": "node2"},
-                status={"addresses": [Mock(type="InternalIP", address="10.0.0.2")]},
-            ),
-        ]
-        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
-            result = step.is_skip(step_context)
-        assert result.result_type == ResultType.SKIPPED
-
-    def test_is_skip_node_on_wrong_space(self, step, jhelper, step_context):
-        """A node with an InternalIP outside the internal subnet → must run."""
-        jhelper.get_space_networks.return_value = [ipaddress.ip_network("10.0.0.0/8")]
-        step.kube.list.return_value = [
-            _to_kube_object(
-                {"name": "node1"},
-                # 192.168.x.x is management space, not in 10.0.0.0/8
-                status={"addresses": [Mock(type="InternalIP", address="192.168.1.5")]},
-            ),
-        ]
-        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
-            result = step.is_skip(step_context)
-        assert result.result_type == ResultType.COMPLETED
-        assert step.needs_restart is True
-
-    def test_is_skip_node_with_no_internal_ip(self, step, jhelper, step_context):
-        """Node with no InternalIP address is ignored (safe default)."""
-        jhelper.get_space_networks.return_value = [ipaddress.ip_network("10.0.0.0/8")]
-        step.kube.list.return_value = [
-            _to_kube_object(
-                {"name": "node1"},
-                # Only a Hostname address, no InternalIP
-                status={"addresses": [Mock(type="Hostname", address="node1")]},
-            ),
-        ]
-        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
-            result = step.is_skip(step_context)
-        assert result.result_type == ResultType.SKIPPED
-
-    def test_is_skip_node_with_no_status(self, step, jhelper, step_context):
-        """Node with no status is ignored (safe default)."""
-        jhelper.get_space_networks.return_value = [ipaddress.ip_network("10.0.0.0/8")]
-        node = Mock()
-        node.metadata = Mock(name="node1")
-        node.status = None
-        step.kube.list.return_value = [node]
-        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
-            result = step.is_skip(step_context)
-        assert result.result_type == ResultType.SKIPPED
-
-    # --- run tests ---
-
-    def test_run_patches_cilium_daemonset(self, step):
-        """run() patches the Cilium DaemonSet and waits for rollout."""
-        step.needs_restart = True
-        step.kube.patch = Mock()
-        step.kube.get = Mock()
-        ds_status = Mock()
-        ds_status.desiredNumberScheduled = 2
-        ds_status.updatedNumberScheduled = 2
-        ds_status.numberAvailable = 2
-        step.kube.get.return_value = Mock(status=ds_status)
-        result = step.run(None)
-        step.kube.patch.assert_called_once()
-        patch_call_kwargs = step.kube.patch.call_args
-        # Second positional arg is the resource name
-        assert patch_call_kwargs[0][1] == "cilium"
-        assert result.result_type == ResultType.COMPLETED
-
-    def test_run_patch_api_error(self, step):
-        """ApiError during DaemonSet patch is surfaced as FAILED."""
-        step.needs_restart = True
-        api_error = ApiError.__new__(ApiError)
-        api_error.status = Mock(code=500)
-        step.kube.patch = Mock(side_effect=api_error)
-        result = step.run(None)
-        assert result.result_type == ResultType.FAILED
-        assert "Failed to restart Cilium DaemonSet" in result.message
-
-    def test_run_rollout_timeout(self, step):
-        """SunbeamException from _wait_for_rollout is surfaced as FAILED."""
-        step.needs_restart = True
-        step.kube.patch = Mock()
-        with patch.object(
-            step, "_wait_for_rollout", side_effect=SunbeamException("timed out")
-        ):
-            result = step.run(None)
-        assert result.result_type == ResultType.FAILED
-        assert "timed out" in result.message
-
-    def test_wait_for_rollout_completes_immediately(self, step):
-        """_wait_for_rollout returns as soon as desired==updated==available."""
-        ds_status = Mock()
-        ds_status.desiredNumberScheduled = 3
-        ds_status.updatedNumberScheduled = 3
-        ds_status.numberAvailable = 3
-        step.kube.get = Mock(return_value=Mock(status=ds_status))
-        # Should not raise
-        step._wait_for_rollout()
-        step.kube.get.assert_called_once()
-
-    def test_wait_for_rollout_times_out(self, step):
-        """_wait_for_rollout raises SunbeamException when deadline passes."""
-        ds_status = Mock()
-        ds_status.desiredNumberScheduled = 3
-        ds_status.updatedNumberScheduled = 1  # not converged
-        ds_status.numberAvailable = 1
-        step.kube.get = Mock(return_value=Mock(status=ds_status))
-        # First call sets deadline=0+300=300; second call returns 301 so loop exits.
-        with (
-            patch("sunbeam.steps.k8s.time.monotonic", side_effect=[0.0, 301.0]),
-            patch("sunbeam.steps.k8s.time.sleep"),
-        ):
-            with pytest.raises(SunbeamException, match="did not complete"):
-                step._wait_for_rollout()

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -26,6 +26,7 @@ from sunbeam.steps.k8s import (
     K8S_CLOUD_SUFFIX,
     AddK8SCloudStep,
     AddK8SCredentialStep,
+    EnsureCiliumDeviceByHostStep,
     EnsureDefaultL2AdvertisementMutedStep,
     EnsureK8SUnitsTaggedStep,
     EnsureL2AdvertisementByHostStep,
@@ -389,21 +390,52 @@ class TestEnsureL2AdvertisementByHostStep:
         kube_mocker.stop()
 
     def test_is_skip_no_outdated_or_deleted(self, step, step_context):
-        step._get_outdated_l2_advertisement = Mock(return_value=([], []))
+        step._get_outdated_resources = Mock(return_value=([], []))
         result = step.is_skip(step_context)
         assert result.result_type == ResultType.SKIPPED
 
     def test_is_skip_with_outdated(self, step, step_context):
-        step._get_outdated_l2_advertisement = Mock(return_value=(["node1"], []))
+        step._get_outdated_resources = Mock(return_value=(["node1"], []))
         result = step.is_skip(step_context)
         assert result.result_type == ResultType.COMPLETED
         assert len(step.to_update) == 1
 
     def test_is_skip_with_deleted(self, step, step_context):
-        step._get_outdated_l2_advertisement = Mock(return_value=([], ["node2"]))
+        step._get_outdated_resources = Mock(return_value=([], ["node2"]))
         result = step.is_skip(step_context)
         assert result.result_type == ResultType.COMPLETED
         assert len(step.to_delete) == 1
+
+    def test_is_skip_single_node_fqdn_preserves_other_resources(
+        self, deployment, client, jhelper, step_context
+    ):
+        """When fqdn is set, resources for other nodes must not be deleted.
+
+        Regression test: during greenfield join, only the joining node is in
+        the working set.  _get_outdated_resources marks other nodes' resources
+        as deleted, but the base class must suppress deletions in single-node
+        mode so previously-joined nodes keep their L2Advertisement.
+        """
+        node_info = {"name": "node2", "machineid": "2", "role": ["control"]}
+        client.cluster.get_node_info = Mock(return_value=node_info)
+        network = Mock()
+        step = EnsureL2AdvertisementByHostStep(
+            deployment,
+            client,
+            jhelper,
+            "test-model",
+            network,
+            "test-pool",
+            fqdn="node2.maas",
+        )
+        step.kube = Mock()
+        step._get_outdated_resources = Mock(return_value=(["node2"], ["node1"]))
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
+            result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert len(step.to_update) == 1
+        assert step.to_update[0]["name"] == "node2"
+        assert step.to_delete == []
 
     def test_run_update_and_delete(self, step):
         step.to_update = [{"name": "node1", "machineid": "1"}]
@@ -460,8 +492,7 @@ class TestEnsureL2AdvertisementByHostStep:
 
     def test_get_interface_cached(self, step):
         step._ifnames = {"node1": "eth0"}
-        network = Mock()
-        result = step._get_interface({"name": "node1"}, network)
+        result = step._get_interface({"name": "node1"})
         assert result == "eth0"
 
     def test_get_interface_found(self, step, jhelper, deployment):
@@ -470,8 +501,7 @@ class TestEnsureL2AdvertisementByHostStep:
             "eth1": Mock(space="other-space"),
         }
         deployment.get_space.return_value = "management"
-        network = Mock()
-        result = step._get_interface({"name": "node1", "machineid": "1"}, network)
+        result = step._get_interface({"name": "node1", "machineid": "1"})
         assert result == "eth0"
         assert step._ifnames["node1"] == "eth0"
 
@@ -482,14 +512,14 @@ class TestEnsureL2AdvertisementByHostStep:
             "eth1": Mock(space="another-space"),
         }
         deployment.get_space.return_value = "management"
-        network = Mock()
-        network.name = "test-network"
+        step.network = Mock()
+        step.network.name = "test-network"
 
         # Test the private method directly - it should raise an exception
         # Using a standard exception pattern instead of accessing the
         # private exception class
         with pytest.raises(Exception) as exc_info:
-            step._get_interface({"name": "node1", "machineid": "1"}, network)
+            step._get_interface({"name": "node1", "machineid": "1"})
 
         # Verify it's the expected error message
         assert "Node node1 has no interface in test-network space" in str(
@@ -652,17 +682,15 @@ def test_get_outdated_l2_advertisement(
         "test-pool",
     )
 
-    def _get_interface(node, network):
+    def _get_interface(node):
         for node_it in nodes:
             if node_it["name"] == node["name"]:
                 return node_it["interface"]
-        raise RuntimeError(
-            f"Node {node['name']} has no interface in network space '{network}'"
-        )
+        raise RuntimeError(f"Node {node['name']} has no interface in network space")
 
     step._get_interface = Mock(side_effect=_get_interface)
 
-    outdated_res, deleted_res = step._get_outdated_l2_advertisement(nodes, kube)
+    outdated_res, deleted_res = step._get_outdated_resources(nodes, kube)
 
     assert outdated_res == outdated
     assert deleted_res == deleted
@@ -1438,3 +1466,374 @@ class TestPatchServiceExternalTrafficStep:
             kube_mock.patch.side_effect = api_error
             result = step.run(None)
         assert result.result_type == ResultType.FAILED
+
+
+class TestEnsureCiliumDeviceByHostStep:
+    @pytest.fixture
+    def deployment(self, basic_deployment):
+        basic_deployment.name = "test-deployment"
+        basic_deployment.get_space.return_value = "internal"
+        return basic_deployment
+
+    @pytest.fixture
+    def control_nodes(self):
+        return [
+            {"name": "node1", "machineid": "1"},
+            {"name": "node2", "machineid": "2"},
+        ]
+
+    @pytest.fixture
+    def client(self, control_nodes):
+        return Mock(
+            cluster=Mock(
+                list_nodes_by_role=Mock(return_value=control_nodes),
+                get_config=Mock(return_value="{}"),
+            )
+        )
+
+    @pytest.fixture
+    def jhelper(self, basic_jhelper):
+        return basic_jhelper
+
+    @pytest.fixture
+    def step(self, deployment, client, jhelper):
+        step = EnsureCiliumDeviceByHostStep(deployment, client, jhelper, "test-model")
+        step.kube = Mock()
+        return step
+
+    @pytest.fixture(autouse=True)
+    def setup_patches(self, step):
+        kubeconfig_mocker = patch(
+            "sunbeam.steps.k8s.l_kubeconfig.KubeConfig",
+            Mock(from_dict=Mock(return_value=Mock())),
+        )
+        kubeconfig_mocker.start()
+        kube_mocker = patch(
+            "sunbeam.steps.k8s.l_client.Client",
+            Mock(return_value=Mock(return_value=step.kube)),
+        )
+        kube_mocker.start()
+        yield
+        kubeconfig_mocker.stop()
+        kube_mocker.stop()
+
+    def test_is_skip_no_changes(self, step, step_context):
+        step._get_outdated_resources = Mock(return_value=([], []))
+        result = step.is_skip(step_context)
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_is_skip_outdated_device(self, step, step_context):
+        step._get_outdated_resources = Mock(return_value=(["node1"], []))
+        result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert len(step.to_update) == 1
+        assert step.to_update[0]["name"] == "node1"
+
+    def test_is_skip_missing_config(self, step, step_context):
+        step._get_outdated_resources = Mock(return_value=(["node1", "node2"], []))
+        result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert len(step.to_update) == 2
+
+    def test_is_skip_deleted_node(self, step, step_context):
+        """Deleted nodes (not in control_nodes) are scheduled for cleanup."""
+        step._get_outdated_resources = Mock(return_value=([], ["departed-node"]))
+        result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert len(step.to_delete) == 1
+        assert step.to_delete[0]["name"] == "departed-node"
+
+    def test_is_skip_single_node_fqdn(self, deployment, client, jhelper, step_context):
+        node_info = {"name": "node1", "machineid": "1", "role": ["control"]}
+        client.cluster.get_node_info = Mock(return_value=node_info)
+        step = EnsureCiliumDeviceByHostStep(
+            deployment, client, jhelper, "test-model", fqdn="node1.maas"
+        )
+        step.kube = Mock()
+        step._get_outdated_resources = Mock(return_value=(["node1"], []))
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
+            result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert step.control_nodes == [node_info]
+
+    def test_is_skip_single_node_fqdn_preserves_other_configs(
+        self, deployment, client, jhelper, step_context
+    ):
+        """When fqdn is set, configs for other nodes must not be deleted.
+
+        Regression test: during greenfield join, only the joining node is in
+        the working set.  _get_outdated_resources marks other nodes' configs
+        as deleted, but the base class must suppress deletions in single-node
+        mode so previously-joined nodes keep their CiliumNodeConfig.
+        """
+        node_info = {"name": "node2", "machineid": "2", "role": ["control"]}
+        client.cluster.get_node_info = Mock(return_value=node_info)
+        step = EnsureCiliumDeviceByHostStep(
+            deployment, client, jhelper, "test-model", fqdn="node2.maas"
+        )
+        step.kube = Mock()
+        # node2 needs an update; node1 reported as deleted (not in working set)
+        step._get_outdated_resources = Mock(return_value=(["node2"], ["node1"]))
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=step.kube):
+            result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+        assert len(step.to_update) == 1
+        assert step.to_update[0]["name"] == "node2"
+        assert step.to_delete == []
+
+    def test_is_skip_wrong_node_selector(self, step, control_nodes, jhelper):
+        jhelper.get_machine_interfaces.return_value = {
+            "eth0": Mock(space="internal"),
+        }
+        wrong_selector_config = Mock()
+        wrong_selector_config.metadata = Mock(
+            name="cilium-devices-node1",
+            labels={
+                "app.kubernetes.io/managed-by": "test-deployment",
+                "sunbeam/hostname": "node1",
+            },
+        )
+        wrong_selector_config.spec = {
+            "nodeSelector": {"matchLabels": {"sunbeam/hostname": "wrong-node"}},
+            "defaults": {"devices": "eth0"},
+        }
+        step.kube.list = Mock(return_value=[wrong_selector_config])
+        outdated, deleted = step._get_outdated_resources(control_nodes, step.kube)
+        assert "node1" in outdated
+
+    def test_run_creates_config(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        step.kube.apply = Mock()
+        step.kube.patch = Mock()
+
+        # _find_cilium_pod returns the old pod
+        old_pod = Mock()
+        old_pod.metadata = Mock(name="cilium-abc")
+        old_pod.spec = Mock(nodeName="node1")
+        # _wait_for_cilium_ready returns a NEW pod (different name)
+        new_pod = Mock()
+        new_pod.metadata = Mock(name="cilium-xyz")
+        new_pod.spec = Mock(nodeName="node1")
+        new_pod.status = Mock(conditions=[Mock(type="Ready", status="True")])
+
+        call_count = [0]
+
+        def list_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [old_pod]  # _find_cilium_pod
+            return [new_pod]  # _wait_for_cilium_ready
+
+        step.kube.list = Mock(side_effect=list_side_effect)
+        step.kube.delete = Mock()
+
+        result = step.run(None)
+
+        step.kube.apply.assert_called_once()
+        step.kube.patch.assert_called_once()  # clears restart-pending
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_updates_config(self, step):
+        step.to_update = [
+            {"name": "node1", "machineid": "1"},
+            {"name": "node2", "machineid": "2"},
+        ]
+        step.to_delete = []
+        step._get_interface = Mock(side_effect=["eth0", "eth1"])
+        step.kube.apply = Mock()
+        step.kube.patch = Mock()
+
+        # Old pods (to be deleted)
+        old_pod1 = Mock()
+        old_pod1.metadata = Mock(name="cilium-aaa")
+        old_pod1.spec = Mock(nodeName="node1")
+        old_pod2 = Mock()
+        old_pod2.metadata = Mock(name="cilium-bbb")
+        old_pod2.spec = Mock(nodeName="node2")
+        # New replacement pods
+        new_pod1 = Mock()
+        new_pod1.metadata = Mock(name="cilium-new1")
+        new_pod1.spec = Mock(nodeName="node1")
+        new_pod1.status = Mock(conditions=[Mock(type="Ready", status="True")])
+        new_pod2 = Mock()
+        new_pod2.metadata = Mock(name="cilium-new2")
+        new_pod2.spec = Mock(nodeName="node2")
+        new_pod2.status = Mock(conditions=[Mock(type="Ready", status="True")])
+
+        call_count = [0]
+
+        def list_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] in (1, 3):  # _find_cilium_pod calls
+                return [old_pod1, old_pod2]
+            if call_count[0] == 2:  # _wait after node1
+                return [new_pod1, old_pod2]
+            return [new_pod1, new_pod2]  # _wait after node2
+
+        step.kube.list = Mock(side_effect=list_side_effect)
+        step.kube.delete = Mock()
+
+        result = step.run(None)
+
+        assert step.kube.apply.call_count == 2
+        assert step.kube.patch.call_count == 2  # clears restart-pending on both
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_deletes_stale_config(self, step):
+        step.to_update = []
+        step.to_delete = [{"name": "node2"}]
+        step.kube.delete = Mock()
+
+        old_pod = Mock()
+        old_pod.metadata = Mock(name="cilium-xyz")
+        old_pod.spec = Mock(nodeName="node2")
+        new_pod = Mock()
+        new_pod.metadata = Mock(name="cilium-new")
+        new_pod.spec = Mock(nodeName="node2")
+        new_pod.status = Mock(conditions=[Mock(type="Ready", status="True")])
+
+        call_count = [0]
+
+        def list_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [old_pod]  # _find_cilium_pod
+            return [new_pod]  # _wait_for_cilium_ready
+
+        step.kube.list = Mock(side_effect=list_side_effect)
+
+        result = step.run(None)
+
+        assert step.kube.delete.call_count == 2  # config + pod
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_api_error(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        api_error = ApiError.__new__(ApiError)
+        api_error.status = Mock(code=500)
+        step.kube.apply = Mock(side_effect=api_error)
+
+        result = step.run(None)
+
+        assert result.result_type == ResultType.FAILED
+        assert "Failed to apply CiliumNodeConfig for node1" in result.message
+
+    def test_run_no_interface_found(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(side_effect=MachineNotFoundException("not found"))
+
+        result = step.run(None)
+
+        assert result.result_type == ResultType.FAILED
+
+    def test_run_cilium_pod_not_found(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        step.kube.apply = Mock()
+        step.kube.list = Mock(return_value=[])
+
+        result = step.run(None)
+
+        assert result.result_type == ResultType.FAILED
+        assert "No cilium pod found on node node1" in result.message
+
+    def test_run_restart_timeout(self, step):
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        step.kube.apply = Mock()
+
+        old_pod = Mock()
+        old_pod.metadata = Mock(name="cilium-abc")
+        old_pod.spec = Mock(nodeName="node1")
+        # Replacement pod exists but never becomes Ready
+        not_ready_pod = Mock()
+        not_ready_pod.metadata = Mock(name="cilium-new")
+        not_ready_pod.spec = Mock(nodeName="node1")
+        not_ready_pod.status = Mock(conditions=[Mock(type="Ready", status="False")])
+
+        call_count = [0]
+
+        def list_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [old_pod]  # _find_cilium_pod
+            return [not_ready_pod]  # _wait_for_cilium_ready
+
+        step.kube.list = Mock(side_effect=list_side_effect)
+        step.kube.delete = Mock()
+
+        with (
+            patch("sunbeam.steps.k8s.time.monotonic", side_effect=[0.0, 301.0]),
+            patch("sunbeam.steps.k8s.time.sleep"),
+        ):
+            result = step.run(None)
+
+        assert result.result_type == ResultType.FAILED
+        assert "did not become Ready" in result.message
+
+    def test_run_old_pod_ignored_during_readiness_wait(self, step):
+        """The terminating pod (same name as deleted) must not satisfy readiness."""
+        step.to_update = [{"name": "node1", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        step.kube.apply = Mock()
+        step.kube.patch = Mock()
+
+        old_pod = Mock()
+        old_pod.metadata = Mock(name="cilium-abc")
+        old_pod.spec = Mock(nodeName="node1")
+        # Old pod still shows as Ready (terminating but not gone yet)
+        old_pod.status = Mock(conditions=[Mock(type="Ready", status="True")])
+        # New pod eventually becomes Ready
+        new_pod = Mock()
+        new_pod.metadata = Mock(name="cilium-new")
+        new_pod.spec = Mock(nodeName="node1")
+        new_pod.status = Mock(conditions=[Mock(type="Ready", status="True")])
+
+        call_count = [0]
+
+        def list_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [old_pod]  # _find_cilium_pod
+            if call_count[0] == 2:
+                return [old_pod]  # _wait: old pod still around, should skip
+            return [new_pod]  # _wait: new pod appears
+
+        step.kube.list = Mock(side_effect=list_side_effect)
+        step.kube.delete = Mock()
+
+        with patch("sunbeam.steps.k8s.time.monotonic", side_effect=[0.0, 1.0, 2.0]):
+            with patch("sunbeam.steps.k8s.time.sleep"):
+                result = step.run(None)
+
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip_restart_pending(self, step, control_nodes, jhelper):
+        """Config with correct device but restart-pending=true is outdated."""
+        jhelper.get_machine_interfaces.return_value = {
+            "eth0": Mock(space="internal"),
+        }
+        config = Mock()
+        config.metadata = Mock(
+            name="cilium-devices-node1",
+            labels={
+                "app.kubernetes.io/managed-by": "test-deployment",
+                "sunbeam/hostname": "node1",
+            },
+            annotations={"sunbeam/restart-pending": "true"},
+        )
+        config.spec = {
+            "nodeSelector": {"matchLabels": {"sunbeam/hostname": "node1"}},
+            "defaults": {"devices": "eth0"},
+        }
+        step.kube.list = Mock(return_value=[config])
+        outdated, deleted = step._get_outdated_resources(control_nodes, step.kube)
+        assert "node1" in outdated

--- a/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
@@ -12,7 +12,6 @@ from sunbeam.core.juju import (
 )
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.steps.k8s import (
-    EnsureCiliumOnCorrectSpaceStep,
     EnsureDefaultL2AdvertisementMutedStep,
 )
 from sunbeam.steps.openstack import OpenStackPatchLoadBalancerServicesIPPoolStep
@@ -874,45 +873,6 @@ class TestLatestInChannelCoordinator:
         assert EnsureDefaultL2AdvertisementMutedStep in step_types
         # MaasDeployK8SApplicationStep was called; its return value is in the plan
         assert mock_maas_deploy_k8s_cls.return_value in plan
-
-    @patch(f"{_INTRA_CHANNEL}.is_maas_deployment")
-    def test_get_plan_maas_includes_cilium_step(self, mock_is_maas):
-        """MAAS refresh plan must include EnsureCiliumOnCorrectSpaceStep."""
-        mock_is_maas.return_value = True
-        self.deployment.public_api_label = "test-public-api"
-
-        mock_maas_client_module = Mock()
-        mock_maas_client_module.MaasClient.from_deployment.return_value = Mock()
-        mock_maas_steps_module = Mock()
-        mock_maas_steps_module.MaasDeployK8SApplicationStep = Mock()
-
-        with patch.dict(
-            sys.modules,
-            {
-                "sunbeam.provider.maas.client": mock_maas_client_module,
-                "sunbeam.provider.maas.steps": mock_maas_steps_module,
-            },
-        ):
-            coordinator = LatestInChannelCoordinator(
-                self.deployment, self.client, self.jhelper, self.manifest
-            )
-            plan = coordinator.get_plan()
-
-        step_types = [type(step) for step in plan]
-        assert EnsureCiliumOnCorrectSpaceStep in step_types
-
-    @patch(f"{_INTRA_CHANNEL}.is_maas_deployment")
-    def test_get_plan_local_includes_cilium_step(self, mock_is_maas):
-        """Local refresh plan must include EnsureCiliumOnCorrectSpaceStep."""
-        mock_is_maas.return_value = False
-
-        coordinator = LatestInChannelCoordinator(
-            self.deployment, self.client, self.jhelper, self.manifest
-        )
-        plan = coordinator.get_plan()
-
-        step_types = [type(step) for step in plan]
-        assert EnsureCiliumOnCorrectSpaceStep in step_types
 
     @patch(f"{_INTRA_CHANNEL}.is_maas_deployment")
     def test_get_plan_always_includes_core_steps(self, mock_is_maas):

--- a/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
@@ -12,6 +12,7 @@ from sunbeam.core.juju import (
 )
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.steps.k8s import (
+    EnsureCiliumDeviceByHostStep,
     EnsureDefaultL2AdvertisementMutedStep,
 )
 from sunbeam.steps.openstack import OpenStackPatchLoadBalancerServicesIPPoolStep
@@ -869,6 +870,7 @@ class TestLatestInChannelCoordinator:
             plan = coordinator.get_plan()
 
         step_types = [type(step) for step in plan]
+        assert EnsureCiliumDeviceByHostStep in step_types
         assert OpenStackPatchLoadBalancerServicesIPPoolStep in step_types
         assert EnsureDefaultL2AdvertisementMutedStep in step_types
         # MaasDeployK8SApplicationStep was called; its return value is in the plan
@@ -886,6 +888,7 @@ class TestLatestInChannelCoordinator:
 
         step_types = [type(step) for step in plan]
         assert LatestInChannel in step_types
+        assert EnsureCiliumDeviceByHostStep in step_types
         assert ReapplyInfraModelConfigStep in step_types
         assert UpgradeFeatures in step_types
 


### PR DESCRIPTION
Replace the cluster-wide device pattern with per-hostCiliumNodeConfig (cilium.io/v2) resources that name the exact internal-space NIC on each control node.

- Extract _PerHostK8SResourceStep base class from EnsureL2AdvertisementByHostStep (shared control-node lookup, kube client, interface-by-space matching, is_skip skeleton)
- Add EnsureCiliumDeviceByHostStep: creates/updates CiliumNodeConfig per node, validates nodeSelector + device + restart-pending state, restarts only affected cilium pods with new-pod readiness gate
- Add CiliumNodeConfig lightkube generic resource to K8SHelper
- Integrate before EnsureL2AdvertisementByHostStep in local, MAAS, and upgrade command plans

Closes-Bug: #2147062