### PR TITLE
fix: handle branch channels (track/risk/branch) in charm refresh

### DIFF
--- a/sunbeam-python/sunbeam/core/juju.py
+++ b/sunbeam-python/sunbeam/core/juju.py
@@ -1620,7 +1620,12 @@ class JujuHelper:
         :param base: Base to lookup charm in, default is JUJU_BASE
         :raises JujuException: if the channel/base combination is not found
         """
-        track, risk = channel.split("/")
+        parts = channel.split("/")
+        if len(parts) < 2:
+            raise JujuException(
+                f"Invalid channel format {channel!r}: expected track/risk[/branch]"
+            )
+        track, risk = parts[0], parts[1]
         _, base_channel = base.split("@")
         output = json.loads(
             self._juju.cli(
@@ -1635,7 +1640,14 @@ class JujuHelper:
         )
 
         revisions: dict[str, int] = {}
-        for risk_info in output["channels"][track][risk]:
+        try:
+            channel_entries = output["channels"][track][risk]
+        except KeyError:
+            raise JujuException(
+                f"Could not find charm {charm_name!r} in channel {channel!r} "
+                f"with base {base!r}"
+            )
+        for risk_info in channel_entries:
             for base_info in risk_info["bases"]:
                 if base_info["channel"] == base_channel:
                     archs = risk_info.get("architectures") or ["all"]
@@ -2166,8 +2178,17 @@ class JujuStepHelper:
         """
         risks = ["stable", "candidate", "beta", "edge"]
         current_channel = self.normalise_channel(channel)
-        current_track, current_risk = current_channel.split("/")
-        new_track, new_risk = new_channel.split("/")
+        current_parts = current_channel.split("/")
+        if len(current_parts) < 2:
+            LOG.error("Invalid channel format %r", channel)
+            return False
+        current_track, current_risk = current_parts[0], current_parts[1]
+        new_channel = self.normalise_channel(new_channel)
+        new_parts = new_channel.split("/")
+        if len(new_parts) < 2:
+            LOG.error("Invalid channel format %r", new_channel)
+            return False
+        new_track, new_risk = new_parts[0], new_parts[1]
         if current_track != new_track:
             try:
                 return version.parse(current_track) < version.parse(new_track)

--- a/sunbeam-python/sunbeam/steps/charm_upgrade.py
+++ b/sunbeam-python/sunbeam/steps/charm_upgrade.py
@@ -105,6 +105,14 @@ def _check_patch_upgrade(
     effective_channel: str,
 ) -> CharmRefreshDecision:
     """Handle patch upgrade: check whether a newer revision is available."""
+    # Branch channels (track/risk/branch) are not listed in the Charmhub
+    # channel map, so revision lookups will fail. Proceed with refresh
+    # anyway so juju picks up any new revision published to the branch.
+    if len(effective_channel.split("/")) > 2:
+        return CharmRefreshDecision(
+            result=Result(ResultType.COMPLETED),
+            effective_channel=effective_channel,
+        )
     try:
         if app.base:
             base = f"{app.base.name}@{app.base.channel}"

--- a/sunbeam-python/sunbeam/steps/mysql.py
+++ b/sunbeam-python/sunbeam/steps/mysql.py
@@ -477,6 +477,17 @@ class MySQLCharmUpgradeStep(BaseStep, JujuStepHelper):
             return Result(ResultType.SKIPPED, msg)
 
         deployed = app.charm_rev
