### PR TITLE
Add sunbeam cluster refresh k8s subcommand

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -144,6 +144,7 @@ jobs:
           sg snap_daemon "openstack.sunbeam list-features"
 
           # cluster refresh
+          sg snap_daemon "openstack.sunbeam cluster refresh k8s"
           sg snap_daemon "openstack.sunbeam cluster refresh"
 
       - name: Collect logs

--- a/sunbeam-python/sunbeam/commands/refresh.py
+++ b/sunbeam-python/sunbeam/commands/refresh.py
@@ -12,6 +12,7 @@ from snaphelpers import Snap
 
 from sunbeam.clusterd.service import ManifestItemNotFoundException
 from sunbeam.core.common import (
+    ResultType,
     RiskLevel,
     get_step_message,
     infer_risk,
@@ -302,17 +303,19 @@ def refresh_k8s(
     manifest_path: Path | None = None,
     show_hints: bool = False,
 ) -> None:
-    """Upgrade k8s charm to latest revision in channel.
+    """Refresh the k8s charm to the latest patch revision.
 
-    Performs a patch upgrade (same channel, new revision) or a minor upgrade
-    (new channel track) following the Canonical Kubernetes upgrade procedure:
+    Performs a patch upgrade (same channel, newer revision) following
+    the Canonical Kubernetes upgrade procedure:
 
     1. Run the pre-upgrade-check action on the k8s leader unit.
-    2. Refresh the k8s charm (optionally to a new channel for minor upgrades).
+    2. Refresh the k8s charm within the currently deployed channel.
     3. Wait for all k8s units to return to active.
+    4. Apply the k8s Terraform plan to sync state.
 
-    The target channel is read from the manifest when provided; otherwise the
-    default channel from the snap is used.
+    Track (minor/major version) upgrades are not supported by this
+    command. A manifest channel entry may change the risk level within
+    the same track (e.g. 1.32/stable -> 1.32/edge).
     """
     deployment: Deployment = ctx.obj
     client = deployment.get_client()
@@ -327,15 +330,22 @@ def refresh_k8s(
         LOG.debug("Getting latest manifest from cluster db")
         manifest = deployment.get_manifest()
 
-    plan: list = [
-        K8SCharmUpgradeStep(
-            deployment,
-            client,
-            manifest,
-            jhelper,
-        ),
-        TerraformInitStep(deployment.get_tfhelper("k8s-plan")),
-    ]
+    upgrade_step = K8SCharmUpgradeStep(
+        deployment,
+        client,
+        manifest,
+        jhelper,
+    )
+    upgrade_results = run_plan([upgrade_step], console, show_hints)
+    upgrade_result = upgrade_results.get(K8SCharmUpgradeStep.__name__)
+    if upgrade_result and upgrade_result.result_type == ResultType.SKIPPED:
+        message = get_step_message(upgrade_results, K8SCharmUpgradeStep)
+        if message:
+            click.echo(message)
+        click.echo("k8s refresh skipped.")
+        return
+
+    plan: list = [TerraformInitStep(deployment.get_tfhelper("k8s-plan"))]
 
     if is_maas_deployment(deployment):
         from sunbeam.provider.maas.client import MaasClient  # noqa: PLC0415
@@ -369,9 +379,9 @@ def refresh_k8s(
             )
         )
 
-    plan_results = run_plan(plan, console, show_hints)
+    run_plan(plan, console, show_hints)
 
-    message = get_step_message(plan_results, K8SCharmUpgradeStep)
+    message = get_step_message(upgrade_results, K8SCharmUpgradeStep)
     if message:
         click.echo(message)
     click.echo("k8s refresh complete.")

--- a/sunbeam-python/sunbeam/commands/refresh.py
+++ b/sunbeam-python/sunbeam/commands/refresh.py
@@ -20,6 +20,10 @@ from sunbeam.core.common import (
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import JujuHelper
 from sunbeam.core.manifest import AddManifestStep
+from sunbeam.core.terraform import TerraformInitStep
+from sunbeam.features.interface.v1.base import is_maas_deployment
+from sunbeam.steps.k8s import DeployK8SApplicationStep
+from sunbeam.steps.k8s_upgrade import K8SCharmUpgradeStep
 from sunbeam.steps.upgrades.base import UpgradeCoordinator
 from sunbeam.steps.upgrades.inter_channel import ChannelUpgradeCoordinator
 from sunbeam.steps.upgrades.intra_channel import (
@@ -281,3 +285,93 @@ def refresh_vault(
     if message:
         click.echo(message)
     click.echo("Vault refresh complete.")
+
+
+@refresh.command("k8s")
+@click.option(
+    "-m",
+    "--manifest",
+    "manifest_path",
+    help="Manifest file.",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click_option_show_hints
+@click.pass_context
+def refresh_k8s(
+    ctx: click.Context,
+    manifest_path: Path | None = None,
+    show_hints: bool = False,
+) -> None:
+    """Upgrade k8s charm to latest revision in channel.
+
+    Performs a patch upgrade (same channel, new revision) or a minor upgrade
+    (new channel track) following the Canonical Kubernetes upgrade procedure:
+
+    1. Run the pre-upgrade-check action on the k8s leader unit.
+    2. Refresh the k8s charm (optionally to a new channel for minor upgrades).
+    3. Wait for all k8s units to return to active.
+
+    The target channel is read from the manifest when provided; otherwise the
+    default channel from the snap is used.
+    """
+    deployment: Deployment = ctx.obj
+    client = deployment.get_client()
+    jhelper = JujuHelper(deployment.juju_controller)
+
+    manifest = None
+    if manifest_path:
+        manifest = deployment.get_manifest(manifest_path)
+        run_plan([AddManifestStep(client, manifest_path)], console, show_hints)
+
+    if not manifest:
+        LOG.debug("Getting latest manifest from cluster db")
+        manifest = deployment.get_manifest()
+
+    plan: list = [
+        K8SCharmUpgradeStep(
+            deployment,
+            client,
+            manifest,
+            jhelper,
+        ),
+        TerraformInitStep(deployment.get_tfhelper("k8s-plan")),
+    ]
+
+    if is_maas_deployment(deployment):
+        from sunbeam.provider.maas.client import MaasClient  # noqa: PLC0415
+        from sunbeam.provider.maas.steps import (  # noqa: PLC0415
+            MaasDeployK8SApplicationStep,
+        )
+
+        maas_client = MaasClient.from_deployment(deployment)
+        plan.append(
+            MaasDeployK8SApplicationStep(
+                deployment,
+                client,
+                maas_client,
+                deployment.get_tfhelper("k8s-plan"),
+                jhelper,
+                manifest,
+                deployment.openstack_machines_model,
+                accept_defaults=True,
+            )
+        )
+    else:
+        plan.append(
+            DeployK8SApplicationStep(
+                deployment,
+                client,
+                deployment.get_tfhelper("k8s-plan"),
+                jhelper,
+                manifest,
+                deployment.openstack_machines_model,
+                refresh=True,
+            )
+        )
+
+    plan_results = run_plan(plan, console, show_hints)
+
+    message = get_step_message(plan_results, K8SCharmUpgradeStep)
+    if message:
+        click.echo(message)
+    click.echo("k8s refresh complete.")

--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -1597,22 +1597,31 @@ class JujuHelper:
                 trust=trust,
             )
 
-    def get_available_charm_revision(
+    def get_available_charm_revisions(
         self,
         charm_name: str,
         channel: str,
         base: str = JUJU_BASE,
-        arch: str | None = None,
-    ) -> int:
-        """Find the latest available revision of a charm in a given channel.
+    ) -> dict[str, int]:
+        """Return a mapping of architecture to revision for a channel+base.
+
+        Each entry in the juju info channel listing may cover one or more
+        architectures, or have a different revision per architecture.  This
+        method expands the list into an ``{arch: revision}`` dict so callers
+        can do either an arch-aware lookup (``revisions.get("amd64")``) or a
+        simple membership check across all architectures
+        (``app.charm_rev in revisions.values()``).
+
+        When no architectures are listed for an entry, the key ``"all"`` is
+        used as a fallback.
 
         :param charm_name: Name of charm to look up
         :param channel: Channel to lookup charm in
         :param base: Base to lookup charm in, default is JUJU_BASE
-        :param arch: Architecture to filter by, or None to match any
+        :raises JujuException: if the channel/base combination is not found
         """
         track, risk = channel.split("/")
-        base_name, base_channel = base.split("@")
+        _, base_channel = base.split("@")
         output = json.loads(
             self._juju.cli(
                 "info",
@@ -1625,17 +1634,20 @@ class JujuHelper:
             )
         )
 
+        revisions: dict[str, int] = {}
         for risk_info in output["channels"][track][risk]:
-            if arch is not None and arch not in risk_info.get("architectures", []):
-                continue
             for base_info in risk_info["bases"]:
                 if base_info["channel"] == base_channel:
-                    return risk_info["revision"]
+                    archs = risk_info.get("architectures") or ["all"]
+                    for arch in archs:
+                        revisions[arch] = risk_info["revision"]
 
-        raise JujuException(
-            f"Could not find charm {charm_name!r} in channel {channel!r} "
-            f"with base {base!r}"
-        )
+        if not revisions:
+            raise JujuException(
+                f"Could not find charm {charm_name!r} in channel {channel!r} "
+                f"with base {base!r}"
+            )
+        return revisions
 
     def get_charm_channel_for_revision(
         self,

--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -1637,6 +1637,37 @@ class JujuHelper:
             f"with base {base!r}"
         )
 
+    def get_charm_channel_for_revision(
+        self,
+        charm_name: str,
+        revision: int,
+    ) -> str | None:
+        """Return the first channel (track/risk) that publishes a given revision.
+
+        Scans all channels returned by ``juju info`` for *charm_name* and returns
+        the channel name (e.g. ``"1.32/stable"``) for the first entry whose
+        revision number matches *revision*.  Returns ``None`` if the revision is
+        not found in any channel.
+
+        :param charm_name: Name of charm to look up
+        :param revision: Charm revision number to find
+        """
+        output = json.loads(
+            self._juju.cli(
+                "info",
+                "--format",
+                "json",
+                charm_name,
+                include_model=False,
+            )
+        )
+        for track, risks in output.get("channels", {}).items():
+            for risk, entries in risks.items():
+                for entry in entries:
+                    if entry.get("revision") == revision:
+                        return f"{track}/{risk}"
+        return None
+
     @staticmethod
     def manual_cloud(cloud_name: str, ip_address: str) -> dict[str, dict]:
         """Create manual cloud definition."""

