### PR TITLE
fix: Use merge patch for CiliumNodeConfig annotation

### DIFF
--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -81,12 +81,14 @@ if typing.TYPE_CHECKING:
     import lightkube.config.kubeconfig as l_kubeconfig
     import lightkube.core.client as l_client
     import lightkube.core.exceptions as l_exceptions
+    import lightkube.types as l_patch_type
     from lightkube.models import meta_v1
     from lightkube.resources import apps_v1, autoscaling_v2, core_v1
 else:
     l_kubeconfig = LazyImport("lightkube.config.kubeconfig")
     l_client = LazyImport("lightkube.core.client")
     l_exceptions = LazyImport("lightkube.core.exceptions")
+    l_patch_type = LazyImport("lightkube.types")
     meta_v1 = LazyImport("lightkube.models.meta_v1")
     apps_v1 = LazyImport("lightkube.resources.apps_v1")
     autoscaling_v2 = LazyImport("lightkube.resources.autoscaling_v2")
@@ -1657,6 +1659,7 @@ class EnsureCiliumDeviceByHostStep(_PerHostK8SResourceStep):
                         }
                     },
                     namespace=self._CILIUM_NAMESPACE,
+                    patch_type=l_patch_type.PatchType.MERGE,
                 )
             except l_exceptions.ApiError:
                 LOG.debug(

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -11,6 +11,7 @@ import lightkube.core.exceptions
 import pytest
 import tenacity
 from lightkube import ApiError
+from lightkube.types import PatchType
 
 from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.core.common import ResultType
@@ -1804,7 +1805,19 @@ class TestEnsureCiliumDeviceByHostStep:
         result = step.run(None)
 
         step.kube.apply.assert_called_once()
-        step.kube.patch.assert_called_once()  # clears restart-pending
+        step.kube.patch.assert_called_once_with(
+            step.cilium_node_config_resource,
+            "cilium-devices-node1",
+            {
+                "metadata": {
+                    "annotations": {
+                        "sunbeam/restart-pending": "false",
+                    }
+                }
+            },
+            namespace="kube-system",
+            patch_type=PatchType.MERGE,
+        )
         assert result.result_type == ResultType.COMPLETED
 
     def test_run_updates_config(self, step):


### PR DESCRIPTION
CiliumNodeConfig is a CRD and rejects strategic merge patch. Use JSON merge patch when clearing the restart-pending annotation after a Cilium restart.