### PR TITLE
fix: handle race condition when joining first storage node

### DIFF
--- a/sunbeam-python/sunbeam/core/steps.py
+++ b/sunbeam-python/sunbeam/core/steps.py
@@ -72,6 +72,7 @@ class DeployMachineApplicationStep(BaseStep):
         roles: list[Role] | list[list[Role]] | None = None,
         banner: str = "",
         description: str = "",
+        wait_for_readiness: bool = True,
     ):
         super().__init__(banner, description)
         self.deployment = deployment
@@ -83,6 +84,7 @@ class DeployMachineApplicationStep(BaseStep):
         self.application = application
         self.model = model
         self.roles = roles or []
+        self.wait_for_readiness = wait_for_readiness
 
     def extra_tfvars(self) -> dict:
         """Extra terraform vars to pass to terraform apply."""
@@ -147,16 +149,17 @@ class DeployMachineApplicationStep(BaseStep):
 
         # Note(gboutry): application is in state unknown when it's deployed
         # without units
-        try:
-            self.jhelper.wait_application_ready(
-                self.application,
-                self.model,
-                accepted_status=self.get_accepted_application_status(),
-                timeout=self.get_application_timeout(),
-            )
-        except TimeoutError as e:
-            LOG.warning(str(e))
-            return Result(ResultType.FAILED, str(e))
+        if self.wait_for_readiness:
+            try:
+                self.jhelper.wait_application_ready(
+                    self.application,
+                    self.model,
+                    accepted_status=self.get_accepted_application_status(),
+                    timeout=self.get_application_timeout(),
+                )
+            except TimeoutError as e:
+                LOG.warning(str(e))
+                return Result(ResultType.FAILED, str(e))
 
         return Result(ResultType.COMPLETED)
 

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -1599,17 +1599,69 @@ def join(  # noqa: C901
             )
 
     if is_storage_node:
-        plan4.append(TerraformInitStep(microceph_tfhelper))
-        plan4.append(
-            DeployMicrocephApplicationStep(
-                deployment,
-                client,
-                microceph_tfhelper,
-                jhelper,
-                manifest,
-                deployment.openstack_machines_model,
-            )
+        # Check if this is the first storage node joining
+        is_first_storage_node = (
+            len(client.cluster.list_nodes_by_role(Role.STORAGE.name.lower())) <= 1
         )
+
+        if is_first_storage_node:
+            # Deploy MicroCeph WITHOUT waiting
+            # The charm will be stuck in "waiting" because it needs traefik-route-rgw
+            # integration which doesn't exist as enable-ceph=False.
+            plan4.append(TerraformInitStep(microceph_tfhelper))
+            plan4.append(
+                DeployMicrocephApplicationStep(
+                    deployment,
+                    client,
+                    microceph_tfhelper,
+                    jhelper,
+                    manifest,
+                    deployment.openstack_machines_model,
+                    wait_for_readiness=False,
+                )
+            )
+
+            # Redeploy control plane with enable-ceph=true
+            plan4.append(
+                DeployControlPlaneStep(
+                    deployment,
+                    openstack_tfhelper,
+                    jhelper,
+                    manifest,
+                    "auto",
+                    deployment.openstack_machines_model,
+                    is_region_controller=is_region_controller,
+                )
+            )
+
+            # Redeploy MicroCeph with output from OS TF variables related to
+            # traefik-rgw/keystone-endpoints offers from openstack model
+            microceph_tfhelper = deployment.get_tfhelper("microceph-plan")
+            plan4.append(TerraformInitStep(microceph_tfhelper))
+            plan4.append(
+                DeployMicrocephApplicationStep(
+                    deployment,
+                    client,
+                    microceph_tfhelper,
+                    jhelper,
+                    manifest,
+                    deployment.openstack_machines_model,
+                )
+            )
+        else:
+            # Deploy MicroCeph directly with blocking as OS TF variables are already set
+            plan4.append(TerraformInitStep(microceph_tfhelper))
+            plan4.append(
+                DeployMicrocephApplicationStep(
+                    deployment,
+                    client,
+                    microceph_tfhelper,
+                    jhelper,
+                    manifest,
+                    deployment.openstack_machines_model,
+                )
+            )
+
         plan4.append(
             ConfigureMicrocephOSDStep(
                 client,
@@ -1630,49 +1682,6 @@ def join(  # noqa: C901
                 deployment.openstack_machines_model,
             )
         )
-
-        # Re-deploy control plane if this is the first storage node joining
-        # the cluster to enable mandatory storage services
-        storage_nodes = client.cluster.list_nodes_by_role(Role.STORAGE.name.lower())
-        if len(storage_nodes) == 1:
-            plan4.append(
-                DeployControlPlaneStep(
-                    deployment,
-                    openstack_tfhelper,
-                    jhelper,
-                    manifest,
-                    "auto",
-                    deployment.openstack_machines_model,
-                    is_region_controller=is_region_controller,
-                )
-            )
-
-            # Redeploy of Microceph is required to fill terraform vars
-            # related to traefik-rgw/keystone-endpoints offers from
-            # openstack model
-            microceph_tfhelper = deployment.get_tfhelper("microceph-plan")
-            plan4.append(TerraformInitStep(microceph_tfhelper))
-            plan4.append(
-                DeployMicrocephApplicationStep(
-                    deployment,
-                    client,
-                    microceph_tfhelper,
-                    jhelper,
-                    manifest,
-                    deployment.openstack_machines_model,
-                )
-            )
-            # Fill AMQP / Keystone / MySQL offers from openstack model
-            plan4.append(
-                DeployCinderVolumeApplicationStep(
-                    deployment,
-                    client,
-                    cinder_volume_tfhelper,
-                    jhelper,
-                    manifest,
-                    deployment.openstack_machines_model,
-                )
-            )
 
         plan4.append(
             ReapplyHypervisorOptionalIntegrationsStep(

--- a/sunbeam-python/sunbeam/steps/microceph.py
+++ b/sunbeam-python/sunbeam/steps/microceph.py
@@ -103,6 +103,7 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
         jhelper: JujuHelper,
         manifest: Manifest,
         model: str,
+        wait_for_readiness: bool = True,
     ):
         super().__init__(
             deployment,
@@ -116,6 +117,7 @@ class DeployMicrocephApplicationStep(DeployMachineApplicationStep):
             [Role.STORAGE],
             "Deploy MicroCeph",
             "Deploying MicroCeph",
+            wait_for_readiness=wait_for_readiness,
         )
 
     def get_application_timeout(self) -> int:

--- a/sunbeam-python/tests/unit/sunbeam/storage/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/test_steps.py
@@ -7,7 +7,9 @@ from unittest.mock import Mock, patch
 import pydantic
 import pytest
 
+from sunbeam.core.common import ResultType
 from sunbeam.core.questions import PasswordPromptQuestion, PromptQuestion
+from sunbeam.core.steps import DeployMachineApplicationStep
 from sunbeam.storage.models import SecretDictField
 from sunbeam.storage.steps import (
     DeploySpecificCinderVolumeStep,
@@ -356,3 +358,34 @@ class TestDeploySpecificCinderVolumeStep:
             ]
             is True
         )
+
+        def test_deploy_machine_application_step_run_skips_wait(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            test_model,
+            step_context,
+        ):
+            step = DeployMachineApplicationStep(
+                basic_deployment,
+                basic_client,
+                basic_tfhelper,
+                basic_jhelper,
+                basic_manifest,
+                config="test-config",
+                application="test-app",
+                model=test_model,
+                roles=[],
+                wait_for_readiness=False,
+            )
+
+            basic_jhelper.get_model_uuid.return_value = "model-uuid"
+            basic_client.cluster.list_nodes_by_role.return_value = []
+
+            result = step.run(step_context)
+
+            assert result.result_type == ResultType.COMPLETED
+            basic_tfhelper.update_tfvars_and_apply_tf.assert_called_once()
+            basic_jhelper.wait_application_ready.assert_not_called()


### PR DESCRIPTION
When adding the first storage node to the cluster that previously contains no storage nodes, the join operation will stall.

This is because `DeployMicrocephApplicationStep` waits for the MicroCeph charm to be active, while it requires `traefik-route-rgw` relation to register with Keystone. The relation does not exist because it requires `enable-ceph: True` in the control plane.

We fix by allowing the first MicroCeph deployment to be non-blocking and then redeploying the control plane. This will establish the required relations and allow us to do blocking redeployment of the MicroCeph charm.

Also removed the redundant `DeployCinderVolumeApplicationStep`.

Closes-Bug: #2149906