--- a/sunbeam-python/sunbeam/steps/charm_upgrade.py
+++ b/sunbeam-python/sunbeam/steps/charm_upgrade.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared logic for deciding whether a charm needs refreshing."""
+
+import logging
+from typing import NamedTuple
+
+import jubilant.statustypes
+
+from sunbeam.core.common import Result, ResultType
+from sunbeam.core.juju import ApplicationNotFoundException, JujuException, JujuHelper
+from sunbeam.core.manifest import Manifest
+
+LOG = logging.getLogger(__name__)
+
+
+class CharmRefreshDecision(NamedTuple):
+    """Decision returned by check_charm_needs_refresh.
+
+    Attributes:
+        result: SKIPPED (already up-to-date or not deployed), FAILED (invalid
+            channel/track), or COMPLETED (refresh needed).
+        effective_channel: The resolved channel to pass to charm_refresh.
+        needs_channel_flag: True when --channel must be passed to charm_refresh
+            (e.g. a risk-level change or an allowed track upgrade).
+        effective_revision: Pinned revision to pass to charm_refresh, or None
+            for latest in channel.
+        app_not_deployed: True when SKIPPED because the application is not
+            deployed (as opposed to already up-to-date).
+    """
+
+    result: Result
+    effective_channel: str
+    needs_channel_flag: bool = False
+    effective_revision: int | None = None
+    app_not_deployed: bool = False
+
+
+def _track_version(track: str) -> tuple:
+    """Parse a version track like '1.18' into a comparable tuple of ints."""
+    try:
+        return tuple(int(x) for x in track.split("."))
+    except ValueError:
+        return (0,)
+
+
+def _check_revision_only(
+    jhelper: JujuHelper,
+    charm_name: str,
+    app: "jubilant.statustypes.AppStatus",
+    manifest_revision: int,
+    deployed_channel: str | None,
+    effective_channel: str,
+    support_track_upgrades: bool,
+) -> CharmRefreshDecision:
+    """Handle the revision-only path (manifest has revision but no channel)."""
+    if app.charm_rev == manifest_revision:
+        return CharmRefreshDecision(
+            result=Result(
+                ResultType.SKIPPED,
+                f"{charm_name} already at manifest pinned revision {manifest_revision}",
+            ),
+            effective_channel=effective_channel,
+        )
+    if not support_track_upgrades and deployed_channel:
+        deployed_track = deployed_channel.split("/")[0]
+        try:
+            revision_channel = jhelper.get_charm_channel_for_revision(
+                charm_name, manifest_revision
+            )
+        except JujuException as e:
+            LOG.debug(
+                "Could not determine channel for revision %s: %s",
+                manifest_revision,
+                e,
+            )
+            revision_channel = None
+
+        if revision_channel:
+            revision_track = revision_channel.split("/")[0]
+            if deployed_track != revision_track:
+                return CharmRefreshDecision(
+                    result=Result(
+                        ResultType.FAILED,
+                        f"Revision {manifest_revision} belongs to channel "
+                        f"{revision_channel!r} (track {revision_track!r}), "
+                        f"but the deployed charm is on track "
+                        f"{deployed_track!r}. "
+                        "Track changes are not supported by this command.",
+                    ),
+                    effective_channel=effective_channel,
+                )
+    return CharmRefreshDecision(
+        result=Result(ResultType.COMPLETED),
+        effective_channel=effective_channel,
+        effective_revision=manifest_revision,
+    )
+
+
+def _check_patch_upgrade(
+    jhelper: JujuHelper,
+    charm_name: str,
+    app: "jubilant.statustypes.AppStatus",
+    effective_channel: str,
+) -> CharmRefreshDecision:
+    """Handle patch upgrade: check whether a newer revision is available."""
+    try:
+        if app.base:
+            base = f"{app.base.name}@{app.base.channel}"
+            latest_revs = jhelper.get_available_charm_revisions(
+                charm_name, effective_channel, base
+            )
+        else:
+            latest_revs = jhelper.get_available_charm_revisions(
+                charm_name, effective_channel
+            )
+    except JujuException as e:
+        LOG.debug("Could not determine latest revision for %s: %s", charm_name, e)
+        return CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED),
+            effective_channel=effective_channel,
+        )
+
+    if app.charm_rev in latest_revs.values():
+        return CharmRefreshDecision(
+            result=Result(
+                ResultType.SKIPPED,
+                f"{charm_name} is already at the latest revision"
+                f" {app.charm_rev} for channel {effective_channel}",
+            ),
+            effective_channel=effective_channel,
+        )
+    return CharmRefreshDecision(
+        result=Result(ResultType.COMPLETED),
+        effective_channel=effective_channel,
+    )
+
+
+def check_charm_needs_refresh(
+    jhelper: JujuHelper,
+    manifest: Manifest,
+    charm_name: str,
+    model: str,
+    application: str,
+    default_channel: str,
+    support_track_upgrades: bool = False,
+) -> CharmRefreshDecision:
+    """Determine whether a charm needs refreshing and how.
+
+    Effective channel resolution (no manifest channel set):
+    - minimum_track is derived from default_channel.
+    - If the deployed track meets the minimum, the deployed channel is used.
+    - If the deployed track is below the minimum and support_track_upgrades is
+      True, fall back to default_channel (e.g. vault).
+    - If the deployed track is below the minimum and support_track_upgrades is
+      False, emit a warning and stay on the deployed channel for a same-track
+      patch refresh (e.g. k8s).
+    - A manifest channel whose track is below the minimum always returns FAILED.
+
+    Args:
+        jhelper: JujuHelper instance.
+        manifest: Manifest to read charm channel/revision from.
+        charm_name: CharmHub charm name (e.g. "vault-k8s", "k8s").
+        model: Juju model name.
+        application: Juju application name.
+        default_channel: Fallback channel when the deployed track is below
+            the derived minimum or there is no deployed channel.
+        support_track_upgrades: If True, track changes are allowed (vault).
+            If False, track changes return FAILED (k8s).
+
+    Returns:
+        CharmRefreshDecision with result, effective_channel, needs_channel_flag.
+    """
+    try:
+        app = jhelper.get_application(application, model)
+    except ApplicationNotFoundException:
+        return CharmRefreshDecision(
+            result=Result(
+                ResultType.SKIPPED,
+                f"{application!r} application has not been deployed yet",
+            ),
+            effective_channel=default_channel,
+            app_not_deployed=True,
+        )
+
+    charm_manifest = manifest.find_charm(charm_name)
+    manifest_channel: str | None = charm_manifest.channel if charm_manifest else None
+    manifest_revision: int | None = charm_manifest.revision if charm_manifest else None
+    deployed_channel: str | None = app.charm_channel
+
+    # Minimum track is always derived from default_channel.
+    minimum_track: str = default_channel.split("/")[0]
+
+    # ------------------------------------------------------------------
+    # Effective channel resolution
+    # ------------------------------------------------------------------
+    # Manifest channel wins when explicitly set.
+    # Without a manifest channel: stay on the deployed channel if its track
+    # meets the minimum, otherwise fall back to default_channel (vault) or
+    # fail (k8s, where track changes are not allowed).
+    if manifest_channel:
+        effective_channel = manifest_channel
+    elif deployed_channel and (
+        _track_version(deployed_channel.split("/")[0]) >= _track_version(minimum_track)
+    ):
+        effective_channel = deployed_channel
+    elif deployed_channel and not support_track_upgrades:
+        # Deployed track is below minimum but track changes are not supported.
+        # Warn and stay on the deployed channel for a same-track patch refresh.
+        LOG.warning(
+            "Deployed track %r is below the minimum supported track %r. "
+            "Refreshing within the deployed track.",
+            deployed_channel.split("/")[0],
+            minimum_track,
+        )
+        effective_channel = deployed_channel
+    else:
+        effective_channel = default_channel
+
+    effective_track: str = effective_channel.split("/")[0]
+
+    # ------------------------------------------------------------------
+    # Downgrade guard: manifest channel below minimum_track → FAILED
+    # ------------------------------------------------------------------
+    if manifest_channel:
+        manifest_track = manifest_channel.split("/")[0]
+        if _track_version(manifest_track) < _track_version(minimum_track):
+            LOG.warning(
+                "Manifest channel %r track is below minimum supported track %r.",
+                manifest_channel,
+                minimum_track,
+            )
+            return CharmRefreshDecision(
+                result=Result(
+                    ResultType.FAILED,
+                    f"Manifest channel {manifest_channel!r} track is below "
+                    f"minimum supported track {minimum_track!r}. "
+                    "Cannot refresh to this channel.",
+                ),
+                effective_channel=effective_channel,
+            )
+
+    # ------------------------------------------------------------------
+    # Revision-only path: manifest has revision but no channel
+    # ------------------------------------------------------------------
+    if manifest_revision is not None and not manifest_channel:
+        return _check_revision_only(
+            jhelper,
+            charm_name,
+            app,
+            manifest_revision,
+            deployed_channel,
+            effective_channel,
+            support_track_upgrades,
+        )
+
+    # ------------------------------------------------------------------
+    # Track change guard (when support_track_upgrades=False)
+    # ------------------------------------------------------------------
+    if not support_track_upgrades and manifest_channel and deployed_channel:
+        deployed_track = deployed_channel.split("/")[0]
+        if deployed_track != effective_track:
+            return CharmRefreshDecision(
+                result=Result(
+                    ResultType.FAILED,
+                    f"Channel track change from {deployed_track!r} to "
+                    f"{effective_track!r} is not supported by this command.",
+                ),
+                effective_channel=effective_channel,
+            )
+
+    # needs_channel_flag: True when effective channel differs from the
+    # deployed one (risk-level change within same track, or track upgrade
+    # for charms that allow it).
+    needs_channel_flag = bool(
+        deployed_channel and deployed_channel != effective_channel
+    )
+
+    # ------------------------------------------------------------------
+    # Exact revision + channel match → SKIPPED
+    # ------------------------------------------------------------------
+    if manifest_revision is not None:
+        if deployed_channel == effective_channel and app.charm_rev == manifest_revision:
+            return CharmRefreshDecision(
+                result=Result(
+                    ResultType.SKIPPED,
+                    f"{charm_name} already at manifest pinned revision"
+                    f" {manifest_revision} for channel {effective_channel}",
+                ),
+                effective_channel=effective_channel,
+                needs_channel_flag=needs_channel_flag,
+            )
+        return CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED),
+            effective_channel=effective_channel,
+            needs_channel_flag=needs_channel_flag,
+            effective_revision=manifest_revision,
+        )
+
+    # ------------------------------------------------------------------
+    # Risk/track change: always proceed without a revision check
+    # ------------------------------------------------------------------
+    if needs_channel_flag:
+        return CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED),
+            effective_channel=effective_channel,
+            needs_channel_flag=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Patch upgrade: check whether a newer revision is available
+    # ------------------------------------------------------------------
+    return _check_patch_upgrade(jhelper, charm_name, app, effective_channel)

--- a/sunbeam-python/sunbeam/steps/k8s_upgrade.py
+++ b/sunbeam-python/sunbeam/steps/k8s_upgrade.py
@@ -12,7 +12,6 @@ from sunbeam.core.common import (
 )
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import (
-    ApplicationNotFoundException,
     JujuException,
     JujuHelper,
     JujuStepHelper,
@@ -20,6 +19,7 @@ from sunbeam.core.juju import (
     LeaderNotFoundException,
 )
 from sunbeam.core.manifest import Manifest
+from sunbeam.steps.charm_upgrade import CharmRefreshDecision, check_charm_needs_refresh
 from sunbeam.versions import K8S_CHANNEL
 
 LOG = logging.getLogger(__name__)
@@ -65,149 +65,36 @@ class K8SCharmUpgradeStep(BaseStep, JujuStepHelper):
         self.manifest = manifest
         self.jhelper = jhelper
         self.application = application
-        self._target_channel: str = K8S_CHANNEL
-        self._needs_channel_flag = False
+        self._decision: CharmRefreshDecision  # set by is_skip()
 
     @property
     def model(self) -> str:
         """Return the model where the k8s charm is deployed."""
         return self.deployment.openstack_machines_model
 
-    def _manifest_channel(self) -> str | None:
-        """Return the channel from the manifest, or None if not explicitly set."""
-        charm_manifest = self.manifest.find_charm(CHARM_NAME)
-        return (charm_manifest.channel if charm_manifest else None) or None
-
-    def _resolve_target_channel(self) -> str:
-        """Return the target channel from the manifest, falling back to K8S_CHANNEL."""
-        return self._manifest_channel() or K8S_CHANNEL
-
-    def _resolve_target_revision(self) -> int | None:
-        """Return the pinned revision from the manifest, or None."""
-        charm_manifest = self.manifest.find_charm(CHARM_NAME)
-        return charm_manifest.revision if charm_manifest else None
-
     def is_skip(self, context: StepContext) -> Result:
         """Skip if k8s is not deployed or already at the target revision."""
-        try:
-            app = self.jhelper.get_application(self.application, self.model)
-        except ApplicationNotFoundException:
+        decision = check_charm_needs_refresh(
+            self.jhelper,
+            self.manifest,
+            CHARM_NAME,
+            self.model,
+            self.application,
+            default_channel=K8S_CHANNEL,
+            support_track_upgrades=False,
+        )
+        self._decision = decision
+        if decision.result.result_type == ResultType.FAILED:
             return Result(
-                ResultType.SKIPPED,
-                f"{self.application!r} application has not been deployed yet",
+                ResultType.FAILED,
+                f"k8s upgrade failed: {decision.result.message}",
             )
-
-        target_revision = self._resolve_target_revision()
-        manifest_channel = self._manifest_channel()
-        deployed_channel = app.charm_channel or ""
-
-        # When the user provides only a revision (no channel in the manifest),
-        # try to resolve which channel that revision belongs to so we can still
-        # enforce the no-track-change rule.
-        if target_revision is not None and manifest_channel is None:
-            self._needs_channel_flag = False
-            if app.charm_rev == target_revision:
-                return Result(
-                    ResultType.SKIPPED,
-                    f"{CHARM_NAME} already at manifest pinned revision"
-                    f" {target_revision}",
-                )
-            # Look up the channel for the requested revision on CharmHub.
-            try:
-                revision_channel = self.jhelper.get_charm_channel_for_revision(
-                    CHARM_NAME, target_revision
-                )
-            except JujuException as e:
-                LOG.debug(
-                    "Could not determine channel for revision %s: %s",
-                    target_revision,
-                    e,
-                )
-                revision_channel = None
-
-            if revision_channel and deployed_channel:
-                deployed_track = deployed_channel.split("/")[0]
-                revision_track = revision_channel.split("/")[0]
-                if deployed_track != revision_track:
-                    return Result(
-                        ResultType.FAILED,
-                        "k8s upgrade failed: "
-                        f"Revision {target_revision} belongs to channel "
-                        f"{revision_channel!r} (track {revision_track!r}), "
-                        f"but the deployed charm is on track {deployed_track!r}. "
-                        "Track changes are not supported by this command.",
-                    )
-            return Result(ResultType.COMPLETED)
-
-        # When no manifest channel is set, stay on whatever channel is already
-        # deployed — this is a patch-only refresh within the same channel/risk.
-        # Only switch channel when the manifest explicitly requests one.
-        effective_target_channel = manifest_channel or deployed_channel or K8S_CHANNEL
-
-        # Block channel track changes (e.g. 1.32 -> 1.35) only when the manifest
-        # explicitly requests a different channel.
-        if manifest_channel and deployed_channel:
-            deployed_track = deployed_channel.split("/")[0]
-            target_track = effective_target_channel.split("/")[0]
-            if deployed_track != target_track:
-                return Result(
-                    ResultType.FAILED,
-                    "k8s upgrade failed: "
-                    f"Channel track change from {deployed_track!r} to "
-                    f"{target_track!r} is not supported by this command. ",
-                )
-
-        # _needs_channel_flag: True when the manifest requests a different risk
-        # level (e.g. stable -> edge). --channel will be passed to charm_refresh.
-        self._needs_channel_flag = deployed_channel != effective_target_channel
-
-        # If a specific revision is pinned together with a channel and already
-        # deployed at that exact combination, there is nothing to do.
-        if target_revision is not None:
-            if (
-                deployed_channel == effective_target_channel
-                and app.charm_rev == target_revision
-            ):
-                return Result(
-                    ResultType.SKIPPED,
-                    f"{CHARM_NAME} already at manifest pinned revision "
-                    f"{target_revision} for channel {effective_target_channel}",
-                )
-            return Result(ResultType.COMPLETED)
-
-        # For risk-level changes, always proceed (no revision check needed).
-        if self._needs_channel_flag:
-            return Result(ResultType.COMPLETED)
-
-        # Patch upgrade: check whether a newer revision is available.
-        try:
-            if app.base:
-                base = f"{app.base.name}@{app.base.channel}"
-                latest_rev = self.jhelper.get_available_charm_revision(
-                    CHARM_NAME, effective_target_channel, base
-                )
-            else:
-                latest_rev = self.jhelper.get_available_charm_revision(
-                    CHARM_NAME, effective_target_channel
-                )
-        except JujuException as e:
-            LOG.debug("Could not determine latest revision for %s: %s", CHARM_NAME, e)
-            # Can't determine; proceed with the refresh anyway.
-            return Result(ResultType.COMPLETED)
-
-        if app.charm_rev == latest_rev:
-            return Result(
-                ResultType.SKIPPED,
-                f"{CHARM_NAME} is already at the latest revision "
-                f"{latest_rev} for channel {effective_target_channel}",
-            )
-
-        return Result(ResultType.COMPLETED)
+        return decision.result
 
     def run(self, context: StepContext) -> Result:
         """Execute the k8s charm upgrade procedure."""
-        target_channel = self._resolve_target_channel()
-        target_revision = self._resolve_target_revision()
+        target_channel = self._decision.effective_channel
+        target_revision = self._decision.effective_revision
 
         # Step 1: pre-upgrade-check
         try:
@@ -239,7 +126,7 @@ class K8SCharmUpgradeStep(BaseStep, JujuStepHelper):
 
         # Step 2: juju refresh k8s [--channel CHANNEL]
         # Pass --channel only when the risk level differs from the deployed channel.
-        refresh_channel = target_channel if self._needs_channel_flag else None
+        refresh_channel = target_channel if self._decision.needs_channel_flag else None
         LOG.info(
             "Refreshing %s charm%s",
             self.application,

--- a/sunbeam-python/sunbeam/steps/k8s_upgrade.py
+++ b/sunbeam-python/sunbeam/steps/k8s_upgrade.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from sunbeam.clusterd.client import Client
+from sunbeam.core.common import (
+    BaseStep,
+    Result,
+    ResultType,
+    StepContext,
+)
+from sunbeam.core.deployment import Deployment
+from sunbeam.core.juju import (
+    ApplicationNotFoundException,
+    JujuException,
+    JujuHelper,
+    JujuStepHelper,
+    JujuWaitException,
+    LeaderNotFoundException,
+)
+from sunbeam.core.manifest import Manifest
+from sunbeam.versions import K8S_CHANNEL
+
+LOG = logging.getLogger(__name__)
+
+CHARM_NAME = "k8s"
+K8S_UPGRADE_TIMEOUT = 3600  # 1 hour — k8s snap is updated unit-by-unit
+
+
+class K8SCharmUpgradeStep(BaseStep, JujuStepHelper):
+    """Upgrade the k8s charm following the Canonical Kubernetes upgrade procedure.
+
+    Supports patch upgrades and risk-level changes within the same channel track.
+    Track changes (e.g. 1.32 -> 1.35) are not supported and will return FAILED.
+
+    Patch (same channel, new revision):
+        1. juju run k8s/leader pre-upgrade-check
+        2. juju refresh k8s
+        3. Wait for k8s to become active
+
+    Risk change (same track, different risk, e.g. 1.32/stable -> 1.32/edge):
+        1. juju run k8s/leader pre-upgrade-check
+        2. juju refresh k8s --channel <new-channel>
+        3. Wait for k8s to become active
+
+    References:
+        https://documentation.ubuntu.com/canonical-kubernetes/latest/charm/howto/upgrade-patch/
+    """
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        manifest: Manifest,
+        jhelper: JujuHelper,
+        application: str = CHARM_NAME,
+    ):
+        super().__init__(
+            "Refresh k8s",
+            "Refreshing k8s charm",
+        )
+        self.deployment = deployment
+        self.client = client
+        self.manifest = manifest
+        self.jhelper = jhelper
+        self.application = application
+        self._target_channel: str = K8S_CHANNEL
+        self._needs_channel_flag = False
+
+    @property
+    def model(self) -> str:
+        """Return the model where the k8s charm is deployed."""
+        return self.deployment.openstack_machines_model
+
+    def _manifest_channel(self) -> str | None:
+        """Return the channel from the manifest, or None if not explicitly set."""
+        charm_manifest = self.manifest.find_charm(CHARM_NAME)
+        return (charm_manifest.channel if charm_manifest else None) or None
+
+    def _resolve_target_channel(self) -> str:
+        """Return the target channel from the manifest, falling back to K8S_CHANNEL."""
+        return self._manifest_channel() or K8S_CHANNEL
+
+    def _resolve_target_revision(self) -> int | None:
+        """Return the pinned revision from the manifest, or None."""
+        charm_manifest = self.manifest.find_charm(CHARM_NAME)
+        return charm_manifest.revision if charm_manifest else None
+
+    def is_skip(self, context: StepContext) -> Result:
+        """Skip if k8s is not deployed or already at the target revision."""
+        try:
+            app = self.jhelper.get_application(self.application, self.model)
+        except ApplicationNotFoundException:
+            return Result(
+                ResultType.SKIPPED,
+                f"{self.application!r} application has not been deployed yet",
+            )
+
+        target_revision = self._resolve_target_revision()
+        manifest_channel = self._manifest_channel()
+        deployed_channel = app.charm_channel or ""
+
+        # When the user provides only a revision (no channel in the manifest),
+        # try to resolve which channel that revision belongs to so we can still
+        # enforce the no-track-change rule.
+        if target_revision is not None and manifest_channel is None:
+            self._needs_channel_flag = False
+            if app.charm_rev == target_revision:
+                return Result(
+                    ResultType.SKIPPED,
+                    f"{CHARM_NAME} already at manifest pinned revision"
+                    f" {target_revision}",
+                )
+            # Look up the channel for the requested revision on CharmHub.
+            try:
+                revision_channel = self.jhelper.get_charm_channel_for_revision(
+                    CHARM_NAME, target_revision
+                )
+            except JujuException as e:
+                LOG.debug(
+                    "Could not determine channel for revision %s: %s",
+                    target_revision,
+                    e,
+                )
+                revision_channel = None
+
+            if revision_channel and deployed_channel:
+                deployed_track = deployed_channel.split("/")[0]
+                revision_track = revision_channel.split("/")[0]
+                if deployed_track != revision_track:
+                    return Result(
+                        ResultType.FAILED,
+                        "k8s upgrade failed: "
+                        f"Revision {target_revision} belongs to channel "
+                        f"{revision_channel!r} (track {revision_track!r}), "
+                        f"but the deployed charm is on track {deployed_track!r}. "
+                        "Track changes are not supported by this command.",
+                    )
+            return Result(ResultType.COMPLETED)
+
+        # When no manifest channel is set, stay on whatever channel is already
+        # deployed — this is a patch-only refresh within the same channel/risk.
+        # Only switch channel when the manifest explicitly requests one.
+        effective_target_channel = manifest_channel or deployed_channel or K8S_CHANNEL
+
+        # Block channel track changes (e.g. 1.32 -> 1.35) only when the manifest
+        # explicitly requests a different channel.
+        if manifest_channel and deployed_channel:
+            deployed_track = deployed_channel.split("/")[0]
+            target_track = effective_target_channel.split("/")[0]
+            if deployed_track != target_track:
+                return Result(
+                    ResultType.FAILED,
+                    "k8s upgrade failed: "
+                    f"Channel track change from {deployed_track!r} to "
+                    f"{target_track!r} is not supported by this command. ",
+                )
+
+        # _needs_channel_flag: True when the manifest requests a different risk
+        # level (e.g. stable -> edge). --channel will be passed to charm_refresh.
+        self._needs_channel_flag = deployed_channel != effective_target_channel
+
+        # If a specific revision is pinned together with a channel and already
+        # deployed at that exact combination, there is nothing to do.
+        if target_revision is not None:
+            if (
+                deployed_channel == effective_target_channel
+                and app.charm_rev == target_revision
+            ):
+                return Result(
+                    ResultType.SKIPPED,
+                    f"{CHARM_NAME} already at manifest pinned revision "
+                    f"{target_revision} for channel {effective_target_channel}",
+                )
+            return Result(ResultType.COMPLETED)
+
+        # For risk-level changes, always proceed (no revision check needed).
+        if self._needs_channel_flag:
+            return Result(ResultType.COMPLETED)
+
+        # Patch upgrade: check whether a newer revision is available.
+        try:
+            if app.base:
+                base = f"{app.base.name}@{app.base.channel}"
+                latest_rev = self.jhelper.get_available_charm_revision(
+                    CHARM_NAME, effective_target_channel, base
+                )
+            else:
+                latest_rev = self.jhelper.get_available_charm_revision(
+                    CHARM_NAME, effective_target_channel
+                )
+        except JujuException as e:
+            LOG.debug("Could not determine latest revision for %s: %s", CHARM_NAME, e)
+            # Can't determine; proceed with the refresh anyway.
+            return Result(ResultType.COMPLETED)
+
+        if app.charm_rev == latest_rev:
+            return Result(
+                ResultType.SKIPPED,
+                f"{CHARM_NAME} is already at the latest revision "
+                f"{latest_rev} for channel {effective_target_channel}",
+            )
+
+        return Result(ResultType.COMPLETED)
+
+    def run(self, context: StepContext) -> Result:
+        """Execute the k8s charm upgrade procedure."""
+        target_channel = self._resolve_target_channel()
+        target_revision = self._resolve_target_revision()
+
+        # Step 1: pre-upgrade-check
+        try:
+            leader = self.jhelper.get_leader_unit(self.application, self.model)
+        except LeaderNotFoundException as e:
+            return Result(
+                ResultType.FAILED,
+                "k8s upgrade failed: "
+                f"Unable to determine leader unit for {self.application!r}: {e}\n"
+                f"Check application status with `juju status -m {self.model} k8s` "
+                "and re-run `sunbeam cluster refresh k8s` to retry.",
+            )
+
+        try:
+            self.update_status(
+                context,
+                f"Running pre-upgrade-check on {leader}",
+            )
+            self.jhelper.run_action(leader, self.model, "pre-upgrade-check")
+        except JujuException as e:
+            return Result(
+                ResultType.FAILED,
+                "k8s upgrade failed: "
+                f"pre-upgrade-check failed on {leader}: {e}\n"
+                f"Check cluster readiness with `juju status -m {self.model} k8s` "
+                "and resolve any issues before re-running "
+                "`sunbeam cluster refresh k8s` to retry.",
+            )
+
+        # Step 2: juju refresh k8s [--channel CHANNEL]
+        # Pass --channel only when the risk level differs from the deployed channel.
+        refresh_channel = target_channel if self._needs_channel_flag else None
+        LOG.info(
+            "Refreshing %s charm%s",
+            self.application,
+            f" to channel {target_channel}" if refresh_channel else "",
+        )
+        try:
+            self.update_status(
+                context,
+                f"Refreshing {self.application} charm"
+                + (f" to channel {target_channel}" if refresh_channel else ""),
+            )
+            self.jhelper.charm_refresh(
+                self.application,
+                self.model,
+                channel=refresh_channel,
+                revision=target_revision,
+            )
+        except JujuException as e:
+            return Result(
+                ResultType.FAILED,
+                "k8s upgrade failed: "
+                f"Failed to refresh {self.application!r}: {e}\n"
+                f"Check application status with `juju status -m {self.model} k8s` "
+                "and re-run `sunbeam cluster refresh k8s` to retry.",
+            )
+
+        # Step 3: Wait for k8s to return to active.
+        # During the upgrade units cycle through maintenance; allow that status
+        # as well as active so the wait does not terminate prematurely.
+        try:
+            self.update_status(
+                context,
+                f"Waiting for {self.application} to complete upgrade",
+            )
+            self.jhelper.wait_until_active(
+                self.model,
+                apps=[self.application],
+                timeout=K8S_UPGRADE_TIMEOUT,
+            )
+        except (JujuWaitException, TimeoutError) as e:
+            return Result(
+                ResultType.FAILED,
+                "k8s upgrade failed: "
+                f"Timed out waiting for {self.application!r} to become active "
+                f"after refresh: {e}\n"
+                f"Monitor unit progress with "
+                f"`juju status -m {self.model} k8s --watch 5s` "
+                "and re-run `sunbeam cluster refresh k8s` once the cluster is healthy.",
+            )
+
+        return Result(ResultType.COMPLETED, "k8s charm refreshed.")

--- a/sunbeam-python/sunbeam/steps/mysql.py
+++ b/sunbeam-python/sunbeam/steps/mysql.py
@@ -479,18 +479,16 @@ class MySQLCharmUpgradeStep(BaseStep, JujuStepHelper):
         deployed = app.charm_rev
         if app.base:
             base = f"{app.base.name}@{app.base.channel}"
-            latest = self.jhelper.get_available_charm_revision(
+            latest_revs = self.jhelper.get_available_charm_revisions(
                 MYSQL_CHARM,
                 deployed_channel,
                 base,
-                arch="amd64",
             )
         else:
             LOG.debug("Could not determine base for mysql-k8s.")
-            latest = self.jhelper.get_available_charm_revision(
+            latest_revs = self.jhelper.get_available_charm_revisions(
                 MYSQL_CHARM,
                 deployed_channel,
-                arch="amd64",
             )
         try:
             leader = self.jhelper.get_leader_unit(self.application, self.model)
@@ -502,7 +500,7 @@ class MySQLCharmUpgradeStep(BaseStep, JujuStepHelper):
         unit_data = self.jhelper.show_unit(self.model, leader)
         stack_empty = not self._get_upgrade_stack(unit_data)
         # charm is already at the latest revision and no upgrade in progress
-        if deployed == latest and stack_empty:
+        if deployed in latest_revs.values() and stack_empty:
             msg = f"mysql-k8s already at latest revision {deployed}"
             LOG.debug(msg)
             return Result(ResultType.SKIPPED, msg)

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -30,7 +30,6 @@ from sunbeam.features.interface.v1.base import is_maas_deployment
 from sunbeam.steps.cinder_volume import DeployCinderVolumeApplicationStep
 from sunbeam.steps.hypervisor import ReapplyHypervisorTerraformPlanStep
 from sunbeam.steps.k8s import (
-    DeployK8SApplicationStep,
     EnsureCiliumDeviceByHostStep,
     EnsureDefaultL2AdvertisementMutedStep,
     EnsureL2AdvertisementByHostStep,
@@ -50,7 +49,7 @@ from sunbeam.steps.upgrades.base import UpgradeCoordinator, UpgradeFeatures
 LOG = logging.getLogger(__name__)
 console = Console()
 
-INFRA_APPS = ["mysql-k8s", "vault-k8s"]
+INFRA_APPS = ["mysql-k8s", "vault-k8s", "k8s"]
 
 # Snap-based charm applications that expose a refresh-snap action.
 # These need to be refreshed explicitly after the charm refresh because
@@ -440,22 +439,11 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
             from sunbeam.provider.maas.client import MaasClient  # noqa: PLC0415
             from sunbeam.provider.maas.steps import (  # noqa: PLC0415
                 MaasCreateLoadBalancerIPPoolsStep,
-                MaasDeployK8SApplicationStep,
             )
 
             maas_client = MaasClient.from_deployment(self.deployment)
             plan.extend(
                 [
-                    TerraformInitStep(self.deployment.get_tfhelper("k8s-plan")),
-                    MaasDeployK8SApplicationStep(
-                        self.deployment,  # type: ignore [arg-type]
-                        self.client,
-                        maas_client,
-                        self.deployment.get_tfhelper("k8s-plan"),
-                        self.jhelper,
-                        self.manifest,
-                        self.deployment.openstack_machines_model,
-                    ),
                     EnsureCiliumDeviceByHostStep(
                         self.deployment,
                         self.client,
@@ -495,16 +483,6 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
         else:
             plan.extend(
                 [
-                    TerraformInitStep(self.deployment.get_tfhelper("k8s-plan")),
-                    DeployK8SApplicationStep(
-                        self.deployment,
-                        self.client,
-                        self.deployment.get_tfhelper("k8s-plan"),
-                        self.jhelper,
-                        self.manifest,
-                        self.deployment.openstack_machines_model,
-                        refresh=True,
-                    ),
                     EnsureCiliumDeviceByHostStep(
                         self.deployment,
                         self.client,

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -93,6 +93,9 @@ class LatestInChannel(BaseStep, JujuStepHelper):
     def is_track_changed_for_any_charm(self, deployed_apps: dict):
         """Check if chanel track is same in manifest and deployed app."""
         for app_name, (charm, channel, _) in deployed_apps.items():
+            # Infra apps are managed by dedicated subcommands; skip them.
+            if charm in INFRA_APPS:
+                continue
             charm_manifest = self.manifest.core.software.charms.get(charm)
             if not charm_manifest:
                 for _, feature in self.manifest.get_features():

--- a/sunbeam-python/sunbeam/steps/vault.py
+++ b/sunbeam-python/sunbeam/steps/vault.py
@@ -12,7 +12,6 @@ from sunbeam.core.common import (
 )
 from sunbeam.core.deployment import Deployment
 from sunbeam.core.juju import (
-    ApplicationNotFoundException,
     JujuException,
     JujuHelper,
     JujuStepHelper,
@@ -33,6 +32,7 @@ from sunbeam.features.vault.feature import (
     auto_unseal_vault,
     migrate_vault_config_in_db,
 )
+from sunbeam.steps.charm_upgrade import CharmRefreshDecision, check_charm_needs_refresh
 from sunbeam.versions import VAULT_CHANNEL
 
 LOG = logging.getLogger(__name__)
@@ -65,7 +65,7 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
         self.tfhelper = tfhelper
         self.application = application
         self.tfvar_config = OPENSTACK_TERRAFORM_VARS
-        self._skip_charm_refresh = False
+        self._decision: CharmRefreshDecision
 
     def upgrade(
         self, revision: int | None = None, channel: str = VAULT_CHANNEL
@@ -81,75 +81,6 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
             trust=True,
         )
 
-    def _needs_charm_refresh(self) -> Result:
-        """Determine whether the charm itself needs refreshing.
-
-        Returns SKIPPED when the deployed charm already matches the target,
-        FAILED when the manifest channel is invalid, COMPLETED otherwise.
-        """
-        try:
-            app = self.jhelper.get_application(self.application, OPENSTACK_MODEL)
-        except ApplicationNotFoundException:
-            return Result(
-                ResultType.SKIPPED,
-                f"{self.application} application has not been deployed yet",
-            )
-
-        charm_manifest = self.manifest.find_charm(CHARM_NAME)
-        target_channel = (
-            charm_manifest.channel if charm_manifest else None
-        ) or VAULT_CHANNEL
-        deployed_channel = app.charm_channel or ""
-
-        if charm_manifest and charm_manifest.channel:
-            target_track = target_channel.split("/")[0]
-            minimum_vault_track = VAULT_CHANNEL.split("/")[0]
-            if target_track != minimum_vault_track and not self.channel_update_needed(
-                VAULT_CHANNEL, target_channel
-            ):
-                msg = (
-                    f"Manifest channel {target_channel} track is below "
-                    f"{VAULT_CHANNEL}. "
-                    "Can not refresh to this channel."
-                )
-                LOG.warning(msg)
-                return Result(ResultType.FAILED, msg)
-
-        if charm_manifest and charm_manifest.revision:
-            if (
-                deployed_channel == target_channel
-                and app.charm_rev == charm_manifest.revision
-            ):
-                msg = (
-                    f"{CHARM_NAME} already at manifest pinned revision "
-                    f"{charm_manifest.revision} for channel {target_channel}"
-                )
-                LOG.debug(msg)
-                return Result(ResultType.SKIPPED, msg)
-            return Result(ResultType.COMPLETED)
-
-        try:
-            if app.base:
-                base = f"{app.base.name}@{app.base.channel}"
-                latest_rev = self.jhelper.get_available_charm_revision(
-                    CHARM_NAME, target_channel, base, arch="amd64"
-                )
-            else:
-                latest_rev = self.jhelper.get_available_charm_revision(
-                    CHARM_NAME, target_channel, arch="amd64"
-                )
-        except JujuException as e:
-            LOG.debug("Could not determine latest revision for %s: %s", CHARM_NAME, e)
-            return Result(ResultType.COMPLETED)
-
-        if deployed_channel == target_channel and app.charm_rev == latest_rev:
-            return Result(
-                ResultType.SKIPPED,
-                f"{CHARM_NAME} is already at the latest revision for "
-                f"channel {target_channel}",
-            )
-        return Result(ResultType.COMPLETED)
-
     def is_skip(self, context: StepContext) -> Result:
         """Determines if the step should be skipped or not.
 