+        # Branch channels (track/risk/branch) are not listed in the Charmhub
+        # channel map, so revision lookups will fail. Proceed with refresh
+        # anyway so juju picks up any new revision published to the branch.
+        if len(deployed_channel.split("/")) > 2:
+            LOG.debug(
+                "%s is on a branch channel %r, refreshing to pick up latest revision",
+                MYSQL_CHARM,
+                deployed_channel,
+            )
+            return Result(ResultType.COMPLETED)
+
         if app.base:
             base = f"{app.base.name}@{app.base.channel}"
             latest_revs = self.jhelper.get_available_charm_revisions(

--- a/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_juju.py
@@ -682,6 +682,71 @@ def test_get_available_charm_revisions(jhelper: jujulib.JujuHelper, juju):
     assert revisions == {"amd64": 121, "arm64": 122}
 
 
+def test_get_available_charm_revisions_branch_channel(
+    jhelper: jujulib.JujuHelper, juju
+):
+    """Branch channels (track/risk/branch) work when track/risk exists in channels."""
+    cmd_out = {
+        "channels": {
+            "1.32": {
+                "edge": [
+                    {
+                        "revision": 200,
+                        "architectures": ["amd64"],
+                        "bases": [{"name": "ubuntu", "channel": "24.04"}],
+                    },
+                ]
+            }
+        }
+    }
+    juju.cli.return_value = json.dumps(cmd_out)
+    revisions = jhelper.get_available_charm_revisions(
+        "k8s", "1.32/edge/hue-fix-kubelet-0405-1"
+    )
+    assert revisions == {"amd64": 200}
+
+
+def test_get_available_charm_revisions_branch_channel_not_in_channels(
+    jhelper: jujulib.JujuHelper, juju
+):
+    """Branch channels absent from the channels dict raise JujuException."""
+    # juju info for a private/ephemeral branch channel may return an empty channels dict
+    cmd_out = {"channels": {}}
+    juju.cli.return_value = json.dumps(cmd_out)
+    with pytest.raises(jujulib.JujuException):
+        jhelper.get_available_charm_revisions("k8s", "1.32/edge/hue-fix-kubelet-0405-1")
+
+
+def test_get_available_charm_revisions_no_matching_base(
+    jhelper: jujulib.JujuHelper, juju
+):
+    """Raise JujuException when channel exists but no entry matches the base."""
+    cmd_out = {
+        "channels": {
+            "legacy": {
+                "edge": [
+                    {
+                        "revision": 121,
+                        "architectures": ["amd64"],
+                        "bases": [{"name": "ubuntu", "channel": "20.04"}],
+                    },
+                ]
+            }
+        }
+    }
+    juju.cli.return_value = json.dumps(cmd_out)
+    with pytest.raises(jujulib.JujuException):
+        jhelper.get_available_charm_revisions("k8s", "legacy/edge", "ubuntu@24.04")
+
+
+def test_get_available_charm_revisions_malformed_channel(
+    jhelper: jujulib.JujuHelper, juju
+):
+    """Abbreviated/malformed channels (no '/') raise JujuException, not IndexError."""
+    with pytest.raises(jujulib.JujuException, match="Invalid channel format"):
+        jhelper.get_available_charm_revisions("k8s", "edge")
+
+
 def test_set_app_config(jhelper: jujulib.JujuHelper, juju):
     """set_app_config passes config values to jubilant."""
     config = {"key1": "value1", "key2": 42}
@@ -718,6 +783,16 @@ class TestJujuStepHelper:
         assert not jsh.channel_update_needed("2023.2/stable", "2023.1/stable")
         assert not jsh.channel_update_needed("latest/stable", "latest/stable")
         assert not jsh.channel_update_needed("foo/stable", "ba/stable")
+        # branch channels (track/risk/branch) must not raise ValueError
+        assert not jsh.channel_update_needed(
+            "1.32/edge/hue-fix-kubelet-0405-1", "1.32/edge/hue-fix-kubelet-0405-1"
+        )
+        assert jsh.channel_update_needed(
+            "1.32/edge/hue-fix-kubelet-0405-1", "1.33/stable"
+        )
+        # malformed channels (no '/') must not raise IndexError
+        assert not jsh.channel_update_needed("malformed", "1.33/stable")
+        assert not jsh.channel_update_needed("1.33/stable", "malformed")
 
     def test_find_subordinate_unit_for(self):
         jhelper = jujulib.JujuStepHelper()

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_charm_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_charm_upgrade.py
@@ -428,3 +428,18 @@ class TestCheckCharmNeedsRefreshPatchUpgrade:
         jhelper.get_available_charm_revisions.assert_called_once_with(
             CHARM_NAME, "1.18/stable", "ubuntu@24.04"
         )
+
+    def test_completed_on_branch_channel(self, jhelper, manifest):
+        """Branch channels proceed with refresh to pick up any new revision."""
+        app = Mock(
+            charm_rev=200, charm_channel="1.32/edge/hue-fix-kubelet-0405-1", base=None
+        )
+        jhelper.get_application.return_value = app
+        manifest.find_charm.return_value = None
+
+        decision = check_charm_needs_refresh(
+            jhelper, manifest, CHARM_NAME, MODEL, APPLICATION, DEFAULT_CHANNEL
+        )
+
+        assert decision.result.result_type == ResultType.COMPLETED
+        jhelper.get_available_charm_revisions.assert_not_called()

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s_upgrade.py
@@ -280,6 +280,21 @@ class TestK8SCharmUpgradeStepIsSkip:
             CHARM_NAME, K8S_CHANNEL, "ubuntu@24.04"
         )
 
