### PR TITLE
fix: resolve K8s node name by label for cilium pod restart

### DIFF
--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -1485,7 +1485,39 @@ class EnsureCiliumDeviceByHostStep(_PerHostK8SResourceStep):
             outdated.remove(hostname)
         return outdated, deleted
 
-    def _find_cilium_pod(self, node_name: str) -> "core_v1.Pod":
+    def _resolve_k8s_node_name(self, sunbeam_name: str) -> str:
+        """Resolve the K8s node name from the sunbeam hostname label.
+
+        Sunbeam identifies nodes by FQDN while Kubernetes may use a short
+        hostname for ``metadata.name`` and ``spec.nodeName``.  Look up the
+        K8s node by its ``sunbeam/hostname`` label (set by
+        ``EnsureK8SUnitsTaggedStep``) and return the authoritative
+        ``metadata.name``.
+        """
+        try:
+            nodes = list_nodes(self.kube, labels={HOSTNAME_LABEL: sunbeam_name})
+        except K8SError as e:
+            raise SunbeamException(
+                f"Failed to resolve K8s node name for {sunbeam_name}"
+            ) from e
+        if not nodes:
+            raise SunbeamException(
+                f"No K8s node found with label {HOSTNAME_LABEL}={sunbeam_name}"
+            )
+        if len(nodes) > 1:
+            names = [
+                str(n.metadata.name) if n.metadata else "<no metadata>" for n in nodes
+            ]
+            raise SunbeamException(
+                f"Multiple K8s nodes found with label "
+                f"{HOSTNAME_LABEL}={sunbeam_name}: {names}"
+            )
+        node = nodes[0]
+        if node.metadata is None or node.metadata.name is None:
+            raise SunbeamException(f"K8s node for {sunbeam_name} has no metadata.name")
+        return str(node.metadata.name)
+
+    def _find_cilium_pod(self, k8s_node_name: str) -> "core_v1.Pod":
         pods = list(
             self.kube.list(
                 core_v1.Pod,
@@ -1494,11 +1526,11 @@ class EnsureCiliumDeviceByHostStep(_PerHostK8SResourceStep):
             )
         )
         for pod in pods:
-            if pod.spec and pod.spec.nodeName == node_name:
+            if pod.spec and pod.spec.nodeName == k8s_node_name:
                 return pod
-        raise SunbeamException(f"No cilium pod found on node {node_name}")
+        raise SunbeamException(f"No cilium pod found on node {k8s_node_name}")
 