@@ -157,30 +88,32 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
         invalid.  The step always runs otherwise so that the DB migration
         and terraform apply happen even when no charm refresh is needed.
         """
-        result = self._needs_charm_refresh()
-        if result.result_type == ResultType.FAILED:
-            return result
-        # Remember whether the charm refresh itself can be skipped so that
-        # run() can avoid the unnecessary upgrade + wait cycle.
-        self._skip_charm_refresh = result.result_type == ResultType.SKIPPED
-        try:
-            self.jhelper.get_application(self.application, OPENSTACK_MODEL)
-        except ApplicationNotFoundException:
-            return Result(
-                ResultType.SKIPPED,
-                f"{self.application} application has not been deployed yet",
-            )
+        decision = check_charm_needs_refresh(
+            self.jhelper,
+            self.manifest,
+            CHARM_NAME,
+            OPENSTACK_MODEL,
+            self.application,
+            default_channel=VAULT_CHANNEL,
+            support_track_upgrades=True,
+        )
+        if (
+            decision.app_not_deployed
+            or decision.result.result_type == ResultType.FAILED
+        ):
+            return decision.result
+        self._decision = decision
+        # Vault always runs (for DB migration + terraform apply) even when
+        # the charm itself is already up-to-date.
         return Result(ResultType.COMPLETED)
 
     def run(self, context: StepContext) -> Result:
         """Run vault-k8s charm upgrade steps."""
-        charm_manifest = self.manifest.find_charm(CHARM_NAME)
-        revision = charm_manifest.revision if charm_manifest else None
-        target_channel = (
-            charm_manifest.channel if charm_manifest else None
-        ) or VAULT_CHANNEL
+        target_channel = self._decision.effective_channel
+        revision = self._decision.effective_revision
+        skip_charm_refresh = self._decision.result.result_type == ResultType.SKIPPED
 
-        if not self._skip_charm_refresh:
+        if not skip_charm_refresh:
             try:
                 self.update_status(
                     context, f"Refreshing Vault to channel {target_channel}"
@@ -227,7 +160,7 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
                 f"Failed to apply terraform plan after vault config migration: {e}",
             )
 
-        if self._skip_charm_refresh:
+        if skip_charm_refresh:
             return Result(
                 ResultType.COMPLETED,
                 "Vault config migrated, no charm refresh needed.",

--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -658,22 +658,28 @@ def test_jhelper_update_k8s_cloud(jhelper: jujulib.JujuHelper):
         )
 
 
-def test_get_available_charm_revision(jhelper: jujulib.JujuHelper, juju):
+def test_get_available_charm_revisions(jhelper: jujulib.JujuHelper, juju):
     cmd_out = {
         "channels": {
             "legacy": {
                 "edge": [
                     {
                         "revision": 121,
+                        "architectures": ["amd64"],
                         "bases": [{"name": "ubuntu", "channel": "24.04"}],
-                    }
+                    },
+                    {
+                        "revision": 122,
+                        "architectures": ["arm64"],
+                        "bases": [{"name": "ubuntu", "channel": "24.04"}],
+                    },
                 ]
             }
         }
     }
     juju.cli.return_value = json.dumps(cmd_out)
-    revno = jhelper.get_available_charm_revision("k8s", "legacy/edge")
-    assert revno == 121
+    revisions = jhelper.get_available_charm_revisions("k8s", "legacy/edge")
+    assert revisions == {"amd64": 121, "arm64": 122}
 
 
 def test_set_app_config(jhelper: jujulib.JujuHelper, juju):

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_charm_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_charm_upgrade.py
@@ -1,0 +1,430 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+
+from sunbeam.core.common import ResultType
+from sunbeam.core.juju import ApplicationNotFoundException, JujuException
+from sunbeam.steps.charm_upgrade import check_charm_needs_refresh
+
+DEFAULT_CHANNEL = "1.18/stable"
+CHARM_NAME = "test-charm"
+MODEL = "test-model"
+APPLICATION = "test-app"
+
+
+@pytest.fixture
+def jhelper():
+    return Mock()
+
+
+@pytest.fixture
+def manifest():
+    m = Mock()
+    m.find_charm.return_value = None
+    return m
+
+
+class TestCheckCharmNeedsRefreshAppNotDeployed:
+    def test_skipped_when_app_not_found(self, jhelper, manifest):
+        jhelper.get_application.side_effect = ApplicationNotFoundException()
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.SKIPPED
+        assert "not been deployed" in decision.result.message
+        assert decision.app_not_deployed is True
+
+
+class TestCheckCharmNeedsRefreshMinimumTrack:
+    def test_failed_when_manifest_channel_below_minimum(self, jhelper, manifest):
+        app = Mock(charm_rev=50, charm_channel="1.16/stable", base=None)
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = Mock(channel="1.16/stable", revision=None)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+        )
+
+        assert decision.result.result_type == ResultType.FAILED
+        assert "minimum supported track" in decision.result.message
+
+    def test_passes_when_manifest_channel_at_minimum(self, jhelper, manifest):
+        app = Mock(charm_rev=50, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
+        manifest.find_charm.return_value = Mock(channel="1.18/stable", revision=None)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+        )
+
+        assert decision.result.result_type != ResultType.FAILED
+
+    def test_passes_when_manifest_channel_above_minimum(self, jhelper, manifest):
+        # scenario: track upgrades allowed (e.g. vault)
+        app = Mock(charm_rev=50, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
+        manifest.find_charm.return_value = Mock(channel="1.19/stable", revision=None)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=True,
+        )
+
+        assert decision.result.result_type != ResultType.FAILED
+
+
+class TestCheckCharmNeedsRefreshEffectiveChannel:
+    def test_no_manifest_stays_on_deployed_channel_when_above_minimum(
+        self, jhelper, manifest
+    ):
+        """No manifest: uses deployed channel when track >= minimum."""
+        app = Mock(charm_rev=50, charm_channel="1.18/edge", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
+        manifest.find_charm.return_value = None
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+        )
+
+        assert decision.effective_channel == "1.18/edge"
+
+    def test_no_manifest_falls_back_to_default_when_below_minimum_and_upgrades_allowed(
+        self, jhelper, manifest
+    ):
+        """Falls back to default_channel when deployed track < minimum.
+
+        Applies when track upgrades are allowed.
+        """
+        # scenario: vault (support_track_upgrades=True)
+        app = Mock(charm_rev=50, charm_channel="1.16/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
+        manifest.find_charm.return_value = None
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=True,
+        )
+
+        assert decision.effective_channel == DEFAULT_CHANNEL
+
+    def test_no_manifest_stays_on_deployed_track_when_below_minimum_and_upgrades_not_allowed(
+        self, jhelper, manifest
+    ):
+        """Warns and stays on deployed track when deployed track < minimum.
+
+        Applies when track upgrades are not allowed.
+        """
+        # scenario: k8s (support_track_upgrades=False)
+        app = Mock(charm_rev=50, charm_channel="1.16/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
+        manifest.find_charm.return_value = None
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=False,
+        )
+
+        assert decision.result.result_type != ResultType.FAILED
+        assert decision.effective_channel == "1.16/stable"
+
+    def test_no_manifest_above_default_track_stays_on_deployed_channel(
+        self, jhelper, manifest
+    ):
+        """No manifest: deployed track above default_channel track stays on deployed."""
+        app = Mock(charm_rev=50, charm_channel="1.36/edge", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
+        manifest.find_charm.return_value = None
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            "1.35/stable",
+        )
+
+        assert decision.effective_channel == "1.36/edge"
+
+    def test_manifest_channel_wins_over_deployed(self, jhelper, manifest):
+        app = Mock(charm_rev=50, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
+        manifest.find_charm.return_value = Mock(channel="1.19/stable", revision=None)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=True,
+        )
+
+        assert decision.effective_channel == "1.19/stable"
+
+
+class TestCheckCharmNeedsRefreshRevisionOnly:
+    def test_skipped_when_already_at_revision(self, jhelper, manifest):
+        app = Mock(charm_rev=500, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.SKIPPED
+        assert "500" in decision.result.message
+
+    def test_completed_when_revision_differs(self, jhelper, manifest):
+        app = Mock(charm_rev=499, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_charm_channel_for_revision.return_value = "1.18/stable"
+        manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+        assert decision.effective_revision == 500
+
+    def test_failed_when_revision_belongs_to_different_track(self, jhelper, manifest):
+        """Track change via revision is blocked when support_track_upgrades=False."""
+        app = Mock(charm_rev=499, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_charm_channel_for_revision.return_value = "1.20/stable"
+        manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=False,
+        )
+
+        assert decision.result.result_type == ResultType.FAILED
+        assert "1.18" in decision.result.message
+        assert "1.20" in decision.result.message
+
+    def test_proceeds_when_track_lookup_fails(self, jhelper, manifest):
+        """Revision-only: proceed rather than block when CharmHub is unreachable."""
+        app = Mock(charm_rev=499, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_charm_channel_for_revision.side_effect = JujuException(
+            "network error"
+        )
+        manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=False,
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+
+    def test_no_track_check_when_support_track_upgrades_true(self, jhelper, manifest):
+        """Revision from a different track is allowed when upgrades are supported."""
+        app = Mock(charm_rev=499, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=True,
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+        jhelper.get_charm_channel_for_revision.assert_not_called()
+
+
+class TestCheckCharmNeedsRefreshTrackChange:
+    def test_failed_on_track_change_when_not_supported(self, jhelper, manifest):
+        app = Mock(charm_rev=100, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = Mock(channel="1.20/stable", revision=None)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=False,
+        )
+
+        assert decision.result.result_type == ResultType.FAILED
+        assert "track change" in decision.result.message
+
+    def test_completed_on_track_change_when_supported(self, jhelper, manifest):
+        app = Mock(charm_rev=100, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = Mock(channel="1.20/stable", revision=None)
+
+        decision = check_charm_needs_refresh(
+            jhelper,
+            manifest,
+            CHARM_NAME,
+            MODEL,
+            APPLICATION,
+            DEFAULT_CHANNEL,
+            support_track_upgrades=True,
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+        assert decision.needs_channel_flag is True
+
+
+class TestCheckCharmNeedsRefreshRiskChange:
+    def test_completed_with_channel_flag_on_risk_change(self, jhelper, manifest):
+        app = Mock(charm_rev=100, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = Mock(channel="1.18/edge", revision=None)
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+        assert decision.needs_channel_flag is True
+        assert decision.effective_channel == "1.18/edge"
+
+
+class TestCheckCharmNeedsRefreshRevisionAndChannel:
+    def test_skipped_when_exact_channel_and_revision_match(self, jhelper, manifest):
+        app = Mock(charm_rev=42, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = Mock(channel="1.18/stable", revision=42)
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.SKIPPED
+        assert "42" in decision.result.message
+
+    def test_completed_when_revision_differs(self, jhelper, manifest):
+        app = Mock(charm_rev=41, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = Mock(channel="1.18/stable", revision=42)
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+        assert decision.effective_revision == 42
+
+
+class TestCheckCharmNeedsRefreshPatchUpgrade:
+    def test_skipped_when_at_latest_revision(self, jhelper, manifest):
+        app = Mock(charm_rev=200, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
+        manifest.find_charm.return_value = None
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.SKIPPED
+        assert "200" in decision.result.message
+
+    def test_completed_when_newer_revision_available(self, jhelper, manifest):
+        app = Mock(charm_rev=199, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
+        manifest.find_charm.return_value = None
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+
+    def test_completed_when_revision_lookup_fails(self, jhelper, manifest):
+        """Proceed rather than skip when CharmHub is unreachable."""
+        app = Mock(charm_rev=200, charm_channel="1.18/stable", base=None)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.side_effect = JujuException("timeout")
+        manifest.find_charm.return_value = None
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+
+    def test_passes_base_to_revision_lookup(self, jhelper, manifest):
+        base = Mock()
+        base.name = "ubuntu"
+        base.channel = "24.04"
+        app = Mock(charm_rev=199, charm_channel="1.18/stable", base=base)
+        jhelper.get_application.return_value = app
+        jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
+        manifest.find_charm.return_value = None
+
+        check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        jhelper.get_available_charm_revisions.assert_called_once_with(
+            CHARM_NAME, "1.18/stable", "ubuntu@24.04"
+        )

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s_upgrade.py
@@ -5,13 +5,14 @@ from unittest.mock import Mock
 
 import pytest
 
-from sunbeam.core.common import ResultType
+from sunbeam.core.common import Result, ResultType
 from sunbeam.core.juju import (
     ApplicationNotFoundException,
     JujuException,
     JujuWaitException,
     LeaderNotFoundException,
 )
+from sunbeam.steps.charm_upgrade import CharmRefreshDecision
 from sunbeam.steps.k8s_upgrade import CHARM_NAME, K8S_CHANNEL, K8SCharmUpgradeStep
 
 
@@ -73,7 +74,7 @@ class TestK8SCharmUpgradeStepIsSkip:
 
         assert result.result_type == ResultType.SKIPPED
         assert "500" in result.message
-        assert step._needs_channel_flag is False
+        assert step._decision.needs_channel_flag is False
 
     def test_not_skipped_when_revision_only_differs(
         self, step, basic_jhelper, basic_manifest, step_context
@@ -87,7 +88,7 @@ class TestK8SCharmUpgradeStepIsSkip:
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._needs_channel_flag is False
+        assert step._decision.needs_channel_flag is False
 
     def test_revision_only_proceeds_when_channel_not_found(
         self, step, basic_jhelper, basic_manifest, step_context
@@ -101,7 +102,7 @@ class TestK8SCharmUpgradeStepIsSkip:
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._needs_channel_flag is False
+        assert step._decision.needs_channel_flag is False
 
     def test_revision_only_fails_for_track_change(
         self, step, basic_jhelper, basic_manifest, step_context
@@ -141,15 +142,15 @@ class TestK8SCharmUpgradeStepIsSkip:
         # Use a non-K8S_CHANNEL value so the test catches any accidental fallback.
         app = Mock(charm_rev=199, charm_channel="1.32/edge", base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
         basic_manifest.find_charm.return_value = None
 
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._needs_channel_flag is False
+        assert step._decision.needs_channel_flag is False
         # Charmhub lookup must use the *deployed* channel, not K8S_CHANNEL
-        basic_jhelper.get_available_charm_revision.assert_called_once_with(
+        basic_jhelper.get_available_charm_revisions.assert_called_once_with(
             CHARM_NAME, "1.32/edge"
         )
 
@@ -159,7 +160,7 @@ class TestK8SCharmUpgradeStepIsSkip:
         """No manifest: SKIPPED when already at latest revision in deployed channel."""
         app = Mock(charm_rev=200, charm_channel="1.32/edge", base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
         basic_manifest.find_charm.return_value = None
 
         result = step.is_skip(step_context)
@@ -177,15 +178,15 @@ class TestK8SCharmUpgradeStepIsSkip:
         """
         app = Mock(charm_rev=199, charm_channel="1.32/stable", base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
         # Simulate a manifest that exists but has no k8s entry
         basic_manifest.find_charm.return_value = None
 
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._needs_channel_flag is False
-        basic_jhelper.get_available_charm_revision.assert_called_once_with(
+        assert step._decision.needs_channel_flag is False
+        basic_jhelper.get_available_charm_revisions.assert_called_once_with(
             CHARM_NAME, "1.32/stable"
         )
 
@@ -219,14 +220,14 @@ class TestK8SCharmUpgradeStepIsSkip:
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._needs_channel_flag is True
+        assert step._decision.needs_channel_flag is True
 
     def test_skip_when_already_at_latest_patch_revision(
         self, step, basic_jhelper, basic_manifest, step_context
     ):
         app = Mock(charm_rev=200, charm_channel=K8S_CHANNEL, base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
         basic_manifest.find_charm.return_value = None
 
         result = step.is_skip(step_context)
@@ -239,13 +240,13 @@ class TestK8SCharmUpgradeStepIsSkip:
     ):
         app = Mock(charm_rev=199, charm_channel=K8S_CHANNEL, base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
         basic_manifest.find_charm.return_value = None
 
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._needs_channel_flag is False
+        assert step._decision.needs_channel_flag is False
 
     def test_proceeds_when_available_revision_lookup_fails(
         self, step, basic_jhelper, basic_manifest, step_context
@@ -253,7 +254,7 @@ class TestK8SCharmUpgradeStepIsSkip:
         """If charmhub can't be reached, proceed rather than skip."""
         app = Mock(charm_rev=200, charm_channel=K8S_CHANNEL, base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.side_effect = JujuException(
+        basic_jhelper.get_available_charm_revisions.side_effect = JujuException(
             "network error"
         )
         basic_manifest.find_charm.return_value = None
@@ -270,24 +271,31 @@ class TestK8SCharmUpgradeStepIsSkip:
         base.channel = "24.04"
         app = Mock(charm_rev=199, charm_channel=K8S_CHANNEL, base=base)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 200}
         basic_manifest.find_charm.return_value = None
 
         step.is_skip(step_context)
 
-        basic_jhelper.get_available_charm_revision.assert_called_once_with(
+        basic_jhelper.get_available_charm_revisions.assert_called_once_with(
             CHARM_NAME, K8S_CHANNEL, "ubuntu@24.04"
         )
 
 
 class TestK8SCharmUpgradeStepRun:
+    @pytest.fixture(autouse=True)
+    def default_decision(self, step):
+        """Set a sensible default _decision so run() tests don't need is_skip()."""
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED),
+            effective_channel=K8S_CHANNEL,
+        )
+
     def test_run_patch_upgrade_success(
         self, step, basic_jhelper, basic_manifest, step_context
     ):
         """Patch upgrade: no channel passed, wait_until_active called."""
         basic_jhelper.get_leader_unit.return_value = "k8s/0"
         basic_manifest.find_charm.return_value = None
-        step._needs_channel_flag = False
 
         result = step.run(step_context)
 
@@ -303,15 +311,14 @@ class TestK8SCharmUpgradeStepRun:
         )
         basic_jhelper.wait_until_active.assert_called_once()
 
-    def test_run_risk_change_uses_new_channel(
-        self, step, basic_jhelper, basic_manifest, step_context
-    ):
+    def test_run_risk_change_uses_new_channel(self, step, basic_jhelper, step_context):
         """Risk-level change: charm_refresh called with the target channel."""
         basic_jhelper.get_leader_unit.return_value = "k8s/0"
-        basic_manifest.find_charm.return_value = Mock(
-            channel="1.32/edge", revision=None
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED),
+            effective_channel="1.32/edge",
+            needs_channel_flag=True,
         )
-        step._needs_channel_flag = True
 
         result = step.run(step_context)
 
@@ -324,13 +331,15 @@ class TestK8SCharmUpgradeStepRun:
         )
 
     def test_run_uses_pinned_revision_from_manifest(
-        self, step, basic_jhelper, basic_manifest, step_context
+        self, step, basic_jhelper, step_context
     ):
         basic_jhelper.get_leader_unit.return_value = "k8s/0"
-        basic_manifest.find_charm.return_value = Mock(
-            channel="1.32/stable", revision=42
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED),
+            effective_channel="1.32/stable",
+            needs_channel_flag=False,
+            effective_revision=42,
         )