+    def test_completed_on_branch_channel(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Branch channel: proceed with refresh, no Charmhub revision lookup."""
+        app = Mock(
+            charm_rev=199, charm_channel="1.32/edge/hue-fix-kubelet-0405-1", base=None
+        )
+        basic_jhelper.get_application.return_value = app
+        basic_manifest.find_charm.return_value = None
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.get_available_charm_revisions.assert_not_called()
+
 
 class TestK8SCharmUpgradeStepRun:
     @pytest.fixture(autouse=True)

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_mysql.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_mysql.py
@@ -118,6 +118,20 @@ class TestMySQLCharmUpgradeStep:
 
         assert result.result_type == ResultType.SKIPPED
 
+    def test_is_skip_branch_channel(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Branch channels proceed with refresh to pick up any new revision."""
+        basic_jhelper.get_application.return_value = Mock(
+            charm_rev=255, base=None, charm_channel="8.0/edge/my-fix-branch"
+        )
+        basic_manifest.find_charm.return_value = Mock(revision=None, channel="8.0/edge")
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.get_available_charm_revisions.assert_not_called()
+
     def test_is_skip_channel_track_mismatch(
         self, step, basic_jhelper, basic_manifest, step_context
     ):

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_vault_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_vault_upgrade.py
@@ -124,6 +124,19 @@ class TestVaultCharmUpgradeStep:
         assert result.result_type == ResultType.COMPLETED
         basic_jhelper.get_available_charm_revisions.assert_not_called()
 
+    def test_completed_on_branch_channel(
+        self, step, basic_jhelper, basic_manifest, step_context
+    ):
+        """Branch channel: proceed with refresh, no Charmhub revision lookup."""
+        app = Mock(charm_rev=50, charm_channel="1.18/stable/my-fix-branch", base=None)
+        basic_jhelper.get_application.return_value = app
+        basic_manifest.find_charm.return_value = None
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.get_available_charm_revisions.assert_not_called()
+
     def test_run_fails_when_vault_unsealed_after_upgrade(
         self,
         step,


### PR DESCRIPTION
Juju channels can have the form `track/risk/branch` (e.g. `1.32/edge/fix`), not just `track/risk`. This caused two failures:

1. `ValueError: too many values to unpack` — unpacking `channel.split("/")` into exactly two variables in `get_available_charm_revisions` and `channel_update_needed`.

2. `KeyError` — for ephemeral branch channels, `juju info` returns a `channels` dict that may not contain the track/risk keys.

Changes:
- `get_available_charm_revisions`: safe split using index access; wrap `channels[track][risk]` lookup in `try/except KeyError` and raise `JujuException` so callers handle it consistently.
- `channel_update_needed`: safe split for both `channel` and `new_channel`; also normalise `new_channel` before splitting (was previously skipped).
- `_check_patch_upgrade`: early-return `COMPLETED` for branch channels before any Charmhub call. Branch channels are not in the standard channel map but can have new revisions, so `juju refresh` should proceed to pick them up.
- `MySQLCharmUpgradeStep.is_skip`: same branch channel early-return `COMPLETED` before the revision lookup.

Add unit tests covering:
- Branch channel happy/missing-track/no-matching-base cases in `get_available_charm_revisions`.
- Branch channel inputs in `channel_update_needed`.
- Branch channel `COMPLETED` result for k8s, vault, charm_upgrade and mysql, with `assert_not_called()` on the Charmhub lookup.

Assisted-by: Claude:claude-4.6-sonnet