### PR TITLE
feat: expose storage config for embedded observability

### DIFF
--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/main.tf
@@ -57,6 +57,8 @@ resource "juju_application" "alertmanager" {
 
   config = var.alertmanager-config
   units  = var.alertmanager-scale
+
+  storage_directives = var.alertmanager-storage
 }
 
 resource "juju_application" "prometheus" {
@@ -73,6 +75,8 @@ resource "juju_application" "prometheus" {
 
   config = var.prometheus-config
   units  = var.prometheus-scale
+
+  storage_directives = var.prometheus-storage
 }
 
 resource "juju_application" "grafana" {
@@ -89,6 +93,8 @@ resource "juju_application" "grafana" {
 
   config = var.grafana-config
   units  = var.grafana-scale
+
+  storage_directives = var.grafana-storage
 }
 
 resource "juju_application" "catalogue" {
@@ -126,6 +132,8 @@ resource "juju_application" "loki" {
 
   config = var.loki-config
   units  = var.loki-scale
+
+  storage_directives = var.loki-storage
 }
 
 # juju integrate traefik prometheus

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/variables.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/variables.tf
@@ -183,3 +183,36 @@ variable "loki-scale" {
   type        = number
   default     = 1
 }
+
+variable "prometheus-storage" {
+  description = "Storage directives for Prometheus"
+  type        = map(string)
+  default = {
+    database = "20G"
+  }
+}
+
+variable "loki-storage" {
+  description = "Storage directives for Loki"
+  type        = map(string)
+  default = {
+    active-index-directory = "2G"
+    loki-chunks            = "5G"
+  }
+}
+
+variable "grafana-storage" {
+  description = "Storage directives for Grafana"
+  type        = map(string)
+  default = {
+    database = "1G"
+  }
+}
+
+variable "alertmanager-storage" {
+  description = "Storage directives for Alertmanager"
+  type        = map(string)
+  default = {
+    data = "1G"
+  }
+}

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -8,6 +8,7 @@ This feature have options to deploy a COS Lite stack internally
 or point to an external COS Lite.
 """
 
+import copy
 import enum
 import logging
 import queue
@@ -17,6 +18,7 @@ import click
 from packaging.version import Version
 from rich.console import Console
 
+from sunbeam.clusterd.client import Client
 from sunbeam.clusterd.service import (
     ClusterServiceUnavailableException,
     ConfigItemNotFoundException,
@@ -52,6 +54,7 @@ from sunbeam.core.manifest import (
     Manifest,
     SoftwareConfig,
     TerraformManifest,
+    check_storage_modifications_in_manifest,
 )
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.steps import (
@@ -95,6 +98,15 @@ OBSERVABILITY_AGENT_CONFIG_KEY = (
     "TerraformVarsFeatureObservabilityPlanObservabilityAgent"
 )
 
+COS_STORAGE_KEY = "ObservabilityStorage"
+
+CHARM_STORAGE_MAP = {
+    "prometheus-k8s": "prometheus-storage",
+    "loki-k8s": "loki-storage",
+    "grafana-k8s": "grafana-storage",
+    "alertmanager-k8s": "alertmanager-storage",
+}
+
 COS_CHANNEL = "1/stable"
 OPENTELEMETRY_COLLECTOR_CHANNEL = "2/stable"
 OPENTELEMETRY_COLLECTOR_K8S_CHANNEL = "2/stable"
@@ -109,6 +121,59 @@ INTEGRATION_APPS = ["openstack-hypervisor", "microceph", "k8s"]
 class ProviderType(enum.Enum):
     EXTERNAL = 1
     EMBEDDED = 2
+
+
+def get_cos_storage_from_manifest(
+    manifest: Manifest,
+) -> dict[str, dict[str, str]]:
+    """Get charm storage for COS Lite from manifest file."""
+    storage: dict[str, dict[str, str]] = {}
+    for charm_name, tfvar_name in CHARM_STORAGE_MAP.items():
+        charm = manifest.find_charm(charm_name)
+        if charm and charm.model_extra:
+            charm_storage = charm.model_extra.get("storage")
+            if isinstance(charm_storage, dict) and charm_storage:
+                storage[tfvar_name] = charm_storage
+    return storage
+
+
+def get_cos_storage_dict(
+    client: Client, manifest: Manifest
+) -> dict[str, dict[str, str]]:
+    """Returns a dict containing the storage allocation for COS Lite.
+
+    Storage is retrieved for each COS charm.
+    Default storage sizes are defined in the Terraform variables.
+    """
+    try:
+        storage_from_db = read_config(client, COS_STORAGE_KEY)
+        if not isinstance(storage_from_db, dict):
+            LOG.warning(
+                "Invalid observability storage config in database: %s.", storage_from_db
+            )
+            raise ValueError("Invalid observability storage config in database")
+    except (ConfigItemNotFoundException, ValueError):
+        storage_from_db = {}
+
+    storage_from_manifest = get_cos_storage_from_manifest(manifest)
+
+    storage = copy.deepcopy(storage_from_db)
+    for charm_key, charm_storage in storage_from_manifest.items():
+        if (
+            charm_key in storage
+            and isinstance(storage[charm_key], dict)
+            and isinstance(charm_storage, dict)
+        ):
+            storage[charm_key].update(charm_storage)
+        else:
+            storage[charm_key] = charm_storage
+
+    return storage
+
+
+def write_cos_storage_dict(client: Client, storage: dict):
+    """Write the COS storage dict."""
+    update_config(client, COS_STORAGE_KEY, storage)
 
 
 class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
@@ -132,6 +197,30 @@ class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
         self.model = OBSERVABILITY_MODEL
         self.cloud = K8SHelper.get_cloud(deployment.name)
 
+    def is_skip(self, context: StepContext) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        # Check for storage size modifications in manifest
+        client = self.deployment.get_client()
+        modified = check_storage_modifications_in_manifest(
+            client,
+            self.manifest,
+            self.tfhelper.tfvar_map,
+            self._CONFIG,
+            extra_tfvar_config_keys=[self.feature.get_tfvar_config_key()],
+        )
+        if modified:
+            return Result(
+                ResultType.FAILED,
+                "Storage sizes are immutable and cannot be modified"
+                f" in manifest: {', '.join(modified)}",
+            )
+
+        return Result(ResultType.COMPLETED)
+
     def run(self, context: StepContext) -> Result:
         """Execute configuration using terraform."""
         f_manifest = self.manifest.get_feature(self.feature.name.split(".")[-1])
@@ -145,12 +234,18 @@ class DeployObservabilityStackStep(BaseStep, JujuStepHelper):
         model_config.update(convert_proxy_to_model_configs(proxy_settings))
         model_config.update({"workload-storage": K8SHelper.get_default_storageclass()})
 
-        extra_tfvars = {
+        extra_tfvars: dict = {
             "model": self.model,
             "cloud": self.cloud,
             "credential": f"{self.cloud}{CREDENTIAL_SUFFIX}",
             "config": model_config,
         }
+
+        # Get COS storage from database and manifest
+        client = self.deployment.get_client()
+        cos_storage = get_cos_storage_dict(client, self.manifest)
+        write_cos_storage_dict(client, cos_storage)
+        extra_tfvars.update(cos_storage)
 
         try:
             self.update_status(context, "deploying services")
@@ -208,6 +303,26 @@ class UpdateObservabilityModelConfigStep(BaseStep, JujuStepHelper):
         self.client = deployment.get_client()
         self.model = OBSERVABILITY_MODEL
         self.cloud = K8SHelper.get_cloud(deployment.name)
+
+    def is_skip(self, context: StepContext) -> Result:
+        """Determines if the step should be skipped or not.
+
+        :return: ResultType.SKIPPED if the Step should be skipped,
+                ResultType.COMPLETED or ResultType.FAILED otherwise
+        """
+        modified = check_storage_modifications_in_manifest(
+            self.client,
+            self.manifest,
+            self.tfhelper.tfvar_map,
+            self._CONFIG,
+        )
+        if modified:
+            return Result(
+                ResultType.FAILED,
+                "Storage sizes are immutable and cannot be modified"
+                f" in manifest: {', '.join(modified)}",
+            )
+        return Result(ResultType.COMPLETED)
 
     def run(self, context: StepContext) -> Result:
         """Execute configuration using terraform."""
@@ -640,11 +755,13 @@ class ObservabilityFeature(OpenStackControlPlaneFeature):
                         "channel": "alertmanager-channel",
                         "revision": "alertmanager-revision",
                         "config": "alertmanager-config",
+                        "storage": "alertmanager-storage",
                     },
                     "grafana-k8s": {
                         "channel": "grafana-channel",
                         "revision": "grafana-revision",
                         "config": "grafana-config",
+                        "storage": "grafana-storage",
                     },
                     "catalogue-k8s": {
                         "channel": "catalogue-channel",
@@ -655,11 +772,13 @@ class ObservabilityFeature(OpenStackControlPlaneFeature):
                         "channel": "prometheus-channel",
                         "revision": "prometheus-revision",
                         "config": "prometheus-config",
+                        "storage": "prometheus-storage",
                     },
                     "loki-k8s": {
                         "channel": "loki-channel",
                         "revision": "loki-revision",
                         "config": "loki-config",
+                        "storage": "loki-storage",
                     },
                 }
             },

--- a/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: 2023 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from sunbeam.clusterd.service import ConfigItemNotFoundException
 from sunbeam.core.common import ResultType
+from sunbeam.core.manifest import Manifest
 from sunbeam.core.terraform import TerraformException
 from sunbeam.features.observability import feature as observability_feature
 
@@ -28,13 +30,37 @@ def update_config():
         yield p
 
 
+@pytest.fixture()
+def read_config_obs():
+    with patch("sunbeam.features.observability.feature.read_config") as p:
+        yield p
+
+
+@pytest.fixture()
+def k8shelper():
+    with patch("sunbeam.features.observability.feature.K8SHelper") as p:
+        p.get_default_storageclass.return_value = "csi-rawfile-default"
+        yield p
+
+
 class TestDeployObservabilityStackStep:
     def test_run(
-        self, deployment, tfhelper, jhelper, observabilityfeature, ssnap, step_context
+        self,
+        deployment,
+        tfhelper,
+        jhelper,
+        observabilityfeature,
+        ssnap,
+        read_config_obs,
+        update_config,
+        k8shelper,
+        step_context,
     ):
         ssnap().config.get.return_value = "k8s"
         observabilityfeature.deployment.proxy_settings.return_value = {}
         jhelper.get_application_names.return_value = ["app1", "app2", "app3"]
+        read_config_obs.side_effect = ConfigItemNotFoundException("not found")
+        observabilityfeature.name = "observability.embedded"
         step = observability_feature.DeployObservabilityStackStep(
             deployment, observabilityfeature, tfhelper, jhelper
         )
@@ -51,10 +77,15 @@ class TestDeployObservabilityStackStep:
         jhelper,
         observabilityfeature,
         ssnap,
+        read_config_obs,
+        update_config,
+        k8shelper,
         step_context,
     ):
         ssnap().config.get.return_value = "k8s"
         observabilityfeature.deployment.proxy_settings.return_value = {}
+        read_config_obs.side_effect = ConfigItemNotFoundException("not found")
+        observabilityfeature.name = "observability.embedded"
         tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
             "apply failed..."
         )
@@ -76,12 +107,17 @@ class TestDeployObservabilityStackStep:
         jhelper,
         observabilityfeature,
         ssnap,
+        read_config_obs,
+        update_config,
+        k8shelper,
         step_context,
     ):
         ssnap().config.get.return_value = "k8s"
         observabilityfeature.deployment.proxy_settings.return_value = {}
         jhelper.get_application_names.return_value = ["app1", "app2", "app3"]
         jhelper.wait_until_active.side_effect = TimeoutError("timed out")
+        read_config_obs.side_effect = ConfigItemNotFoundException("not found")
+        observabilityfeature.name = "observability.embedded"
 
         step = observability_feature.DeployObservabilityStackStep(
             deployment, observabilityfeature, tfhelper, jhelper
@@ -92,6 +128,72 @@ class TestDeployObservabilityStackStep:
         jhelper.wait_until_active.assert_called_once()
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
+
+    def test_is_skip_no_modification(
+        self, deployment, tfhelper, jhelper, observabilityfeature, ssnap, step_context
+    ):
+        ssnap().config.get.return_value = "k8s"
+        with patch(
+            "sunbeam.features.observability.feature"
+            ".check_storage_modifications_in_manifest",
+            return_value=[],
+        ):
+            step = observability_feature.DeployObservabilityStackStep(
+                deployment, observabilityfeature, tfhelper, jhelper
+            )
+            result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip_modification_detected(
+        self, deployment, tfhelper, jhelper, observabilityfeature, ssnap, step_context
+    ):
+        ssnap().config.get.return_value = "k8s"
+        with patch(
+            "sunbeam.features.observability.feature"
+            ".check_storage_modifications_in_manifest",
+            return_value=["prometheus-storage"],
+        ):
+            step = observability_feature.DeployObservabilityStackStep(
+                deployment, observabilityfeature, tfhelper, jhelper
+            )
+            result = step.is_skip(step_context)
+        assert result.result_type == ResultType.FAILED
+        assert "immutable" in result.message
+
+
+class TestUpdateObservabilityModelConfigStep:
+    """Test the UpdateObservabilityModelConfigStep."""
+
+    def test_is_skip_no_modification(
+        self, deployment, tfhelper, observabilityfeature, ssnap, step_context
+    ):
+        ssnap().config.get.return_value = "k8s"
+        with patch(
+            "sunbeam.features.observability.feature"
+            ".check_storage_modifications_in_manifest",
+            return_value=[],
+        ):
+            step = observability_feature.UpdateObservabilityModelConfigStep(
+                deployment, observabilityfeature, tfhelper
+            )
+            result = step.is_skip(step_context)
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_is_skip_modification_detected(
+        self, deployment, tfhelper, observabilityfeature, ssnap, step_context
+    ):
+        ssnap().config.get.return_value = "k8s"
+        with patch(
+            "sunbeam.features.observability.feature"
+            ".check_storage_modifications_in_manifest",
+            return_value=["prometheus-storage"],
+        ):
+            step = observability_feature.UpdateObservabilityModelConfigStep(
+                deployment, observabilityfeature, tfhelper
+            )
+            result = step.is_skip(step_context)
+        assert result.result_type == ResultType.FAILED
+        assert "immutable" in result.message
 
 
 class TestRemoveObservabilityStackStep:
@@ -430,3 +532,111 @@ class TestObservabilityFeatureTimeouts:
         assert (
             timeout == observability_feature.OBSERVABILITY_AGENT_K8S_DEPLOY_TIMEOUT * 3
         )
+
+
+class TestCosStorage:
+    """Test COS charm storage helpers."""
+
+    def test_storage_from_manifest(self):
+        """Charms with storage in manifest are extracted."""
+        manifest = Manifest(
+            **{
+                "features": {
+                    "observability": {
+                        "embedded": {
+                            "software": {
+                                "charms": {
+                                    "prometheus-k8s": {"storage": {"database": "8G"}},
+                                    "loki-k8s": {
+                                        "storage": {
+                                            "active-index-directory": "16G",
+                                            "loki-chunks": "16G",
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        result = observability_feature.get_cos_storage_from_manifest(manifest)
+
+        assert result == {
+            "prometheus-storage": {"database": "8G"},
+            "loki-storage": {"active-index-directory": "16G", "loki-chunks": "16G"},
+        }
+
+    def test_storage_from_manifest_empty(self):
+        """No charms with storage returns empty dict."""
+        manifest = Manifest()
+        assert not observability_feature.get_cos_storage_from_manifest(manifest)
+
+    def test_storage_from_manifest_non_dict(self):
+        """Non-dict storage values are ignored."""
+        manifest = MagicMock()
+        charm = MagicMock()
+        charm.model_extra = {"storage": "not-a-dict"}
+        manifest.find_charm.return_value = charm
+        assert not observability_feature.get_cos_storage_from_manifest(manifest)
+
+    def test_storage_dict_empty(self, read_config_obs):
+        """Returns empty when DB and manifest have no storage."""
+        read_config_obs.side_effect = ConfigItemNotFoundException("not found")
+        manifest = Manifest()
+        assert not observability_feature.get_cos_storage_dict(Mock(), manifest)
+
+    def test_storage_dict_from_db(self, read_config_obs):
+        """DB values are returned."""
+        read_config_obs.return_value = {"prometheus-storage": {"database": "8G"}}
+        manifest = Manifest()
+        result = observability_feature.get_cos_storage_dict(Mock(), manifest)
+        assert result == {"prometheus-storage": {"database": "8G"}}
+
+    def test_storage_dict_manifest_overrides_db(self, read_config_obs):
+        """Manifest values override DB values."""
+        read_config_obs.return_value = {"prometheus-storage": {"database": "4G"}}
+        manifest = Manifest(
+            **{
+                "features": {
+                    "observability": {
+                        "embedded": {
+                            "software": {
+                                "charms": {
+                                    "prometheus-k8s": {"storage": {"database": "16G"}}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        result = observability_feature.get_cos_storage_dict(Mock(), manifest)
+        assert result["prometheus-storage"] == {"database": "16G"}
+
+    def test_storage_dict_deep_merges(self, read_config_obs):
+        """Partial manifest merges with DB, not replaces."""
+        read_config_obs.return_value = {
+            "loki-storage": {"active-index-directory": "4G", "loki-chunks": "4G"}
+        }
+        manifest = Manifest(
+            **{
+                "features": {
+                    "observability": {
+                        "embedded": {
+                            "software": {
+                                "charms": {
+                                    "loki-k8s": {"storage": {"loki-chunks": "8G"}}
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        result = observability_feature.get_cos_storage_dict(Mock(), manifest)
+        assert result["loki-storage"] == {
+            "active-index-directory": "4G",
+            "loki-chunks": "8G",
+        }


### PR DESCRIPTION
Expose storage options for the embedded observability with a new sensible default.

This can be done in the manifest file by spesifying these values:

```yaml
features:
   observability:
     embedded:
       software:
         charms:
           prometheus-k8s:
             storage:
               database: "40G"               # default: 20G, mount: /var/lib/prometheus
           loki-k8s:
             storage:
               active-index-directory: "4G"  # default: 2G, mount: /loki/boltdb-shipper-active
               loki-chunks: "10G"            # default: 5G, mount: /loki/chunks
           grafana-k8s:
             storage:
               database: "2G"                # default: 1G, mount: /var/lib/grafana
           alertmanager-k8s:
             storage:
               data: "2G"                    # default: 1G, mount: /alertmanager
```

From 8 hours observation for single node deployment with `control,compute,storage` role, the disk usages for each component of the embedded observability are:

| Storage | Usage |
| --- | --- |
| `prometheus:database` | 1.27 GiB / day |
| `loki:loki-chunks` | 0.29 GiB / day |
| `loki:active-index-directory` | 0.06 GiB / day |
| `grafana:database` | static |
| `alertmanager-storage:data` | static |



Related Launchpad bug: [LP#2105962](https://bugs.launchpad.net/snap-openstack/+bug/2105962)