-        step._needs_channel_flag = False
 
         result = step.run(step_context)
 
@@ -368,13 +377,11 @@ class TestK8SCharmUpgradeStepRun:
         basic_jhelper.charm_refresh.assert_not_called()
 
     def test_run_fails_when_charm_refresh_fails(
-        self, step, basic_jhelper, basic_manifest, step_context
+        self, step, basic_jhelper, step_context
     ):
         basic_jhelper.get_leader_unit.return_value = "k8s/0"
         basic_jhelper.run_action.return_value = {}
         basic_jhelper.charm_refresh.side_effect = JujuException("bad channel")
-        basic_manifest.find_charm.return_value = None
-        step._needs_channel_flag = False
 
         result = step.run(step_context)
 
@@ -383,15 +390,11 @@ class TestK8SCharmUpgradeStepRun:
         assert "bad channel" in result.message
         basic_jhelper.wait_until_active.assert_not_called()
 
-    def test_run_fails_on_wait_timeout(
-        self, step, basic_jhelper, basic_manifest, step_context
-    ):
+    def test_run_fails_on_wait_timeout(self, step, basic_jhelper, step_context):
         basic_jhelper.get_leader_unit.return_value = "k8s/0"
         basic_jhelper.run_action.return_value = {}
         basic_jhelper.charm_refresh.return_value = None
         basic_jhelper.wait_until_active.side_effect = TimeoutError("timed out")
