### PR TITLE
k8s: wait for k8s application after coredns hpa is enabled

### DIFF
--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -106,7 +106,7 @@ K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
 COREDNS_HPA = {
     "enabled": True,
     "minReplicas": 1,
-    "maxReplicas": 5,
+    "maxReplicas": 100,
     "metrics": [
         {
             "type": "Resource",
@@ -114,15 +114,19 @@ COREDNS_HPA = {
                 "name": "cpu",
                 "target": {"type": "Utilization", "averageUtilization": 80},
             },
-        }
-    ],
-    "behavior": {
-        "scaleUp": {"policies": [{"periodSeconds": 30, "type": "Pods", "value": 2}]},
-        "scaleDown": {
-            "stabilizationWindowSeconds": 300,
-            "policies": [{"type": "Pods", "value": 2, "periodSeconds": 60}],
         },
-    },
+        {
+            "type": "Resource",
+            "resource": {
+                "name": "memory",
+                "target": {"type": "Utilization", "averageUtilization": 70},
+            },
+        },
+    ],
+}
+
+COREDNS_PDB = {
+    "minAvailable": 1,
 }
 
 COREDNS_RESOURCES = {
@@ -1997,6 +2001,9 @@ class PatchCoreDNSStep(BaseStep):
 
     This is a workaround for https://github.com/canonical/k8s-operator/issues/504
     Resources and HPA settings are updated for coredns
+    There is a fix in k8s snap but not backported. Here is the bug link
+    https://github.com/canonical/k8s-snap/issues/2456
+    TODO: Remove this class once #2456 is fixed and available in k8s 1.32/stable
     """
 
     def __init__(
@@ -2036,6 +2043,9 @@ class PatchCoreDNSStep(BaseStep):
             LOG.debug("Failed to create k8s client", exc_info=True)
             return Result(ResultType.FAILED, str(e))
 
+        control_nodes = self.client.cluster.list_nodes_by_role("control")
+        self.replica_count = self.compute_coredns_replica_count(len(control_nodes))
+
         try:
             coredns_hpa = self.kube.get(
                 autoscaling_v2.HorizontalPodAutoscaler, name=self.coredns_hpa
@@ -2045,9 +2055,6 @@ class PatchCoreDNSStep(BaseStep):
             if coredns_hpa_spec is None:
                 LOG.debug("Coredns HPA has no spec")
                 return Result(ResultType.COMPLETED)
-
-            control_nodes = self.client.cluster.list_nodes_by_role("control")
-            self.replica_count = self.compute_coredns_replica_count(len(control_nodes))
 
             if self.replica_count == coredns_hpa_spec.minReplicas:
                 return Result(ResultType.SKIPPED)
@@ -2079,13 +2086,17 @@ class PatchCoreDNSStep(BaseStep):
         hpa_dict["minReplicas"] = self.replica_count
         hpa = json.dumps(hpa_dict)
         resources = json.dumps(COREDNS_RESOURCES)
+        pdb = json.dumps(COREDNS_PDB)
         # Note: Applying coredns hpa with modified minReplica will take time
         # to see the scale in, scale out based on policy defined in COREDNS_HPA
         try:
+            set_json = (
+                f"hpa='{hpa}',resources='{resources}',podDisruptionBudget='{pdb}'"
+            )
             cmd_str = (
                 f"k8s helm upgrade -n {self.coredns_namespace} ck-dns "
                 "/snap/k8s/current/k8s/manifests/charts/coredns-*.tgz"
-                f" --reuse-values --set-json hpa='{hpa}',resources='{resources}'"
+                f" --reuse-values --set-json {set_json}"
             )
             LOG.debug(f"Running cmd in unit {leader}: {cmd_str}")
 
@@ -2107,6 +2118,20 @@ class PatchCoreDNSStep(BaseStep):
                 "Failed to run helm upgrade on coredns",
                 exc_info=True,
             )
+            return Result(ResultType.FAILED, str(e))
+
+        # The helm upgrade modifies the CoreDNS pod template (resources), triggering
+        # a rolling restart. Wait for the k8s application to return to active before
+        # proceeding so that DNS is available when subsequent steps deploy OpenStack.
+        try:
+            self.jhelper.wait_application_ready(
+                self.juju_app_name,
+                self.deployment.openstack_machines_model,
+                accepted_status=["active"],
+                timeout=K8S_APP_TIMEOUT,
+            )
+        except TimeoutError as e:
+            LOG.warning(str(e))
             return Result(ResultType.FAILED, str(e))
 
         return Result(ResultType.COMPLETED)

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -25,6 +25,7 @@ from sunbeam.core.k8s import K8SError
 from sunbeam.errors import SunbeamException
 from sunbeam.steps.k8s import (
     CREDENTIAL_SUFFIX,
+    K8S_APP_TIMEOUT,
     K8S_CLOUD_SUFFIX,
     AddK8SCloudStep,
     AddK8SCredentialStep,
@@ -1261,6 +1262,40 @@ class TestPatchCoreDNSStep:
             result = step.is_skip(step_context)
         assert result.result_type == ResultType.COMPLETED
 
+    def test_is_skip_no_hpa_computes_replica_count(self, step, kube, step_context):
+        """Replica count must be derived from control-node count even without HPA.
+
+        Previously replica_count defaulted to 1 because the computation was inside
+        the try-block that raised on 404.
+        """
+        control_nodes = [
+            {"name": "node1", "machineid": "1"},
+            {"name": "node2", "machineid": "2"},
+            {"name": "node3", "machineid": "3"},
+        ]
+        step.client.cluster.list_nodes_by_role.return_value = control_nodes
+        api_error = ApiError(
+            Mock(),
+            httpx.Response(
+                status_code=404,
+                content=json.dumps(
+                    {
+                        "code": 404,
+                        "message": "horizontalpodautoscalers.autoscaling"
+                        ' "ck-dns-coredns" not found',
+                    }
+                ),
+            ),
+        )
+        kube.get = Mock(side_effect=api_error)
+
+        with patch("sunbeam.steps.k8s.get_kube_client", return_value=kube):
+            result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        # 3 control nodes → replica_count must be 3, not the default 1
+        assert step.replica_count == 3
+
     def test_is_skip_kube_get_error(self, step, kube, step_context):
         api_error = ApiError(
             Mock(),
@@ -1334,6 +1369,7 @@ class TestPatchCoreDNSStep:
         assert result.result_type == ResultType.COMPLETED
         jhelper.get_leader_unit.assert_called_once()
         jhelper.run_cmd_on_machine_unit_payload.assert_called_once()
+        jhelper.wait_application_ready.assert_called_once()
 
     def test_run_helm_upgrade_failed(self, step, jhelper):
         jhelper.run_cmd_on_machine_unit_payload.return_value = Mock(return_code=1)
@@ -1341,6 +1377,7 @@ class TestPatchCoreDNSStep:
         assert result.result_type == ResultType.FAILED
         jhelper.get_leader_unit.assert_called_once()
         jhelper.run_cmd_on_machine_unit_payload.assert_called_once()
+        jhelper.wait_application_ready.assert_not_called()
 
     def test_run_failed_on_juju_run_on_machine_unit(self, step, jhelper):
         jhelper.run_cmd_on_machine_unit_payload.side_effect = JujuException(
@@ -1350,6 +1387,7 @@ class TestPatchCoreDNSStep:
         assert result.result_type == ResultType.FAILED
         jhelper.get_leader_unit.assert_called_once()
         jhelper.run_cmd_on_machine_unit_payload.assert_called_once()
+        jhelper.wait_application_ready.assert_not_called()
 
     def test_run_leader_not_found(self, step, jhelper):
         jhelper.get_leader_unit.side_effect = LeaderNotFoundException(
@@ -1359,6 +1397,35 @@ class TestPatchCoreDNSStep:
         assert result.result_type == ResultType.FAILED
         jhelper.get_leader_unit.assert_called_once()
         jhelper.run_cmd_on_machine_unit_payload.assert_not_called()
+        jhelper.wait_application_ready.assert_not_called()
+
+    def test_run_waits_for_k8s_application_ready(self, step, jhelper):
+        """wait_application_ready must be called after a successful helm upgrade.
+
+        Ensures DNS is available before subsequent OpenStack deployment steps.
+        """
+        jhelper.run_cmd_on_machine_unit_payload.return_value = Mock(return_code=0)
+        result = step.run(None)
+        assert result.result_type == ResultType.COMPLETED
+        jhelper.wait_application_ready.assert_called_once_with(
+            "k8s",
+            step.deployment.openstack_machines_model,
+            accepted_status=["active"],
+            timeout=K8S_APP_TIMEOUT,
+        )
+
+    def test_run_wait_application_ready_timeout(self, step, jhelper):
+        """A TimeoutError from wait_application_ready must propagate as FAILED.
+
+        Ensures the deployment does not silently proceed with DNS unavailable.
+        """
+        jhelper.run_cmd_on_machine_unit_payload.return_value = Mock(return_code=0)
+        jhelper.wait_application_ready.side_effect = TimeoutError(
+            "Timed out waiting for k8s to be ready"
+        )
+        result = step.run(None)
+        assert result.result_type == ResultType.FAILED
+        jhelper.wait_application_ready.assert_called_once()
 
 
 class TestPatchServiceExternalTrafficStep:


### PR DESCRIPTION
Currently PatchCoreDnsStep applies hpa policy on coredns but not waiting for k8s application to settle to active/idle. Add logic to wait for k8s application to be active once coredns hpa is applied.

Fix a bug in updating hpa replica based on number of control nodes irrespective of existence of hpa policy.

Fixes LP#2148639
Fixes LP#2148371