### PR TITLE
tics: add prerequisite packages

### DIFF
--- a/.github/workflows/TiCS.yml
+++ b/.github/workflows/TiCS.yml
@@ -43,6 +43,7 @@ jobs:
           run: |
             uv sync --all-extras
             source .venv/bin/activate
+            echo PATH=$PATH >> $GITHUB_ENV
 
         - name: TICS
           uses: tiobe/tics-github-action@v3

--- a/sunbeam-python/pyproject.toml
+++ b/sunbeam-python/pyproject.toml
@@ -112,6 +112,7 @@ dev = [
     "mypy",
     "python-watcherclient",
 ]
+tics = ["pylint", "flake8"]
 
 [project.urls]
 "Homepage" = "https://github.com/canonical/snap-openstack"


### PR DESCRIPTION
Add packages required for tics in pyporject.toml
Pass PATH env to GITHUB_PATH so that uv venv is
considered in tics execution