-    def _wait_for_cilium_ready(self, node_name: str, deleted_pod_name: str) -> None:
+    def _wait_for_cilium_ready(self, k8s_node_name: str, deleted_pod_name: str) -> None:
         """Wait until a NEW Ready cilium pod exists on the given node.
 
         Skips pods matching ``deleted_pod_name`` so the terminating pod
@@ -1520,7 +1552,7 @@ class EnsureCiliumDeviceByHostStep(_PerHostK8SResourceStep):
                 ) from e
 
             for pod in pods:
-                if pod.spec and pod.spec.nodeName == node_name:
+                if pod.spec and pod.spec.nodeName == k8s_node_name:
                     pod_name = (
                         pod.metadata.name
                         if pod.metadata and pod.metadata.name
@@ -1534,25 +1566,26 @@ class EnsureCiliumDeviceByHostStep(_PerHostK8SResourceStep):
                                 LOG.debug(
                                     "New cilium pod %s on %s is Ready",
                                     pod_name,
-                                    node_name,
+                                    k8s_node_name,
                                 )
                                 return
-            LOG.debug("Waiting for cilium pod on %s to be Ready", node_name)
+            LOG.debug("Waiting for cilium pod on %s to be Ready", k8s_node_name)
             time.sleep(self._RESTART_POLL_INTERVAL)
 
         raise SunbeamException(
-            f"Cilium pod on {node_name} did not become Ready "
+            f"Cilium pod on {k8s_node_name} did not become Ready "
             f"within {self._RESTART_TIMEOUT}s"
         )
 
-    def _restart_cilium_on_node(self, node_name: str) -> None:
-        pod = self._find_cilium_pod(node_name)
+    def _restart_cilium_on_node(self, sunbeam_node_name: str) -> None:
+        k8s_node_name = self._resolve_k8s_node_name(sunbeam_node_name)
+        pod = self._find_cilium_pod(k8s_node_name)
         pod_name = (
             pod.metadata.name if pod.metadata and pod.metadata.name else "unknown"
         )
-        LOG.debug("Deleting cilium pod %s on node %s", pod_name, node_name)
+        LOG.debug("Deleting cilium pod %s on node %s", pod_name, k8s_node_name)
         self.kube.delete(core_v1.Pod, pod_name, namespace=self._CILIUM_NAMESPACE)
-        self._wait_for_cilium_ready(node_name, deleted_pod_name=pod_name)
+        self._wait_for_cilium_ready(k8s_node_name, deleted_pod_name=pod_name)
 
     def run(self, context: StepContext) -> Result:
         """Apply or delete CiliumNodeConfig resources and restart cilium pods."""

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -21,6 +21,8 @@ from sunbeam.core.juju import (
     LeaderNotFoundException,
     MachineNotFoundException,
 )
+from sunbeam.core.k8s import K8SError
+from sunbeam.errors import SunbeamException
 from sunbeam.steps.k8s import (
     CREDENTIAL_SUFFIX,
     K8S_CLOUD_SUFFIX,
@@ -1605,6 +1607,7 @@ class TestEnsureCiliumDeviceByHostStep:
         step.to_update = [{"name": "node1", "machineid": "1"}]
         step.to_delete = []
         step._get_interface = Mock(return_value="eth0")
+        step._resolve_k8s_node_name = Mock(return_value="node1")
         step.kube.apply = Mock()
         step.kube.patch = Mock()
 
@@ -1642,6 +1645,7 @@ class TestEnsureCiliumDeviceByHostStep:
         ]
         step.to_delete = []
         step._get_interface = Mock(side_effect=["eth0", "eth1"])
+        step._resolve_k8s_node_name = Mock(side_effect=lambda n: n)
         step.kube.apply = Mock()
         step.kube.patch = Mock()
 
@@ -1684,6 +1688,7 @@ class TestEnsureCiliumDeviceByHostStep:
     def test_run_deletes_stale_config(self, step):
         step.to_update = []
         step.to_delete = [{"name": "node2"}]
+        step._resolve_k8s_node_name = Mock(return_value="node2")
         step.kube.delete = Mock()
 
         old_pod = Mock()
@@ -1735,6 +1740,7 @@ class TestEnsureCiliumDeviceByHostStep:
         step.to_update = [{"name": "node1", "machineid": "1"}]
         step.to_delete = []
         step._get_interface = Mock(return_value="eth0")
+        step._resolve_k8s_node_name = Mock(return_value="node1")
         step.kube.apply = Mock()
         step.kube.list = Mock(return_value=[])
 
@@ -1747,6 +1753,7 @@ class TestEnsureCiliumDeviceByHostStep:
         step.to_update = [{"name": "node1", "machineid": "1"}]
         step.to_delete = []
         step._get_interface = Mock(return_value="eth0")
+        step._resolve_k8s_node_name = Mock(return_value="node1")
         step.kube.apply = Mock()
 
         old_pod = Mock()
@@ -1783,6 +1790,7 @@ class TestEnsureCiliumDeviceByHostStep:
         step.to_update = [{"name": "node1", "machineid": "1"}]
         step.to_delete = []
         step._get_interface = Mock(return_value="eth0")
+        step._resolve_k8s_node_name = Mock(return_value="node1")
         step.kube.apply = Mock()
         step.kube.patch = Mock()
 
@@ -1837,3 +1845,106 @@ class TestEnsureCiliumDeviceByHostStep:
         step.kube.list = Mock(return_value=[config])
         outdated, deleted = step._get_outdated_resources(control_nodes, step.kube)
         assert "node1" in outdated
+
+    def test_resolve_k8s_node_name(self, step):
+        """_resolve_k8s_node_name queries K8s node by sunbeam/hostname label."""
+        k8s_node = Mock()
+        k8s_node_meta = Mock()
+        k8s_node_meta.name = "node1"
+        k8s_node.metadata = k8s_node_meta
+
+        with patch("sunbeam.steps.k8s.list_nodes", return_value=[k8s_node]):
+            result = step._resolve_k8s_node_name("node1.maas")
+
+        assert result == "node1"
+
+    def test_resolve_k8s_node_name_not_found(self, step):
+        """_resolve_k8s_node_name raises when no K8s node matches."""
+        with patch("sunbeam.steps.k8s.list_nodes", return_value=[]):
+            with pytest.raises(SunbeamException, match="No K8s node found"):
+                step._resolve_k8s_node_name("node1.maas")
+
+    def test_run_fqdn_vs_short_hostname(self, step):
+        """Full flow: sunbeam FQDN resolved to K8s short hostname for pod lookup."""
+        step.to_update = [{"name": "node1.maas", "machineid": "1"}]
+        step.to_delete = []
+        step._get_interface = Mock(return_value="eth0")
+        step.kube.apply = Mock()
+        step.kube.patch = Mock()
+
+        # _resolve_k8s_node_name returns the short hostname
+        k8s_node = Mock()
+        k8s_node_meta = Mock()
+        k8s_node_meta.name = "node1"
+        k8s_node.metadata = k8s_node_meta
+
+        # k8s pod has short hostname in spec.nodeName
+        old_pod = Mock()
+        old_pod.metadata = Mock(name="cilium-abc")
+        old_pod.spec = Mock(nodeName="node1")
+        new_pod = Mock()
+        new_pod.metadata = Mock(name="cilium-xyz")
+        new_pod.spec = Mock(nodeName="node1")
+        new_pod.status = Mock(conditions=[Mock(type="Ready", status="True")])
+
+        call_count = [0]
+
+        def list_side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [old_pod]  # _find_cilium_pod
+            return [new_pod]  # _wait_for_cilium_ready
+
+        step.kube.list = Mock(side_effect=list_side_effect)
+        step.kube.delete = Mock()
+
+        with patch("sunbeam.steps.k8s.list_nodes", return_value=[k8s_node]):
+            result = step.run(None)
+
+        step.kube.apply.assert_called_once()
+        step.kube.patch.assert_called_once()
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_resolve_k8s_node_name_multiple_matches(self, step):
+        """_resolve_k8s_node_name raises when multiple K8s nodes share the label."""
+        node1 = Mock()
+        node1_meta = Mock()
+        node1_meta.name = "node1-a"
+        node1.metadata = node1_meta
+        node2 = Mock()
+        node2_meta = Mock()
+        node2_meta.name = "node1-b"
+        node2.metadata = node2_meta
+
+        with patch("sunbeam.steps.k8s.list_nodes", return_value=[node1, node2]):
+            with pytest.raises(SunbeamException, match="Multiple K8s nodes found"):
+                step._resolve_k8s_node_name("node1.maas")
+
+    def test_resolve_k8s_node_name_k8s_error(self, step):
+        """_resolve_k8s_node_name raises when the K8s API call fails."""
+        with patch("sunbeam.steps.k8s.list_nodes", side_effect=K8SError("api down")):
+            with pytest.raises(SunbeamException, match="Failed to resolve"):
+                step._resolve_k8s_node_name("node1.maas")
+
+    def test_resolve_k8s_node_name_no_metadata(self, step):
+        """_resolve_k8s_node_name raises when matched node has no metadata."""
+        k8s_node = Mock()
+        k8s_node.metadata = None
+
+        with patch("sunbeam.steps.k8s.list_nodes", return_value=[k8s_node]):
+            with pytest.raises(SunbeamException, match="has no metadata.name"):
+                step._resolve_k8s_node_name("node1.maas")
+
+    def test_run_delete_node_already_gone(self, step):
+        """If K8s node is gone, config is deleted and restart is skipped."""
+        step.to_update = []
+        step.to_delete = [{"name": "gone-node.maas"}]
+        step.kube.delete = Mock()
+
+        with patch("sunbeam.steps.k8s.list_nodes", return_value=[]):
+            result = step.run(None)
+
+        # Config deletion should still happen
+        step.kube.delete.assert_called_once()
+        # Step completes (restart failure is swallowed for delete path)
+        assert result.result_type == ResultType.COMPLETED


### PR DESCRIPTION
Sunbeam identifies nodes by FQDN (e.g. node.maas) while Kubernetes uses the short hostname (e.g. node) in spec.nodeName.  The cilium pod restart compared spec.nodeName against the FQDN directly, so the lookup always missed and bootstrap failed.

- Add _resolve_k8s_node_name(): queries K8s node by sunbeam/hostname label (set by EnsureK8SUnitsTaggedStep) and returns the authoritative metadata.name, same pattern as MetalLB nodeSelector
- Guard against duplicate labels (raises if multiple nodes match)
- _find_cilium_pod and _wait_for_cilium_ready now use the resolved K8s node name instead of the sunbeam FQDN