### PR TITLE
Add Infinidat storage backend integration

### DIFF
--- a/sunbeam-python/sunbeam/storage/backends/infinidat/__init__.py
+++ b/sunbeam-python/sunbeam/storage/backends/infinidat/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+"""Infinidat backend for Sunbeam storage."""

--- a/sunbeam-python/sunbeam/storage/backends/infinidat/backend.py
+++ b/sunbeam-python/sunbeam/storage/backends/infinidat/backend.py
@@ -4,12 +4,11 @@
 """Infinidat InfiniBox storage backend implementation using base step classes."""
 
 import logging
-from typing import Annotated, Any, Literal
+from typing import Annotated, Literal
 
 from pydantic import Field
 
-from sunbeam.core.deployment import Deployment
-from sunbeam.core.manifest import Manifest, StorageBackendConfig
+from sunbeam.core.manifest import StorageBackendConfig
 from sunbeam.storage.base import StorageBackendBase
 from sunbeam.storage.models import SecretDictField
 

--- a/sunbeam-python/sunbeam/storage/backends/infinidat/backend.py
+++ b/sunbeam-python/sunbeam/storage/backends/infinidat/backend.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+"""Infinidat InfiniBox storage backend implementation using base step classes."""
+
+import logging
+from typing import Annotated, Any, Literal
+
+from pydantic import Field
+
+from sunbeam.core.deployment import Deployment
+from sunbeam.core.manifest import Manifest, StorageBackendConfig
+from sunbeam.storage.base import StorageBackendBase
+from sunbeam.storage.models import SecretDictField
+
+LOG = logging.getLogger(__name__)
+
+
+class InfinidatConfig(StorageBackendConfig):
+    """Static configuration model for Infinidat storage backend."""
+
+    # Mandatory connection parameters
+    san_ip: Annotated[str, Field(description="InfiniBox Management IP")]
+    infinidat_pool_name: Annotated[str, Field(description="InfiniBox Pool Name")]
+    protocol: Annotated[
+        Literal["iscsi", "fc"] | None,
+        Field(description="Storage Protocol (iscsi or fc)"),
+    ] = "iscsi"
+    infinidat_iscsi_netspaces: Annotated[
+        str | None, Field(description="Comma-separated list of iSCSI network spaces")
+    ] = None
+    use_chap_auth: Annotated[
+        bool | None, Field(description="Use CHAP authentication")
+    ] = True
+
+    # Secrets
+    san_login: Annotated[
+        str,
+        Field(description="InfiniBox Username"),
+        SecretDictField(field="san-login"),
+    ]
+    san_password: Annotated[
+        str,
+        Field(description="InfiniBox Password"),
+        SecretDictField(field="san-password"),
+    ]
+    chap_username: Annotated[
+        str | None,
+        Field(description="CHAP Username"),
+        SecretDictField(field="chap-username"),
+    ] = None
+    chap_password: Annotated[
+        str | None,
+        Field(description="CHAP Password"),
+        SecretDictField(field="chap-password"),
+    ] = None
+
+    # Storage provisioning and management
+    infinidat_use_compression: Annotated[
+        bool | None,
+        Field(description="Enable InfiniBox volume compression"),
+    ] = None
+    max_over_subscription_ratio: Annotated[
+        float | None,
+        Field(description="Maximum oversubscription ratio for thin provisioning"),
+    ] = None
+
+
+class InfinidatBackend(StorageBackendBase):
+    """Infinidat Cinder Backend."""
+
+    backend_type = "infinidat"
+    display_name = "Infinidat"
+
+    @property
+    def charm_name(self) -> str:
+        """Return the charm name for this backend."""
+        return "cinder-volume-infinidat"
+
+    @property
+    def charm_channel(self) -> str:
+        """Return the charm channel for this backend."""
+        return "latest/edge"
+
+    @property
+    def charm_revision(self) -> str | None:
+        """Return the charm revision for this backend."""
+        return None
+
+    @property
+    def charm_base(self) -> str:
+        """Return the charm base for this backend."""
+        return "ubuntu@24.04"
+
+    @property
+    def supports_ha(self) -> bool:
+        """Return whether this backend supports HA deployments."""
+        return True
+
+    def config_type(self) -> type[StorageBackendConfig]:
+        """Return the configuration class for Infinidat backend."""
+        return InfinidatConfig

--- a/sunbeam-python/sunbeam/storage/backends/infinidat/backend.py
+++ b/sunbeam-python/sunbeam/storage/backends/infinidat/backend.py
@@ -6,7 +6,7 @@
 import logging
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from sunbeam.core.manifest import StorageBackendConfig
 from sunbeam.storage.base import StorageBackendBase
