### PR TITLE
fix: decrease tolerationSeconds to 60s in k8s apiserver args

### DIFF
--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -104,6 +104,9 @@ K8S_DESTROY_TIMEOUT = 900
 K8S_UNIT_TIMEOUT = 1800  # 30 minutes, adding / removing units can take a long time
 K8S_ENABLE_ADDONS_TIMEOUT = 300  # 5 minutes
 K8SD_SNAP_SOCKET = "/var/snap/k8s/common/var/lib/k8sd/state/control.socket"
+# Toleration seconds for node failure recovery k8s default of 5 min to 1 min
+DEFAULT_NOT_READY_TOLERATION_SECONDS = 60
+DEFAULT_UNREACHABLE_TOLERATION_SECONDS = 60
 
 COREDNS_HPA = {
     "enabled": True,
@@ -294,6 +297,22 @@ class DeployK8SApplicationStep(DeployMachineApplicationStep):
         config_tfvars["node-labels"] = " ".join(
             node_label for node_label in node_labels if node_label
         )
+        toleration_settings = {
+            "default-not-ready-toleration-seconds": str(
+                DEFAULT_NOT_READY_TOLERATION_SECONDS
+            ),
+            "default-unreachable-toleration-seconds": str(
+                DEFAULT_UNREACHABLE_TOLERATION_SECONDS
+            ),
+        }
+        existing_apiserver_args = [
+            arg
+            for arg in str(config_tfvars.get("kube-apiserver-extra-args", "")).split()
+            if arg.split("=")[0] not in toleration_settings
+        ]
+        for key, value in toleration_settings.items():
+            existing_apiserver_args.append(f"{key}={value}")
+        config_tfvars["kube-apiserver-extra-args"] = " ".join(existing_apiserver_args)
 
         return config_tfvars
 

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -1560,6 +1560,7 @@ class TestMaasDeployK8SApplicationStep:
                 {"endpoint": "cluster", "space": "internal_space"},
             ],
             "k8s_config": {
+                "kube-apiserver-extra-args": "default-not-ready-toleration-seconds=60 default-unreachable-toleration-seconds=60",
                 "load-balancer-cidrs": "10.0.0.0/28",
                 "load-balancer-enabled": True,
                 "load-balancer-l2-mode": True,

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -1126,6 +1126,24 @@ class TestDeployK8SApplicationStep:
     def test_get_k8s_config_tfvars_does_not_manage_cluster_annotations(self, step):
         assert "cluster-annotations" not in step._get_k8s_config_tfvars()
 
+    def test_get_k8s_config_tfvars_sets_default_toleration_seconds(self, step):
+        config = step._get_k8s_config_tfvars()
+        apiserver_args = config.get("kube-apiserver-extra-args", "")
+        assert "default-not-ready-toleration-seconds=60" in apiserver_args
+        assert "default-unreachable-toleration-seconds=60" in apiserver_args
+
+    def test_get_k8s_config_tfvars_merges_toleration_seconds_with_existing_args(
+        self, step, manifest
+    ):
+        charm_mock = Mock()
+        charm_mock.config = {"kube-apiserver-extra-args": "xyz-flag=true"}
+        manifest.core.software.charms.get.return_value = charm_mock
+        config = step._get_k8s_config_tfvars()
+        apiserver_args = config.get("kube-apiserver-extra-args", "")
+        assert "xyz-flag=true" in apiserver_args
+        assert "default-not-ready-toleration-seconds=60" in apiserver_args
+        assert "default-unreachable-toleration-seconds=60" in apiserver_args
+
 
 class TestGetKubeClient:
     @pytest.fixture


### PR DESCRIPTION
Sets the following options
`-default-not-ready-toleration-seconds int`  
`--default-unreachable-toleration-seconds int`  

Both are reduced from the kubernetes default of 300s to 60s. This is handled by the DefaultTolerationSeconds
admission controller, which is enabled by default in all Kubernetes clusters and injects this toleration into
every new pod when created.

Reference: [https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/)
via config option `kube-apiserver-extra-args` (https://charmhub.io/k8s/configurations#kube-apiserver-extra-args)

**Limitation**

The k8s charm only applies kube-apiserver-extra-args at deployment time (documented limitation). This means existing deployments running `sunbeam cluster refresh` will have juju receive the config but kube-apiserver is not restarted with the new flags
  