### PR TITLE
fix: apply manifest model configs to openstack model

### DIFF
--- a/.github/assets/testing/edge.yml
+++ b/.github/assets/testing/edge.yml
@@ -4,6 +4,9 @@ core:
       bootstrap_args:
         - --bootstrap-constraints
         - root-disk=5G
+      bootstrap_model_configs:
+        openstack:
+          logging-config: "<root>=WARNING;unit=DEBUG"
     charms:
       cinder-volume:
         channel: 2024.1/edge

--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -79,6 +79,16 @@ jobs:
           # closer to the tutorial scenario.
           sg snap_daemon "openstack.sunbeam cluster bootstrap --manifest .github/assets/testing/edge.yml --accept-defaults --topology single --database single"
           sg snap_daemon "openstack.sunbeam cluster list"
+
+          # Verify bootstrap_model_configs from manifest were applied to the openstack model.
+          # The edge.yml sets logging-config for the openstack model; confirm it is not the default.
+          actual_logging=$(juju model-config -m openstack logging-config)
+          expected_logging="<root>=WARNING;unit=DEBUG"
+          if [ "$actual_logging" != "$expected_logging" ]; then
+            echo "ERROR: logging-config mismatch: expected '$expected_logging', got '$actual_logging'"
+            exit 1
+          fi
+          echo "OK: logging-config correctly set to '$actual_logging'"
           # Note: Moving configure before enabling caas just to ensure caas images are not downloaded
           # To download caas image, require ports to open on firewall to access fedora images.
           sg snap_daemon "openstack.sunbeam configure --accept-defaults --openrc demo-openrc"

--- a/sunbeam-python/sunbeam/commands/proxy.py
+++ b/sunbeam-python/sunbeam/commands/proxy.py
@@ -112,7 +112,7 @@ def _update_proxy(proxy: dict, deployment: Deployment, show_hints: bool):
         plan.append(TerraformInitStep(openstack_tfhelper))
         plan.append(
             UpdateOpenStackModelConfigStep(
-                client, openstack_tfhelper, manifest, model_config
+                deployment, openstack_tfhelper, manifest, model_config
             )
         )
     run_plan(plan, console, show_hints)

--- a/sunbeam-python/sunbeam/steps/openstack.py
+++ b/sunbeam-python/sunbeam/steps/openstack.py
@@ -73,6 +73,7 @@ OPENSTACK_DESTROY_TIMEOUT = 1800  # 30 minutes
 
 CONFIG_KEY = "TerraformVarsOpenstack"
 TOPOLOGY_KEY = "Topology"
+OPENSTACK_MODEL_CONFIG_KEY = "OpenStackModelConfig"
 DATABASE_MEMORY_KEY = "DatabaseMemory"
 DATABASE_STORAGE_KEY = "DatabaseStorage"
 DEFAULT_DATABASE_TOPOLOGY = "single"
@@ -751,8 +752,14 @@ class DeployControlPlaneStep(BaseStep, JujuStepHelper):
         region_controllers = self.client.cluster.list_nodes_by_role("region_controller")
 
         self.update_status(context, "computing deployment sizing")
-        model_config = convert_proxy_to_model_configs(self.proxy_settings)
+        model_config = dict(
+            self.manifest.core.software.juju.bootstrap_model_configs.get(
+                OPENSTACK_MODEL, {}
+            )
+        )
+        model_config.update(convert_proxy_to_model_configs(self.proxy_settings))
         model_config.update({"workload-storage": K8SHelper.get_default_storageclass()})
+        update_config(self.client, OPENSTACK_MODEL_CONFIG_KEY, model_config)
         os_api_scale = compute_os_api_scale(
             self.topology, len(control_nodes) or len(region_controllers)
         )
@@ -1056,27 +1063,48 @@ class UpdateOpenStackModelConfigStep(BaseStep):
 
     def __init__(
         self,
-        client: Client,
+        deployment: Deployment,
         tfhelper: TerraformHelper,
         manifest: Manifest,
-        model_config: dict,
+        model_config: dict | None = None,
     ):
         super().__init__(
             "Update OpenStack model config",
             "Updating OpenStack model config related to proxy",
         )
-        self.client = client
+        self.client = deployment.get_client()
         self.tfhelper = tfhelper
         self.manifest = manifest
-        self.model_config = model_config
+        self.deployment = deployment
+        self.model_config = model_config or {}
 
     def run(self, context: StepContext) -> Result:
         """Apply model configs to openstack terraform plan."""
         try:
-            self.model_config.update(
-                {"workload-storage": K8SHelper.get_default_storageclass()}
-            )
-            override_tfvars = {"config": self.model_config}
+            try:
+                final_config = dict(
+                    read_config(self.client, OPENSTACK_MODEL_CONFIG_KEY)
+                )
+            except ConfigItemNotFoundException:
+                # Backward compatibility: OPENSTACK_MODEL_CONFIG_KEY is absent on
+                # deployments predating this change. Reconstruct the baseline
+                # following the same priority order as DeployControlPlaneStep:
+                # manifest bootstrap_model_configs → proxy settings → workload-storage.
+                # This ensures the targeted terraform apply doesn't drop existing
+                # model config keys. The key will be persisted after this run so
+                # subsequent calls take the fast path.
+                final_config = dict(
+                    self.manifest.core.software.juju.bootstrap_model_configs.get(
+                        OPENSTACK_MODEL, {}
+                    )
+                )
+                final_config.update(
+                    convert_proxy_to_model_configs(self.deployment.get_proxy_settings())
+                )
+                final_config["workload-storage"] = K8SHelper.get_default_storageclass()
+            final_config.update(self.model_config)
+            update_config(self.client, OPENSTACK_MODEL_CONFIG_KEY, final_config)
+            override_tfvars = {"config": final_config}
             self.tfhelper.update_tfvars_and_apply_tf(
                 self.client,
                 self.manifest,

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_openstack.py
@@ -32,11 +32,13 @@ from sunbeam.steps.openstack import (
     DEFAULT_RABBITMQ_STORAGE,
     DEFAULT_STORAGE_MULTI_DATABASE,
     DEFAULT_STORAGE_SINGLE_DATABASE,
+    OPENSTACK_MODEL_CONFIG_KEY,
     RABBITMQ_STORAGE_KEY,
     DeployControlPlaneStep,
     OpenStackPatchLoadBalancerServicesIPPoolStep,
     OpenStackPatchLoadBalancerServicesIPStep,
     ReapplyOpenStackTerraformPlanStep,
+    UpdateOpenStackModelConfigStep,
     compute_ha_scale,
     compute_ingress_scale,
     compute_os_api_scale,
@@ -1418,6 +1420,179 @@ class TestLoadStoredTfvars:
         result = load_stored_tfvars(client, [CONFIG_KEY, "TerraformVarsDns"])
 
         assert result["mysql-storage-map"]["nova"] == {"database": "10G"}
+
+
+class TestUpdateOpenStackModelConfigStep:
+    @pytest.fixture
+    def tfhelper(self):
+        return Mock()
+
+    @pytest.fixture
+    def manifest(self):
+        manifest = Mock()
+        manifest.core.software.juju.bootstrap_model_configs.get.return_value = {}
+        return manifest
+
+    @pytest.fixture
+    def deployment(self):
+        dep = Mock()
+        dep.get_proxy_settings.return_value = {}
+        return dep
+
+    def test_run_merges_model_config_onto_db_config(
+        self, tfhelper, manifest, deployment, step_context, snap_patch, snap_mock
+    ):
+        """model_config passed to constructor is merged on top of the DB config."""
+        snap_mock().config.get.return_value = "k8s"
+        db_config = {"workload-storage": "ceph-xfs", "juju-http-proxy": ""}
+        extra_config = {"juju-http-proxy": "http://proxy:3128"}
+
+        with (
+            patch("sunbeam.steps.openstack.read_config", return_value=db_config),
+            patch("sunbeam.steps.openstack.update_config") as mock_update,
+        ):
+            step = UpdateOpenStackModelConfigStep(
+                deployment, tfhelper, manifest, extra_config
+            )
+            result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        saved = mock_update.call_args[0][2]
+        assert saved["workload-storage"] == "ceph-xfs"
+        assert saved["juju-http-proxy"] == "http://proxy:3128"
+
+    def test_run_saves_updated_config_to_db(
+        self, tfhelper, manifest, deployment, step_context, snap_patch, snap_mock
+    ):
+        """Updated final_config is persisted back to OPENSTACK_MODEL_CONFIG_KEY."""
+        snap_mock().config.get.return_value = "k8s"
+        db_config = {"workload-storage": "ceph-xfs"}
+
+        with (
+            patch("sunbeam.steps.openstack.read_config", return_value=db_config),
+            patch("sunbeam.steps.openstack.update_config") as mock_update,
+        ):
+            step = UpdateOpenStackModelConfigStep(deployment, tfhelper, manifest)
+            step.run(step_context)
+
+        mock_update.assert_called_once_with(
+            deployment.get_client(),
+            OPENSTACK_MODEL_CONFIG_KEY,
+            {"workload-storage": "ceph-xfs"},
+        )
+
+    def test_run_tf_apply_failed(
+        self, tfhelper, manifest, deployment, step_context, snap_patch, snap_mock
+    ):
+        """Returns FAILED result when terraform raises TerraformException."""
+        snap_mock().config.get.return_value = "k8s"
+        tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
+            "apply failed"
+        )
+
+        with (
+            patch("sunbeam.steps.openstack.read_config", return_value={}),
+            patch("sunbeam.steps.openstack.update_config"),
+        ):
+            step = UpdateOpenStackModelConfigStep(deployment, tfhelper, manifest)
+            result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "apply failed" in result.message
+
+    def test_run_backward_compat_key_absent_builds_baseline(
+        self, tfhelper, manifest, deployment, step_context, snap_patch, snap_mock
+    ):
+        """Backward compat: when OPENSTACK_MODEL_CONFIG_KEY is absent, baseline.
+
+        Baseline is built from bootstrap_model_configs + proxy settings
+        + workload-storage.
+        """
+        snap_mock().config.get.return_value = "k8s"
+        manifest.core.software.juju.bootstrap_model_configs.get.return_value = {
+            "logging-config": "<root>=DEBUG"
+        }
+        deployment.get_proxy_settings.return_value = {"HTTP_PROXY": "http://p:3128"}
+
+        with (
+            patch(
+                "sunbeam.steps.openstack.read_config",
+                side_effect=ConfigItemNotFoundException("absent"),
+            ),
+            patch("sunbeam.steps.openstack.update_config") as mock_update,
+        ):
+            step = UpdateOpenStackModelConfigStep(deployment, tfhelper, manifest)
+            result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        saved = mock_update.call_args[0][2]
+        assert saved["logging-config"] == "<root>=DEBUG"
+        assert saved["juju-http-proxy"] == "http://p:3128"
+        assert "workload-storage" in saved
+
+    def test_run_backward_compat_no_proxy(
+        self, tfhelper, manifest, deployment, step_context, snap_patch, snap_mock
+    ):
+        """Backward compat: empty proxy settings are handled gracefully."""
+        snap_mock().config.get.return_value = "k8s"
+        deployment.get_proxy_settings.return_value = {}
+
+        with (
+            patch(
+                "sunbeam.steps.openstack.read_config",
+                side_effect=ConfigItemNotFoundException("absent"),
+            ),
+            patch("sunbeam.steps.openstack.update_config"),
+        ):
+            step = UpdateOpenStackModelConfigStep(deployment, tfhelper, manifest)
+            result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+
+
+class TestDeployControlPlaneStepModelConfigPersisted:
+    """Verifies that DeployControlPlaneStep persists model config to the DB."""
+
+    def test_run_saves_model_config_to_db(
+        self,
+        deployment_with_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        config_mock,
+        snap_patch,
+        snap_mock,
+        step_context,
+    ):
+        """Verify OPENSTACK_MODEL_CONFIG_KEY is written to DB.
+
+        Checks that DeployControlPlaneStep.run() persists the key.
+        """
+        snap_mock().config.get.return_value = "k8s"
+        basic_jhelper.get_application_names.return_value = []
+        deployment_with_client.get_ovn_manager().get_control_plane_tfvars.return_value = {}
+
+        step = DeployControlPlaneStep(
+            deployment_with_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            TOPOLOGY,
+            MODEL,
+        )
+
+        with patch("sunbeam.steps.openstack.update_config") as mock_update:
+            step.run(step_context)
+
+        saved_keys = [call[0][1] for call in mock_update.call_args_list]
+        assert OPENSTACK_MODEL_CONFIG_KEY in saved_keys
+        model_config_call = next(
+            c
+            for c in mock_update.call_args_list
+            if c[0][1] == OPENSTACK_MODEL_CONFIG_KEY
+        )
+        saved_config = model_config_call[0][2]
+        assert "workload-storage" in saved_config
 
     def test_missing_extra_key_ignored(self, manifest_read_config, snap):
         """Missing extra config keys are silently skipped."""


### PR DESCRIPTION
Juju's --model-default bootstrap args are stored keyed to the controller's cloud, so they are not inherited by the openstack model which is deployed on a separately-added K8s cloud. This means fields like logging-config in JujuManifest.bootstrap_model_configs were silently ignored for the openstack model.

Fix this by explicitly building the model config in DeployControlPlaneStep.run() using the merge priority:
  manifest bootstrap_model_configs → proxy settings → workload-storage

The resulting config is persisted to cluster DB under the new OPENSTACK_MODEL_CONFIG_KEY so that UpdateOpenStackModelConfigStep can read, merge any additional caller-supplied overrides, save back, and pass to terraform — without needing the caller to pre-compute it.

UpdateOpenStackModelConfigStep is refactored to be self-contained:
- model_config constructor arg is optional (defaults to {})
- reads the DB key as the base, merges model_config on top
- backward compatibility: if the DB key is absent (pre-existing deployment), reconstructs the baseline from manifest + proxy + workload-storage, following the same priority as DeployControlPlaneStep