@@ -22,7 +22,7 @@ class InfinidatConfig(StorageBackendConfig):
     san_ip: Annotated[str, Field(description="InfiniBox Management IP")]
     infinidat_pool_name: Annotated[str, Field(description="InfiniBox Pool Name")]
     protocol: Annotated[
-        Literal["iscsi", "fc"] | None,
+        Literal["iscsi", "fc"],
         Field(description="Storage Protocol (iscsi or fc)"),
     ] = "iscsi"
     infinidat_iscsi_netspaces: Annotated[
@@ -30,7 +30,7 @@ class InfinidatConfig(StorageBackendConfig):
     ] = None
     use_chap_auth: Annotated[
         bool | None, Field(description="Use CHAP authentication")
-    ] = True
+    ] = None
 
     # Secrets
     san_login: Annotated[
@@ -63,6 +63,26 @@ class InfinidatConfig(StorageBackendConfig):
         float | None,
         Field(description="Maximum oversubscription ratio for thin provisioning"),
     ] = None
+
+    @model_validator(mode="after")
+    def chap_credentials_required_when_enabled(self) -> "InfinidatConfig":
+        """Validate CHAP credentials are provided when CHAP auth is enabled."""
+        if self.use_chap_auth:
+            missing = [
+                name
+                for name, val in [
+                    ("chap_username", self.chap_username),
+                    ("chap_password", self.chap_password),
+                ]
+                if not val
+            ]
+            if missing:
+                raise ValueError(
+                    "Status: Blocked - "
+                    + ", ".join(missing)
+                    + " required when use_chap_auth is enabled"
+                )
+        return self
 
 
 class InfinidatBackend(StorageBackendBase):

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/conftest.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/conftest.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common fixtures and utilities for backend-specific tests."""
+
+import pytest
+
+from sunbeam.storage.backends.dellsc.backend import DellSCBackend
+from sunbeam.storage.backends.hitachi.backend import HitachiBackend
+from sunbeam.storage.backends.infinidat.backend import InfinidatBackend
+from sunbeam.storage.backends.purestorage.backend import PureStorageBackend
+
+
+@pytest.fixture
+def hitachi_backend():
+    """Provide a Hitachi backend instance."""
+    return HitachiBackend()
+
+
+@pytest.fixture
+def purestorage_backend():
+    """Provide a Pure Storage backend instance."""
+    return PureStorageBackend()
+
+
+@pytest.fixture
+def dellsc_backend():
+    """Provide a Dell Storage Center backend instance."""
+    return DellSCBackend()
+
+
+@pytest.fixture
+def infinidat_backend():
+    """Provide an Infinidat backend instance."""
+    return InfinidatBackend()
+
+
+@pytest.fixture(params=["hitachi", "purestorage", "dellsc", "infinidat"])
+def any_backend(request):
+    """Parametrized fixture that provides each backend type."""
+    backends = {
+        "hitachi": HitachiBackend(),
+        "purestorage": PureStorageBackend(),
+        "dellsc": DellSCBackend(),
+        "infinidat": InfinidatBackend(),
+    }
+    return backends[request.param]

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/conftest.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from sunbeam.storage.backends.dellsc.backend import DellSCBackend
 from sunbeam.storage.backends.hitachi.backend import HitachiBackend
+from sunbeam.storage.backends.hpe3par.backend import HPEthreeparBackend
 from sunbeam.storage.backends.infinidat.backend import InfinidatBackend
 from sunbeam.storage.backends.purestorage.backend import PureStorageBackend
 

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/test_common.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/test_common.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: 2025 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common base test class for all storage backends.
+
+This module provides a base test class that can be inherited by backend-specific
+test classes to ensure all backends implement the required interface correctly.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from sunbeam.core.manifest import StorageBackendConfig
+from sunbeam.storage.base import StorageBackendBase
+
+
+class BaseBackendTests:
+    """Base test class for all storage backends.
+
+    This class provides common tests that verify each backend implements
+    the required interface and behaves correctly. Backend-specific test
+    classes should inherit from this class and override the `backend` fixture
+    to provide their specific backend instance.
+
+    Example:
+        class TestHitachiBackend(BaseBackendTests):
+            @pytest.fixture
+            def backend(self, hitachi_backend):
+                return hitachi_backend
+    """
+
+    @pytest.fixture
+    def backend(self):
+        """Override this fixture in subclasses to provide the backend instance.
+
+        Raises:
+            NotImplementedError: If not overridden in subclass.
+        """
+        raise NotImplementedError(
+            "Subclasses must override the backend fixture to provide a backend instance"
+        )
+
+    # Core attribute tests
+
+    def test_backend_has_type(self, backend):
+        """Test that backend has a type identifier."""
+        assert hasattr(backend, "backend_type")
+        assert isinstance(backend.backend_type, str)
+        assert len(backend.backend_type) > 0
+
+    def test_backend_has_display_name(self, backend):
+        """Test that backend has a display name."""
+        assert hasattr(backend, "display_name")
+        assert isinstance(backend.display_name, str)
+        assert len(backend.display_name) > 0
+
+    def test_backend_is_storage_backend_base(self, backend):
+        """Test that backend inherits from StorageBackendBase."""
+        assert isinstance(backend, StorageBackendBase)
+
+    # Charm property tests
+
+    def test_charm_name_is_set(self, backend):
+        """Test that charm_name property is set."""
+        assert backend.charm_name
+        assert isinstance(backend.charm_name, str)
+        assert backend.charm_name.startswith("cinder-volume-")
+
+    def test_charm_channel_is_set(self, backend):
+        """Test that charm_channel property is set."""
+        assert backend.charm_channel
+        assert isinstance(backend.charm_channel, str)
+
+    def test_charm_base_is_set(self, backend):
+        """Test that charm_base property is set."""
+        assert backend.charm_base
+        assert isinstance(backend.charm_base, str)
+
+    # Configuration tests
+
+    def test_config_type_returns_class(self, backend):
+        """Test that config_type() returns a class."""
+        config_class = backend.config_type()
+        assert isinstance(config_class, type)
+
+    def test_config_type_is_storage_backend_config(self, backend):
+        """Test that config_type() returns a StorageBackendConfig subclass."""
+        config_class = backend.config_type()
+        assert issubclass(config_class, StorageBackendConfig)
+
+    def test_config_type_is_pydantic_model(self, backend):
+        """Test that config_type() returns a Pydantic model."""
+        config_class = backend.config_type()
+        assert issubclass(config_class, BaseModel)
+
+    # Required field tests
+
+    def test_config_has_san_ip_field(self, backend):
+        """Test that config has san_ip field."""
+        config_class = backend.config_type()
+        assert "san_ip" in config_class.model_fields
+
+    def test_config_has_protocol_field(self, backend):
+        """Test that config has protocol field."""
+        config_class = backend.config_type()
+        # Protocol field should exist
+        assert "protocol" in config_class.model_fields
+
+    # Method existence tests
+
+    def test_has_get_endpoint_bindings_method(self, backend):
+        """Test that backend has get_endpoint_bindings method."""
+        assert hasattr(backend, "get_endpoint_bindings")
+        assert callable(backend.get_endpoint_bindings)
+
+    def test_has_validate_ip_or_fqdn_static_method(self, backend):
+        """Test that backend class has _validate_ip_or_fqdn static method."""
+        # This is a static method on the base class
+        assert hasattr(StorageBackendBase, "_validate_ip_or_fqdn")
+        assert callable(StorageBackendBase._validate_ip_or_fqdn)
+
+    def test_has_register_terraform_plan_method(self, backend):
+        """Test that backend has register_terraform_plan method."""
+        assert hasattr(backend, "register_terraform_plan")
+        assert callable(backend.register_terraform_plan)
+
+    def test_has_add_backend_instance_method(self, backend):
+        """Test that backend has add_backend_instance method."""
+        assert hasattr(backend, "add_backend_instance")
+        assert callable(backend.add_backend_instance)
+
+    def test_has_remove_backend_method(self, backend):
+        """Test that backend has remove_backend method."""
+        assert hasattr(backend, "remove_backend")
+        assert callable(backend.remove_backend)
+
+    def test_has_build_terraform_vars_method(self, backend):
+        """Test that backend has build_terraform_vars method."""
+        assert hasattr(backend, "build_terraform_vars")
+        assert callable(backend.build_terraform_vars)
+
+
+class TestAllBackends(BaseBackendTests):
+    """Test all backends using parametrized fixture.
+
+    This class runs the common tests against all backends to ensure
+    they all implement the required interface consistently.
+    """
+
+    @pytest.fixture
+    def backend(self, any_backend):
+        """Use the parametrized any_backend fixture."""
+        return any_backend
+
+
+# Backend uniqueness tests
+
+
+def test_all_backends_have_unique_types(
+    hitachi_backend, purestorage_backend, dellsc_backend, infinidat_backend
+):
+    """Test that all backends have unique type identifiers."""
+    backends = [hitachi_backend, purestorage_backend, dellsc_backend, infinidat_backend]
+    types = [b.backend_type for b in backends]
+
+    # Check no duplicates
+    assert len(types) == len(set(types)), f"Duplicate backend types found: {types}"
+
+
+def test_all_backends_have_unique_charm_names(
+    hitachi_backend, purestorage_backend, dellsc_backend, infinidat_backend
+):
+    """Test that all backends have unique charm names."""
+    backends = [hitachi_backend, purestorage_backend, dellsc_backend, infinidat_backend]
+    charm_names = [b.charm_name for b in backends]
+
+    # Check no duplicates
+    assert len(charm_names) == len(set(charm_names)), (
+        f"Duplicate charm names found: {charm_names}"
+    )
+
+
+@pytest.mark.parametrize(
+    "backend_type,expected_type",
+    [
+        ("hitachi", "hitachi"),
+        ("purestorage", "purestorage"),
+        ("dellsc", "dellsc"),
+        ("infinidat", "infinidat"),
+    ],
+)
+def test_backend_types_match_expected(any_backend, backend_type, expected_type):
+    """Test that backend types match expected values."""
+    if any_backend.backend_type == backend_type:
+        assert any_backend.backend_type == expected_type
+
+
+@pytest.mark.parametrize(
+    "backend_type,expected_charm",
+    [
+        ("hitachi", "cinder-volume-hitachi"),
+        ("purestorage", "cinder-volume-purestorage"),
+        ("dellsc", "cinder-volume-dellsc"),
+        ("infinidat", "cinder-volume-infinidat"),
+    ],
+)
+def test_backend_charm_names_match_expected(any_backend, backend_type, expected_charm):
+    """Test that backend charm names match expected values."""
+    if any_backend.backend_type == backend_type:
+        assert any_backend.charm_name == expected_charm

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
@@ -412,7 +412,10 @@ class TestInfinidatBuildTerraformVars:
     def test_channel_override_preserves_other_defaults(
         self, infinidat_backend, mock_deployment, sample_config
     ):
-        """Channel override via standard manifest field works, other fields stay default."""
+        """Channel override via standard manifest field works.
+
+        Other fields stay default.
+        """
         manifest = self._make_manifest(channel="stable")
         result = infinidat_backend.build_terraform_vars(
             mock_deployment, manifest, "my-backend", sample_config
@@ -426,7 +429,10 @@ class TestInfinidatBuildTerraformVars:
     def test_revision_override_preserves_other_defaults(
         self, infinidat_backend, mock_deployment, sample_config
     ):
-        """Revision override via standard manifest field works, other fields stay default."""
+        """Revision override via standard manifest field works.
+
+        Other fields stay default.
+        """
         manifest = self._make_manifest(revision=42)
         result = infinidat_backend.build_terraform_vars(
             mock_deployment, manifest, "my-backend", sample_config

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
@@ -519,9 +519,7 @@ class TestInfinidatChapValidation:
         from pydantic import ValidationError
 
         with pytest.raises(ValidationError, match="Blocked"):
-            InfinidatConfig.model_validate(
-                {**self.BASE_CONFIG, "use-chap-auth": True}
-            )
+            InfinidatConfig.model_validate({**self.BASE_CONFIG, "use-chap-auth": True})
 
     def test_chap_enabled_username_missing_raises_blocked(self):
         """CHAP enabled with only password raises blocked error."""

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
@@ -1,0 +1,493 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Infinidat storage backend."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sunbeam.core.manifest import (
+    CharmManifest,
+    Manifest,
+    SoftwareConfig,
+    StorageBackendManifests,
+    StorageInstanceManifest,
+    StorageManifest,
+)
+from sunbeam.storage.backends.infinidat.backend import InfinidatConfig
+from tests.unit.sunbeam.storage.backends.test_common import BaseBackendTests
+
+
+class TestInfinidatBackend(BaseBackendTests):
+    """Tests for Infinidat storage backend.
+
+    Inherits all generic tests from BaseBackendTests and adds
+    backend-specific tests.
+    """
+
+    @pytest.fixture
+    def backend(self, infinidat_backend):
+        """Provide Infinidat backend instance."""
+        return infinidat_backend
+
+    # Backend-specific tests
+
+    def test_backend_type_is_infinidat(self, backend):
+        """Test that backend type is 'infinidat'."""
+        assert backend.backend_type == "infinidat"
+
+    def test_display_name_mentions_infinidat(self, backend):
+        """Test that display name mentions Infinidat."""
+        assert "infinidat" in backend.display_name.lower()
+
+    def test_charm_name_is_infinidat_charm(self, backend):
+        """Test that charm name is cinder-volume-infinidat."""
+        assert backend.charm_name == "cinder-volume-infinidat"
+
+    def test_infinidat_config_has_required_fields(self, backend):
+        """Test that Infinidat config has all required fields."""
+        config_class = backend.config_type()
+        fields = config_class.model_fields
+
+        # Verify Infinidat-specific required fields
+        required_fields = [
+            "san_ip",
+            "infinidat_pool_name",
+            "san_login",
+            "san_password",
+        ]
+        for field in required_fields:
+            assert field in fields, f"Required field {field} not found in config"
+
+    def test_infinidat_protocol_is_optional_literal(self, backend):
+        """Test that protocol field accepts iscsi or fc."""
+        config_class = backend.config_type()
+        protocol_field = config_class.model_fields.get("protocol")
+        assert protocol_field is not None
+
+        # Test valid config with iSCSI (default)
+        valid_config_iscsi = config_class.model_validate(
+            {
+                "san-ip": "192.168.1.1",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+                "protocol": "iscsi",
+            }
+        )
+        assert valid_config_iscsi.protocol == "iscsi"
+
+        # Test valid config with FC
+        valid_config_fc = config_class.model_validate(
+            {
+                "san-ip": "192.168.1.1",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+                "protocol": "fc",
+            }
+        )
+        assert valid_config_fc.protocol == "fc"
+
+    def test_infinidat_protocol_defaults_to_iscsi(self, backend):
+        """Test that protocol defaults to iscsi when not specified."""
+        config_class = backend.config_type()
+
+        config = config_class.model_validate(
+            {
+                "san-ip": "192.168.1.1",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+            }
+        )
+        assert config.protocol == "iscsi"
+
+    def test_infinidat_san_credentials_are_secret(self, backend):
+        """Test that SAN credentials are properly marked as secrets."""
+        from sunbeam.storage.models import SecretDictField
+
+        config_class = backend.config_type()
+
+        # Check san_login is marked as secret
+        login_field = config_class.model_fields.get("san_login")
+        assert login_field is not None
+        has_secret_marker = any(
+            isinstance(m, SecretDictField) for m in login_field.metadata
+        )
+        assert has_secret_marker, "san_login should be marked as secret"
+
+        # Check san_password is marked as secret
+        password_field = config_class.model_fields.get("san_password")
+        assert password_field is not None
+        has_secret_marker = any(
+            isinstance(m, SecretDictField) for m in password_field.metadata
+        )
+        assert has_secret_marker, "san_password should be marked as secret"
+
+    def test_infinidat_chap_credentials_are_secret(self, backend):
+        """Test that CHAP credentials are properly marked as secrets."""
+        from sunbeam.storage.models import SecretDictField
+
+        config_class = backend.config_type()
+
+        # Check chap_username is marked as secret
+        chap_user_field = config_class.model_fields.get("chap_username")
+        assert chap_user_field is not None
+        has_secret_marker = any(
+            isinstance(m, SecretDictField) for m in chap_user_field.metadata
+        )
+        assert has_secret_marker, "chap_username should be marked as secret"
+
+        # Check chap_password is marked as secret
+        chap_pass_field = config_class.model_fields.get("chap_password")
+        assert chap_pass_field is not None
+        has_secret_marker = any(
+            isinstance(m, SecretDictField) for m in chap_pass_field.metadata
+        )
+        assert has_secret_marker, "chap_password should be marked as secret"
+
+    def test_infinidat_config_optional_fields_work(self, backend):
+        """Test that optional fields can be omitted."""
+        config_class = backend.config_type()
+
+        # Create config with only required fields
+        config = config_class.model_validate(
+            {
+                "san-ip": "192.168.1.1",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+            }
+        )
+
+        # Verify optional fields default to expected values
+        assert config.protocol == "iscsi"  # defaults to iscsi
+        assert config.infinidat_iscsi_netspaces is None
+        assert config.chap_username is None
+        assert config.chap_password is None
+        assert config.volume_backend_name is None
+        assert config.backend_availability_zone is None
+
+    def test_infinidat_use_chap_auth_defaults_to_true(self, backend):
+        """Test that use_chap_auth defaults to True."""
+        config_class = backend.config_type()
+
+        config = config_class.model_validate(
+            {
+                "san-ip": "192.168.1.1",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+            }
+        )
+        assert config.use_chap_auth is True
+
+    def test_infinidat_supports_ha(self, backend):
+        """Test that Infinidat backend supports HA deployments."""
+        assert backend.supports_ha is True
+
+    def test_infinidat_principal_application_is_ha(self, backend):
+        """Test that principal application is cinder-volume (HA)."""
+        assert backend.principal_application == "cinder-volume"
+
+    def test_infinidat_new_optional_fields_default_to_none(self, backend):
+        """Test that new optional fields default to None."""
+        config_class = backend.config_type()
+
+        config = config_class.model_validate(
+            {
+                "san-ip": "192.168.1.1",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+            }
+        )
+
+        assert config.infinidat_use_compression is None
+        assert config.max_over_subscription_ratio is None
+
+
+class TestInfinidatConfigValidation:
+    """Test Infinidat config validation behavior."""
+
+    def test_protocol_accepts_only_valid_values(self, infinidat_backend):
+        """Test that protocol field rejects invalid values."""
+        from pydantic import ValidationError
+
+        config_class = infinidat_backend.config_type()
+
+        # Should reject invalid protocol
+        with pytest.raises(ValidationError) as exc_info:
+            config_class.model_validate(
+                {
+                    "san-ip": "192.168.1.1",
+                    "infinidat-pool-name": "pool1",
+                    "san-login": "admin",
+                    "san-password": "secret",
+                    "protocol": "INVALID",
+                }
+            )
+
+        assert "protocol" in str(exc_info.value).lower()
+
+    def test_missing_required_fields_raises_error(self, infinidat_backend):
+        """Test that missing required fields raise ValidationError."""
+        from pydantic import ValidationError
+
+        config_class = infinidat_backend.config_type()
+
+        # Missing san_ip
+        with pytest.raises(ValidationError):
+            config_class.model_validate(
+                {
+                    "infinidat-pool-name": "pool1",
+                    "san-login": "admin",
+                    "san-password": "secret",
+                }
+            )
+
+        # Missing infinidat_pool_name
+        with pytest.raises(ValidationError):
+            config_class.model_validate(
+                {
+                    "san-ip": "192.168.1.1",
+                    "san-login": "admin",
+                    "san-password": "secret",
+                }
+            )
+
+        # Missing san_login
+        with pytest.raises(ValidationError):
+            config_class.model_validate(
+                {
+                    "san-ip": "192.168.1.1",
+                    "infinidat-pool-name": "pool1",
+                    "san-password": "secret",
+                }
+            )
+
+        # Missing san_password
+        with pytest.raises(ValidationError):
+            config_class.model_validate(
+                {
+                    "san-ip": "192.168.1.1",
+                    "infinidat-pool-name": "pool1",
+                    "san-login": "admin",
+                }
+            )
+
+    def test_boolean_fields_accept_boolean_values(self, infinidat_backend):
+        """Test that boolean fields accept boolean values."""
+        config_class = infinidat_backend.config_type()
+
+        config = config_class.model_validate(
+            {
+                "san-ip": "192.168.1.1",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+                "use-chap-auth": False,
+            }
+        )
+        assert config.use_chap_auth is False
+
+    def test_max_over_subscription_ratio_accepts_float(self, infinidat_backend):
+        """Test that max_over_subscription_ratio accepts float values."""
+        config_class = infinidat_backend.config_type()
+
+        config = config_class.model_validate(
+            {
+                "san-ip": "192.168.1.1",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+                "max-over-subscription-ratio": 20.0,
+            }
+        )
+        assert config.max_over_subscription_ratio == 20.0
+
+
+class TestInfinidatBuildTerraformVars:
+    """Tests for the Infinidat build_terraform_vars override.
+
+    Verifies the local charm source support via manifest model_extra.
+    """
+
+    @pytest.fixture
+    def mock_deployment(self):
+        """Provide a mock Deployment object."""
+        deployment = MagicMock()
+        deployment.get_space.return_value = "alpha"
+        return deployment
+
+    @pytest.fixture
+    def sample_config(self):
+        """Provide a sample InfinidatConfig instance."""
+        return InfinidatConfig.model_validate(
+            {
+                "san-ip": "192.168.1.100",
+                "infinidat-pool-name": "pool1",
+                "san-login": "admin",
+                "san-password": "secret",
+            }
+        )
+
+    @pytest.fixture
+    def empty_manifest(self):
+        """Provide a Manifest with no storage overrides."""
+        return Manifest(storage=StorageManifest(root={}))
+
+    def _make_manifest(self, channel=None, revision=None):
+        """Build a Manifest with optional charm config for the infinidat backend.
+
+        Args:
+            channel: optional channel override
+            revision: optional revision override
+        """
+        charm_kwargs = {}
+        if channel is not None:
+            charm_kwargs["channel"] = channel
+        if revision is not None:
+            charm_kwargs["revision"] = revision
+
+        charm_manifest = CharmManifest(**charm_kwargs)
+
+        backend_instance = StorageInstanceManifest(
+            software=SoftwareConfig(charms={"cinder-volume-infinidat": charm_manifest})
+        )
+        backend_manifests = StorageBackendManifests(
+            root={"my-backend": backend_instance}
+        )
+        return Manifest(storage=StorageManifest(root={"infinidat": backend_manifests}))
+
+    def test_no_manifest_override_uses_defaults(
+        self, infinidat_backend, mock_deployment, sample_config, empty_manifest
+    ):
+        """With no storage manifest entries, defaults from the class are used."""
+        result = infinidat_backend.build_terraform_vars(
+            mock_deployment, empty_manifest, "my-backend", sample_config
+        )
+
+        assert result["charm_name"] == "cinder-volume-infinidat"
+        assert result["charm_channel"] == "latest/edge"
+        assert result["charm_revision"] is None
+        assert result["charm_base"] == "ubuntu@24.04"
+
+    def test_channel_and_revision_override(
+        self, infinidat_backend, mock_deployment, sample_config
+    ):
+        """When both channel and revision are set in manifest, both are applied."""
+        manifest = self._make_manifest(channel="stable", revision=42)
+        result = infinidat_backend.build_terraform_vars(
+            mock_deployment, manifest, "my-backend", sample_config
+        )
+
+        assert result["charm_name"] == "cinder-volume-infinidat"
+        assert result["charm_channel"] == "stable"
+        assert result["charm_revision"] == 42
+        assert result["charm_base"] == "ubuntu@24.04"
+
+    def test_manifest_without_charm_entry_uses_defaults(
+        self, infinidat_backend, mock_deployment, sample_config
+    ):
+        """When manifest has backend entry but no charm config, defaults are used."""
+        backend_instance = StorageInstanceManifest(software=SoftwareConfig(charms={}))
+        backend_manifests = StorageBackendManifests(
+            root={"my-backend": backend_instance}
+        )
+        manifest = Manifest(
+            storage=StorageManifest(root={"infinidat": backend_manifests})
+        )
+        result = infinidat_backend.build_terraform_vars(
+            mock_deployment, manifest, "my-backend", sample_config
+        )
+
+        assert result["charm_name"] == "cinder-volume-infinidat"
+        assert result["charm_channel"] == "latest/edge"
+        assert result["charm_revision"] is None
+        assert result["charm_base"] == "ubuntu@24.04"
+
+    def test_channel_override_preserves_other_defaults(
+        self, infinidat_backend, mock_deployment, sample_config
+    ):
+        """Channel override via standard manifest field works, other fields stay default."""
+        manifest = self._make_manifest(channel="stable")
+        result = infinidat_backend.build_terraform_vars(
+            mock_deployment, manifest, "my-backend", sample_config
+        )
+
+        assert result["charm_name"] == "cinder-volume-infinidat"
+        assert result["charm_channel"] == "stable"
+        assert result["charm_revision"] is None
+        assert result["charm_base"] == "ubuntu@24.04"
+
+    def test_revision_override_preserves_other_defaults(
+        self, infinidat_backend, mock_deployment, sample_config
+    ):
+        """Revision override via standard manifest field works, other fields stay default."""
+        manifest = self._make_manifest(revision=42)
+        result = infinidat_backend.build_terraform_vars(
+            mock_deployment, manifest, "my-backend", sample_config
+        )
+
+        assert result["charm_name"] == "cinder-volume-infinidat"
+        assert result["charm_channel"] == "latest/edge"
+        assert result["charm_revision"] == 42
+
+    def test_revision_without_channel_uses_default_channel(
+        self, infinidat_backend, mock_deployment, sample_config
+    ):
+        """When only revision is set, channel falls back to the backend default."""
+        manifest = self._make_manifest(revision=42)
+        result = infinidat_backend.build_terraform_vars(
+            mock_deployment, manifest, "my-backend", sample_config
+        )
+
+        assert result["charm_channel"] == "latest/edge"
+        assert result["charm_revision"] == 42
+
+    def test_different_backend_name_not_matched(
+        self, infinidat_backend, mock_deployment, sample_config
+    ):
+        """Manifest entry for a different backend name doesn't affect result."""
+        # Create manifest with a different backend name
+        charm_manifest = CharmManifest(channel="stable")
+        backend_instance = StorageInstanceManifest(
+            software=SoftwareConfig(charms={"cinder-volume-infinidat": charm_manifest})
+        )
+        backend_manifests = StorageBackendManifests(
+            root={"other-backend": backend_instance}
+        )
+        manifest = Manifest(
+            storage=StorageManifest(root={"infinidat": backend_manifests})
+        )
+
+        result = infinidat_backend.build_terraform_vars(
+            mock_deployment, manifest, "my-backend", sample_config
+        )
+
+        # Should use defaults since "my-backend" doesn't match "other-backend"
+        assert result["charm_name"] == "cinder-volume-infinidat"
+        assert result["charm_channel"] == "latest/edge"
+
+    def test_tfvars_contains_expected_keys(
+        self, infinidat_backend, mock_deployment, sample_config, empty_manifest
+    ):
+        """Verify the result dict contains all expected Terraform variable keys."""
+        result = infinidat_backend.build_terraform_vars(
+            mock_deployment, empty_manifest, "my-backend", sample_config
+        )
+
+        expected_keys = {
+            "principal_application",
+            "charm_name",
+            "charm_base",
+            "charm_channel",
+            "charm_revision",
+            "endpoint_bindings",
+            "charm_config",
+            "secrets",
+        }
+        assert set(result.keys()) == expected_keys

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
@@ -494,7 +494,7 @@ class TestInfinidatBuildTerraformVars:
             "charm_config",
             "secrets",
         }