-        basic_manifest.find_charm.return_value = None
-        step._needs_channel_flag = False
 
         result = step.run(step_context)
 
@@ -399,15 +402,11 @@ class TestK8SCharmUpgradeStepRun:
         assert "k8s upgrade failed" in result.message
         assert "Timed out" in result.message
 
-    def test_run_fails_on_juju_wait_exception(
-        self, step, basic_jhelper, basic_manifest, step_context
-    ):
+    def test_run_fails_on_juju_wait_exception(self, step, basic_jhelper, step_context):
         basic_jhelper.get_leader_unit.return_value = "k8s/0"
         basic_jhelper.run_action.return_value = {}
         basic_jhelper.charm_refresh.return_value = None
         basic_jhelper.wait_until_active.side_effect = JujuWaitException("wait error")
-        basic_manifest.find_charm.return_value = None
-        step._needs_channel_flag = False
 
         result = step.run(step_context)
 

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s_upgrade.py
@@ -1,0 +1,427 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+import pytest
+
+from sunbeam.core.common import ResultType
+from sunbeam.core.juju import (
+    ApplicationNotFoundException,
+    JujuException,
+    JujuWaitException,
+    LeaderNotFoundException,
+)
+from sunbeam.steps.k8s_upgrade import CHARM_NAME, K8S_CHANNEL, K8SCharmUpgradeStep
+
+
+@pytest.fixture
+def step(basic_deployment, basic_client, basic_manifest, basic_jhelper):
+    basic_deployment.openstack_machines_model = "openstack-machines"
+    return K8SCharmUpgradeStep(
+        basic_deployment, basic_client, basic_manifest, basic_jhelper
+    )
+
+
+class TestK8SCharmUpgradeStepIsSkip:
+    def test_skip_when_application_not_deployed(
+        self, step, basic_jhelper, step_context
+    ):
+        basic_jhelper.get_application.side_effect = ApplicationNotFoundException()
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        assert "not been deployed" in result.message
+
+    def test_skip_when_already_at_pinned_revision(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        app = Mock(charm_rev=100, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_manifest.find_charm.return_value = Mock(
+            channel="1.32/stable", revision=100
+        )
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        assert "pinned revision" in result.message
+
+    def test_not_skipped_when_revision_differs_from_pinned(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        app = Mock(charm_rev=99, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_manifest.find_charm.return_value = Mock(
+            channel="1.32/stable", revision=100
+        )
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_skip_when_already_at_revision_only(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Revision-only manifest: skip when already at that revision."""
+        app = Mock(charm_rev=500, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        assert "500" in result.message
+        assert step._needs_channel_flag is False
+
+    def test_not_skipped_when_revision_only_differs(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Revision-only manifest: proceed when revision differs, no --channel."""
+        app = Mock(charm_rev=499, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_charm_channel_for_revision.return_value = "1.32/stable"
+        basic_manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        assert step._needs_channel_flag is False
+
+    def test_revision_only_proceeds_when_channel_not_found(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Revision-only: if revision is not found in any channel, proceed."""
+        app = Mock(charm_rev=499, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_charm_channel_for_revision.return_value = None
+        basic_manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        assert step._needs_channel_flag is False
+
+    def test_revision_only_fails_for_track_change(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Revision-only: FAILED when revision belongs to a different track."""
+        app = Mock(charm_rev=499, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_charm_channel_for_revision.return_value = "1.35/stable"
+        basic_manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "1.32" in result.message
+        assert "1.35" in result.message
+        assert "500" in result.message
+
+    def test_revision_only_proceeds_when_channel_lookup_fails(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Revision-only: if CharmHub lookup fails, proceed rather than block."""
+        app = Mock(charm_rev=499, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_charm_channel_for_revision.side_effect = JujuException(
+            "network error"
+        )
+        basic_manifest.find_charm.return_value = Mock(channel=None, revision=500)
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_no_manifest_uses_deployed_channel(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """With no manifest, refresh in the same channel/risk as deployed."""
+        # Use a non-K8S_CHANNEL value so the test catches any accidental fallback.
+        app = Mock(charm_rev=199, charm_channel="1.32/edge", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_manifest.find_charm.return_value = None
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        assert step._needs_channel_flag is False
+        # Charmhub lookup must use the *deployed* channel, not K8S_CHANNEL
+        basic_jhelper.get_available_charm_revision.assert_called_once_with(
+            CHARM_NAME, "1.32/edge"
+        )
+
+    def test_no_manifest_skips_when_already_at_latest(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """No manifest: SKIPPED when already at latest revision in deployed channel."""
+        app = Mock(charm_rev=200, charm_channel="1.32/edge", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_manifest.find_charm.return_value = None
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        assert "1.32/edge" in result.message
+
+    def test_manifest_without_k8s_entry_uses_deployed_channel(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Manifest present but k8s not listed: behaves same as no manifest.
+
+        find_charm returns None in both cases, so the deployed channel is used
+        and no channel switch is attempted.
+        """
+        app = Mock(charm_rev=199, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_available_charm_revision.return_value = 200
+        # Simulate a manifest that exists but has no k8s entry
+        basic_manifest.find_charm.return_value = None
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        assert step._needs_channel_flag is False
+        basic_jhelper.get_available_charm_revision.assert_called_once_with(
+            CHARM_NAME, "1.32/stable"
+        )
+
+    def test_fails_for_track_change(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """When the channel track changes (e.g. 1.31 -> 1.32), return FAILED."""
+        app = Mock(charm_rev=100, charm_channel="1.31/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_manifest.find_charm.return_value = Mock(
+            channel="1.32/stable", revision=None
+        )
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "track change" in result.message
+        assert "1.31" in result.message
+        assert "1.32" in result.message
+
+    def test_not_skipped_for_risk_change(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """When only the risk level changes (same track), proceed with --channel."""
+        app = Mock(charm_rev=100, charm_channel="1.32/stable", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_manifest.find_charm.return_value = Mock(
+            channel="1.32/edge", revision=None
+        )
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        assert step._needs_channel_flag is True
+
+    def test_skip_when_already_at_latest_patch_revision(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        app = Mock(charm_rev=200, charm_channel=K8S_CHANNEL, base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_manifest.find_charm.return_value = None
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        assert "already at the latest revision" in result.message
+
+    def test_not_skipped_when_newer_patch_revision_available(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        app = Mock(charm_rev=199, charm_channel=K8S_CHANNEL, base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_manifest.find_charm.return_value = None
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        assert step._needs_channel_flag is False
+
+    def test_proceeds_when_available_revision_lookup_fails(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """If charmhub can't be reached, proceed rather than skip."""
+        app = Mock(charm_rev=200, charm_channel=K8S_CHANNEL, base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_available_charm_revision.side_effect = JujuException(
+            "network error"
+        )
+        basic_manifest.find_charm.return_value = None
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_uses_base_when_available_for_revision_lookup(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        base = Mock()
+        base.name = "ubuntu"
+        base.channel = "24.04"
+        app = Mock(charm_rev=199, charm_channel=K8S_CHANNEL, base=base)
+        basic_jhelper.get_application.return_value = app
+        basic_jhelper.get_available_charm_revision.return_value = 200
+        basic_manifest.find_charm.return_value = None
+
+        step.is_skip(step_context)
+
+        basic_jhelper.get_available_charm_revision.assert_called_once_with(
+            CHARM_NAME, K8S_CHANNEL, "ubuntu@24.04"
+        )
+
+
+class TestK8SCharmUpgradeStepRun:
+    def test_run_patch_upgrade_success(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Patch upgrade: no channel passed, wait_until_active called."""
+        basic_jhelper.get_leader_unit.return_value = "k8s/0"
+        basic_manifest.find_charm.return_value = None
+        step._needs_channel_flag = False
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.run_action.assert_called_once_with(
+            "k8s/0", "openstack-machines", "pre-upgrade-check"
+        )
+        basic_jhelper.charm_refresh.assert_called_once_with(
+            "k8s",
+            "openstack-machines",
+            channel=None,
+            revision=None,
+        )
+        basic_jhelper.wait_until_active.assert_called_once()
+
+    def test_run_risk_change_uses_new_channel(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Risk-level change: charm_refresh called with the target channel."""
+        basic_jhelper.get_leader_unit.return_value = "k8s/0"
+        basic_manifest.find_charm.return_value = Mock(
+            channel="1.32/edge", revision=None
+        )
+        step._needs_channel_flag = True
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.charm_refresh.assert_called_once_with(
+            "k8s",
+            "openstack-machines",
+            channel="1.32/edge",
+            revision=None,
+        )
+
+    def test_run_uses_pinned_revision_from_manifest(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        basic_jhelper.get_leader_unit.return_value = "k8s/0"
+        basic_manifest.find_charm.return_value = Mock(
+            channel="1.32/stable", revision=42
+        )
+        step._needs_channel_flag = False
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.charm_refresh.assert_called_once_with(
+            "k8s",
+            "openstack-machines",
+            channel=None,
+            revision=42,
+        )
+
+    def test_run_fails_when_no_leader_found(self, step, basic_jhelper, step_context):
+        basic_jhelper.get_leader_unit.side_effect = LeaderNotFoundException()
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "k8s upgrade failed" in result.message
+        assert "leader unit" in result.message
+        basic_jhelper.run_action.assert_not_called()
+
+    def test_run_fails_when_pre_upgrade_check_fails(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        basic_jhelper.get_leader_unit.return_value = "k8s/0"
+        basic_jhelper.run_action.side_effect = JujuException("cluster not ready")
+        basic_manifest.find_charm.return_value = None
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "k8s upgrade failed" in result.message
+        assert "pre-upgrade-check" in result.message
+        assert "cluster not ready" in result.message
+        basic_jhelper.charm_refresh.assert_not_called()
+
+    def test_run_fails_when_charm_refresh_fails(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        basic_jhelper.get_leader_unit.return_value = "k8s/0"
+        basic_jhelper.run_action.return_value = {}
+        basic_jhelper.charm_refresh.side_effect = JujuException("bad channel")
+        basic_manifest.find_charm.return_value = None
+        step._needs_channel_flag = False
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "k8s upgrade failed" in result.message
+        assert "bad channel" in result.message
+        basic_jhelper.wait_until_active.assert_not_called()
+
+    def test_run_fails_on_wait_timeout(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        basic_jhelper.get_leader_unit.return_value = "k8s/0"
+        basic_jhelper.run_action.return_value = {}
+        basic_jhelper.charm_refresh.return_value = None
+        basic_jhelper.wait_until_active.side_effect = TimeoutError("timed out")
+        basic_manifest.find_charm.return_value = None
+        step._needs_channel_flag = False
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "k8s upgrade failed" in result.message
+        assert "Timed out" in result.message
+
+    def test_run_fails_on_juju_wait_exception(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        basic_jhelper.get_leader_unit.return_value = "k8s/0"
+        basic_jhelper.run_action.return_value = {}
+        basic_jhelper.charm_refresh.return_value = None
+        basic_jhelper.wait_until_active.side_effect = JujuWaitException("wait error")
+        basic_manifest.find_charm.return_value = None
+        step._needs_channel_flag = False
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "k8s upgrade failed" in result.message
+
+    def test_run_error_messages_include_model_name(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Error messages should include the model name for actionable juju commands."""
+        basic_jhelper.get_leader_unit.return_value = "k8s/0"
+        basic_jhelper.run_action.side_effect = JujuException("not ready")
+        basic_manifest.find_charm.return_value = None
+
+        result = step.run(step_context)
+
+        assert "openstack-machines" in result.message

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_mysql.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_mysql.py
@@ -135,7 +135,7 @@ class TestMySQLCharmUpgradeStep:
     def test_is_skip_already_latest(self, step, basic_jhelper, step_context):
         app = Mock(charm_rev=343, base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 343
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 343}
         basic_jhelper.show_unit.return_value = {}
 
         result = step.is_skip(step_context)
@@ -147,7 +147,7 @@ class TestMySQLCharmUpgradeStep:
     ):
         app = Mock(charm_rev=255, base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 343
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 343}
         basic_jhelper.show_unit.return_value = {
             "relation-info": [
                 {
@@ -167,7 +167,7 @@ class TestMySQLCharmUpgradeStep:
         basic_manifest.find_charm.return_value = charm_manifest
         app = Mock(charm_rev=255, charm_channel="8.0/stable", base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 343
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 343}
         basic_jhelper.show_unit.return_value = {}
 
         result = step.is_skip(step_context)

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_vault_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_vault_upgrade.py
@@ -5,13 +5,14 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from sunbeam.core.common import ResultType
+from sunbeam.core.common import Result, ResultType
 from sunbeam.core.juju import (
     ApplicationNotFoundException,
     JujuException,
 )
 from sunbeam.core.terraform import TerraformException
 from sunbeam.features.vault.feature import VaultCommandFailedException
+from sunbeam.steps.charm_upgrade import CharmRefreshDecision
 from sunbeam.steps.vault import (
     CHARM_BASE,
     VAULT_CHANNEL,
@@ -64,8 +65,7 @@ class TestVaultCharmUpgradeStep:
             channel="1.16/stable", revision=None
         )
 
-        with patch.object(step, "channel_update_needed", return_value=False):
-            result = step.is_skip(step_context)
+        result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.FAILED
         assert "track is below" in result.message
@@ -79,55 +79,50 @@ class TestVaultCharmUpgradeStep:
             channel="1.19/stable", revision=200
         )
 
-        with patch.object(step, "channel_update_needed", return_value=True):
-            result = step.is_skip(step_context)
+        result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._skip_charm_refresh is True
+        assert step._decision.result.result_type == ResultType.SKIPPED
 
     def test_no_skip_when_already_at_latest_revision_for_target(
         self, step, basic_jhelper, basic_manifest, step_context
     ):
         app = Mock(charm_rev=100, charm_channel=VAULT_CHANNEL, base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 100
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
         basic_manifest.find_charm.return_value = None
 
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._skip_charm_refresh is True
+        assert step._decision.result.result_type == ResultType.SKIPPED
 
     def test_not_skipped_when_newer_revision_available(
         self, step, basic_jhelper, basic_manifest, step_context
     ):
         app = Mock(charm_rev=50, charm_channel="1.18/stable", base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 100
+        basic_jhelper.get_available_charm_revisions.return_value = {"amd64": 100}
         basic_manifest.find_charm.return_value = None
 
         result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        assert step._skip_charm_refresh is False
+        assert step._decision.result.result_type == ResultType.COMPLETED
 
     def test_not_skipped_when_manifest_channel_is_upgrade(
         self, step, basic_jhelper, basic_manifest, step_context
     ):
         app = Mock(charm_rev=100, charm_channel="1.18/stable", base=None)
         basic_jhelper.get_application.return_value = app
-        basic_jhelper.get_available_charm_revision.return_value = 120
         basic_manifest.find_charm.return_value = Mock(
             channel="1.19/stable", revision=None
         )
 
-        with patch.object(step, "channel_update_needed", return_value=True):
-            result = step.is_skip(step_context)
+        result = step.is_skip(step_context)
 
         assert result.result_type == ResultType.COMPLETED
-        basic_jhelper.get_available_charm_revision.assert_called_once_with(
-            "vault-k8s", "1.19/stable", arch="amd64"
-        )
+        basic_jhelper.get_available_charm_revisions.assert_not_called()
 
     def test_run_fails_when_vault_unsealed_after_upgrade(
         self,
@@ -141,6 +136,9 @@ class TestVaultCharmUpgradeStep:
         basic_manifest.find_charm.return_value = None
         vaulthelper.get_vault_status.return_value = {"sealed": False}
         basic_jhelper.get_leader_unit.return_value = "vault/0"
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel=VAULT_CHANNEL
+        )
 
         result = step.run(step_context)
 
@@ -172,6 +170,9 @@ class TestVaultCharmUpgradeStep:
         vaulthelper.get_vault_status.return_value = {"sealed": True}
         basic_jhelper.get_leader_unit.return_value = "vault/0"
         mock_auto_unseal.return_value = None
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel="1.18/stable"
+        )
 
         result = step.run(step_context)
 
@@ -193,6 +194,9 @@ class TestVaultCharmUpgradeStep:
         basic_jhelper.charm_refresh.side_effect = JujuException(
             "something bad happened"
         )
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel=VAULT_CHANNEL
+        )
 
         result = step.run(step_context)
 
@@ -202,6 +206,9 @@ class TestVaultCharmUpgradeStep:
 
     def test_run_wait_times_out(self, step, basic_jhelper, step_context):
         basic_jhelper.wait_until_desired_status.side_effect = TimeoutError("timed out")
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel=VAULT_CHANNEL
+        )
 
         result = step.run(step_context)
 
@@ -222,6 +229,9 @@ class TestVaultCharmUpgradeStep:
         mock_auto_unseal.side_effect = VaultCommandFailedException(
             "Vault is not in dev mode"
         )
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel=VAULT_CHANNEL
+        )
 
         result = step.run(step_context)
 
@@ -240,6 +250,9 @@ class TestVaultCharmUpgradeStep:
         basic_jhelper.get_leader_unit.return_value = "vault/0"
         vaulthelper.get_vault_status.return_value = {"sealed": True}
         mock_auto_unseal.return_value = None
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel=VAULT_CHANNEL
+        )
 
         result = step.run(step_context)
 
@@ -259,6 +272,9 @@ class TestVaultCharmUpgradeStep:
         basic_jhelper.get_leader_unit.return_value = "vault/0"
         vaulthelper.get_vault_status.return_value = {"sealed": True}
         mock_auto_unseal.side_effect = VaultCommandFailedException("unseal failed")
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel=VAULT_CHANNEL
+        )
 
         result = step.run(step_context)
 
@@ -276,7 +292,9 @@ class TestVaultCharmUpgradeStep:
         step_context,
     ):
         basic_manifest.find_charm.return_value = None
-        step._skip_charm_refresh = True
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.SKIPPED), effective_channel=VAULT_CHANNEL
+        )
 
         result = step.run(step_context)
 
@@ -299,7 +317,9 @@ class TestVaultCharmUpgradeStep:
         basic_tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
             "apply failed"
         )
-        step._skip_charm_refresh = True
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.SKIPPED), effective_channel=VAULT_CHANNEL
+        )
 
         result = step.run(step_context)
 
@@ -318,6 +338,9 @@ class TestVaultCharmUpgradeStep:
         basic_manifest.find_charm.return_value = None
         basic_tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
             "apply failed"
+        )
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel=VAULT_CHANNEL
         )
 
         result = step.run(step_context)
@@ -341,6 +364,9 @@ class TestVaultCharmUpgradeStep:
         vaulthelper.get_vault_status.return_value = {"sealed": True}
         basic_jhelper.get_leader_unit.return_value = "vault/0"
         mock_auto_unseal.return_value = None
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel=VAULT_CHANNEL
+        )
 
         step.run(step_context)
 
@@ -365,6 +391,9 @@ class TestVaultCharmUpgradeStep:
         vaulthelper.get_vault_status.return_value = {"sealed": True}
         basic_jhelper.get_leader_unit.return_value = "vault/0"
         mock_auto_unseal.return_value = None
+        step._decision = CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED), effective_channel="1.19/stable"
+        )
 
         step.run(step_context)
 

--- a/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
@@ -853,9 +853,7 @@ class TestLatestInChannelCoordinator:
             mock_maas_client
         )
 
-        mock_maas_deploy_k8s_cls = Mock()
         mock_maas_steps_module = Mock()
-        mock_maas_steps_module.MaasDeployK8SApplicationStep = mock_maas_deploy_k8s_cls
 
         with patch.dict(
             sys.modules,
@@ -873,8 +871,10 @@ class TestLatestInChannelCoordinator:
         assert EnsureCiliumDeviceByHostStep in step_types
         assert OpenStackPatchLoadBalancerServicesIPPoolStep in step_types
         assert EnsureDefaultL2AdvertisementMutedStep in step_types
-        # MaasDeployK8SApplicationStep was called; its return value is in the plan
-        assert mock_maas_deploy_k8s_cls.return_value in plan
+        # k8s charm refresh is handled by `sunbeam cluster refresh k8s`, not here
+        assert (
+            mock_maas_steps_module.MaasDeployK8SApplicationStep.return_value not in plan
+        )
 
     @patch(f"{_INTRA_CHANNEL}.is_maas_deployment")
     def test_get_plan_always_includes_core_steps(self, mock_is_maas):


### PR DESCRIPTION
Add sunbeam cluster refresh k8s subcommand

Introduce a dedicated `sunbeam cluster refresh k8s` subcommand to
refresh the Canonical Kubernetes (k8s) charm for patch-level upgrades
only. Track changes (minor/major Kubernetes version upgrades, e.g.
1.32 -> 1.35) are explicitly not supported and will return an error
directing the user to the manual upgrade procedure.

Supported operations:
  - Patch upgrade: refresh to the latest revision within the deployed
    channel/risk.
  - Risk-level change within the same track (e.g. 1.32/stable ->
    1.32/edge).
  - Pinned revision from manifest (with cross-track guard via
    `juju info` reverse-lookup).

Upgrade procedure:
  1. Run `pre-upgrade-check` action on the k8s leader unit.
  2. Refresh the k8s charm via `juju refresh`, with channel/revision
     determined from the manifest (see below).
  3. Wait up to 1 hour for all k8s units to return to active.
  4. Run `terraform apply` against the k8s-plan to sync Terraform
     state (MAAS and local branches).

Channel/revision resolution from manifest:
  - No manifest / k8s absent from manifest: refresh within the
    currently deployed channel/risk; no channel switch attempted.
  - Channel only: allow risk-level changes within the same track,
    block track changes with a clear error.
  - Revision only: look up the revision's track via `juju info` and
    block cross-track upgrades; proceed fail-open if CharmHub is
    unreachable.
  - Channel + revision: enforce no-track-change and pass --revision
    to charm_refresh.

Add `get_charm_channel_for_revision(charm_name, revision)` to
JujuHelper, which uses `juju info --format json` to reverse-lookup
a revision number to its published channel without requiring the
channel to be specified upfront.

The k8s charm is added to INFRA_APPS so that `sunbeam cluster refresh`
skips it (handled by this dedicated subcommand instead).
DeployK8SApplicationStep and MaasDeployK8SApplicationStep are removed
from LatestInChannelCoordinator; Terraform plan updates are now
handled exclusively by the new subcommand.

Refactored charm_upgrade.py with common functionality to determine actions for changing channels/revisions etc

References:
  https://documentation.ubuntu.com/canonical-kubernetes/latest/charm/howto/upgrade-patch/

Assisted-by: Claude:claude-4.6-sonnet