-        assert set(result.keys()) == expected_keys
+        assert expected_keys.issubset(result.keys())
 
 
 class TestInfinidatChapValidation:

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
@@ -311,10 +311,7 @@ class TestInfinidatConfigValidation:
 
 
 class TestInfinidatBuildTerraformVars:
-    """Tests for the Infinidat build_terraform_vars override.
-
-    Verifies the local charm source support via manifest model_extra.
-    """
+    """Tests Infinidat build_terraform_vars behavior."""
 
     @pytest.fixture
     def mock_deployment(self):

--- a/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/backends/test_infinidat.py
@@ -165,13 +165,14 @@ class TestInfinidatBackend(BaseBackendTests):
         # Verify optional fields default to expected values
         assert config.protocol == "iscsi"  # defaults to iscsi
         assert config.infinidat_iscsi_netspaces is None
+        assert config.use_chap_auth is None
         assert config.chap_username is None
         assert config.chap_password is None
         assert config.volume_backend_name is None
         assert config.backend_availability_zone is None
 
-    def test_infinidat_use_chap_auth_defaults_to_true(self, backend):
-        """Test that use_chap_auth defaults to True."""
+    def test_infinidat_use_chap_auth_defaults_to_none(self, backend):
+        """Test that use_chap_auth defaults to None (defers to charm)."""
         config_class = backend.config_type()
 
         config = config_class.model_validate(
@@ -182,7 +183,7 @@ class TestInfinidatBackend(BaseBackendTests):
                 "san-password": "secret",
             }
         )
-        assert config.use_chap_auth is True
+        assert config.use_chap_auth is None
 
     def test_infinidat_supports_ha(self, backend):
         """Test that Infinidat backend supports HA deployments."""
@@ -497,3 +498,85 @@ class TestInfinidatBuildTerraformVars:
             "secrets",
         }
         assert set(result.keys()) == expected_keys
+
+
+class TestInfinidatChapValidation:
+    """Test CHAP authentication cross-field validation.
+
+    When use_chap_auth is enabled, chap_username and chap_password
+    must be provided or validation raises a blocked status error.
+    """
+
+    BASE_CONFIG = {
+        "san-ip": "192.168.1.1",
+        "infinidat-pool-name": "pool1",
+        "san-login": "admin",
+        "san-password": "secret",
+    }
+
+    def test_chap_enabled_both_missing_raises_blocked(self):
+        """CHAP enabled with no credentials raises blocked error."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="Blocked"):
+            InfinidatConfig.model_validate(
+                {**self.BASE_CONFIG, "use-chap-auth": True}
+            )
+
+    def test_chap_enabled_username_missing_raises_blocked(self):
+        """CHAP enabled with only password raises blocked error."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="chap_username"):
+            InfinidatConfig.model_validate(
+                {
+                    **self.BASE_CONFIG,
+                    "use-chap-auth": True,
+                    "chap-password": "pass",
+                }
+            )
+
+    def test_chap_enabled_password_missing_raises_blocked(self):
+        """CHAP enabled with only username raises blocked error."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="chap_password"):
+            InfinidatConfig.model_validate(
+                {
+                    **self.BASE_CONFIG,
+                    "use-chap-auth": True,
+                    "chap-username": "user",
+                }
+            )
+
+    def test_chap_enabled_both_provided_passes(self):
+        """CHAP enabled with both credentials passes validation."""
+        config = InfinidatConfig.model_validate(
+            {
+                **self.BASE_CONFIG,
+                "use-chap-auth": True,
+                "chap-username": "user",
+                "chap-password": "pass",
+            }
+        )
+        assert config.use_chap_auth is True
+        assert config.chap_username == "user"
+        assert config.chap_password == "pass"
+
+    def test_chap_disabled_no_credentials_passes(self):
+        """CHAP disabled without credentials passes validation."""
+        config = InfinidatConfig.model_validate(
+            {**self.BASE_CONFIG, "use-chap-auth": False}
+        )
+        assert config.use_chap_auth is False
+        assert config.chap_username is None
+        assert config.chap_password is None
+
+    def test_chap_none_no_credentials_passes(self):
+        """CHAP set to None without credentials passes validation."""
+        config = InfinidatConfig.model_validate(
+            {**self.BASE_CONFIG, "use-chap-auth": None}
+        )
+        assert config.use_chap_auth is None
+        assert config.chap_username is None
+        assert config.chap_password is None


### PR DESCRIPTION
Add InfinidatConfig and InfinidatBackend with all upstream driver options:
- san_ip
- san_login
- san_password
- infinidat_pool_name
- protocol
- infinidat_iscsi_netspaces
- use_chap_auth
- chap_username
- chap_password
- infinidat_use_compression
- max_over_subscription_ratio

(cherry picked from commit e684244b11c6539729f08f0c4cbbce78fc237f1a)