### PR TITLE
Add tab completion with pre-built and dynamic cache for sunbeam commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ MANIFEST
 # Snap artifacts
 *.snap
 prime/
+squashfs-root/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/snap-wrappers/completions/generate_completion_cache.py
+++ b/snap-wrappers/completions/generate_completion_cache.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helper script to generate shell completion cache for Sunbeam CLI.
+
+Run during Snapcraft's packing to generate a single completion cache file.
+
+Usage: ./bin/python3 completions/generate_completion_cache.py <cache_file>
+"""
+
+import os
+import sys
+
+from sunbeam.commands import configure as configure_cmds
+from sunbeam.commands import dashboard_url as dashboard_url_cmds
+from sunbeam.commands import generate_cloud_config as generate_cloud_config_cmds
+from sunbeam.commands import juju_utils as juju_cmds
+from sunbeam.commands import launch as launch_cmds
+from sunbeam.commands import manifest as manifest_cmds
+from sunbeam.commands import openrc as openrc_cmds
+from sunbeam.commands import plans as plans_cmd
+from sunbeam.commands import prepare_node as prepare_node_cmds
+from sunbeam.commands import proxy as proxy_cmds
+from sunbeam.commands import sso as sso_cmd
+from sunbeam.commands import utils as utils_cmds
+from sunbeam.feature_manager import list_feature_gates, list_features
+from sunbeam.main import (
+    cli,
+    disable,
+    enable,
+    identity_group,
+    juju,
+    manifest,
+    provider_group,
+    proxy,
+    utils,
+)
+
+try:
+    from sunbeam.provider.commands import deployment_group
+    from sunbeam.provider.local.commands import LocalProvider
+except ImportError as e:
+    LocalProvider = None
+    print(f"Warning: Could not import provider commands: {e}", file=sys.stderr)
+
+try:
+    from sunbeam.storage.manager import storage as storage_group
+except ImportError as e:
+    storage_group = None
+    print(f"Warning: Could not import storage commands: {e}", file=sys.stderr)
+
+
+def build_completion(group, entries, prefix="sunbeam"):
+    """Traverse the Click CLI command tree and collect completions at each level.
+
+    Args:
+        group: Click group or command to traverse.
+        entries: dict to populate with {key: [completion_lines]}.
+        prefix: current command prefix used as cache key.
+    """
+    completions = []
+    commands = getattr(group, "commands", {})
+    if not commands and hasattr(group, "list_commands"):
+        try:
+            ctx = group.make_context(
+                prefix.split("_")[-1], [], parent=None, resilient_parsing=True
+            )
+            for name in group.list_commands(ctx):
+                cmd = group.get_command(ctx, name)
+                if cmd:
+                    commands[name] = cmd
+        except Exception as e:
+            print(
+                f"Warning: Could not list commands for {prefix}: {e}",
+                file=sys.stderr,
+            )
+
+    for name, cmd in sorted(commands.items()):
+        completions.append(f"plain,{name}")
+
+    if completions:
+        entries[prefix] = completions
+
+    # Recurse into subgroups
+    for name, cmd in sorted(commands.items()):
+        if hasattr(cmd, "commands") or hasattr(cmd, "list_commands"):
+            build_completion(cmd, entries, f"{prefix}_{name}")
+
+
+def register_commands():
+    """Register all CLI commands for completion cache generation."""
+    # Static commands
+    cli.add_command(prepare_node_cmds.prepare_node_script)
+    cli.add_command(configure_cmds.configure)
+    cli.add_command(generate_cloud_config_cmds.cloud_config)
+    cli.add_command(launch_cmds.launch)
+    cli.add_command(openrc_cmds.openrc)
+    cli.add_command(dashboard_url_cmds.dashboard_url)
+    cli.add_command(identity_group)
+    identity_group.add_command(provider_group)
+    identity_group.add_command(sso_cmd.set_saml_x509)
+    provider_group.add_command(sso_cmd.list_sso)
+    provider_group.add_command(sso_cmd.add_sso)
+    provider_group.add_command(sso_cmd.remove_sso)
+    provider_group.add_command(sso_cmd.update_sso)
+    provider_group.add_command(sso_cmd.get_openid_redirect_uri)
+    provider_group.add_command(sso_cmd.purge_sso)
+    cli.add_command(manifest)
+    manifest.add_command(manifest_cmds.list_manifests)
+    manifest.add_command(manifest_cmds.show)
+    manifest.add_command(manifest_cmds.generate)
+    cli.add_command(proxy)
+    proxy.add_command(proxy_cmds.show)
+    proxy.add_command(proxy_cmds.set)
+    proxy.add_command(proxy_cmds.clear)
+    cli.add_command(enable)
+    cli.add_command(disable)
+    cli.add_command(plans_cmd.plans)
+    cli.add_command(list_features)
+    cli.add_command(list_feature_gates)
+    cli.add_command(utils)
+    utils.add_command(utils_cmds.juju_login)
+    cli.add_command(juju)
+    juju.add_command(juju_cmds.register_controller)
+    juju.add_command(juju_cmds.unregister_controller)
+
+    # LocalProvider commands
+    if LocalProvider:
+        try:
+            LocalProvider().register_cli(
+                cli, configure_cmds.configure, deployment_group
+            )
+            cli.add_command(deployment_group)
+        except Exception as e:
+            print(
+                f"Warning: Could not register provider commands: {e}",
+                file=sys.stderr,
+            )
+
+    # Storage group
+    if storage_group:
+        cli.add_command(storage_group)
+
+
+def main():
+    """Main entry point for cache generation."""
+    # Parse CLI arguments
+    if len(sys.argv) != 2 or sys.argv[1] in ("-h", "--help"):
+        print(f"Usage: {sys.argv[0]} <cache_file>", file=sys.stderr)
+        sys.exit(1)
+
+    cache_file = sys.argv[1]
+
+    register_commands()
+
+    entries = {}
+    build_completion(cli, entries)
+
+    # Write the cache file
+    cache_dir = os.path.dirname(cache_file)
+    if cache_dir:
+        os.makedirs(cache_dir, exist_ok=True)
+
+    with open(cache_file, "w", encoding="utf-8") as f:
+        for key in sorted(entries.keys()):
+            f.write(f"## {key}\n")
+            for line in entries[key]:
+                f.write(f"{line}\n")
+
+    print(f"Cached {len(entries)} completion entries in {cache_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/snap-wrappers/completions/sunbeam-completion
+++ b/snap-wrappers/completions/sunbeam-completion
@@ -1,0 +1,160 @@
+# Shell completion script for Sunbeam CLI
+# - The runtime cache file is validated before use: must be a regular file,
+#   owned by the current user, not a symlink, and not world-writable.
+# - COMPREPLY values are properly quoted to avoid glob expansion.
+# - The live fallback invokes the snap's own binary instead of relying on
+#   an unqualified PATH lookup.
+# - Runtime cache size is bounded to prevent disk exhaustion.
+
+# Maximum runtime cache file size in bytes (256 KiB).
+_SUNBEAM_CACHE_MAX_SIZE=262144
+
+_sunbeam_completion() {
+    local IFS=$'\n'
+    local response
+
+    # Cache locations from build-time and runtime
+    local snap_cache="${SNAP:-}/usr/share/bash-completion/completions/.sunbeam-completion-cache"
+    local runtime_cache="${SNAP_USER_DATA:-.}/.sunbeam-completion-cache"
+
+    # Lookup completion candidates
+    local cache_key="sunbeam"
+    local word
+    for ((i=1; i<COMP_CWORD; i++)); do
+        word="${COMP_WORDS[i]}"
+        # Sanitize cache key
+        word="${word//[^a-zA-Z0-9_-]/}"
+        if [[ -n "$word" ]]; then
+            cache_key+="_${word}"
+        fi
+    done
+
+    local current_word="${COMP_WORDS[COMP_CWORD]}"
+
+    # (1) Lookup in snap cache (read-only, built at snap build time)
+    if [[ -f "$snap_cache" ]]; then
+        response=$(_sunbeam_cache_lookup "$snap_cache" "$cache_key")
+    fi
+
+    # (2) Lookup in runtime cache
+    if [[ -z "$response" ]] && _sunbeam_cache_check "$runtime_cache"; then
+        response=$(_sunbeam_cache_lookup "$runtime_cache" "$cache_key")
+    fi
+
+    # (3) Invoke the snap's own completion binary
+    if [[ -z "$response" ]]; then
+        local full_words=""
+        for ((i=0; i<=COMP_CWORD; i++)); do
+            full_words+="${COMP_WORDS[i]} "
+        done
+
+        # Prefer the snap binary to avoid PATH shadowing
+        local sunbeam_bin="${SNAP:-}/bin/sunbeam"
+        if [[ ! -x "$sunbeam_bin" ]]; then
+            sunbeam_bin="sunbeam"
+        fi
+        response=$(env COMP_WORDS="$full_words" COMP_CWORD=$COMP_CWORD \
+            _SUNBEAM_COMPLETE=bash_complete "$sunbeam_bin" 2>/dev/null)
+
+        # Cache the result for next time (only inside a snap environment)
+        if [[ -n "$response" && -n "$SNAP_USER_DATA" ]]; then
+            _sunbeam_cache_write "$runtime_cache" "$cache_key" "$response"
+        fi
+    fi
+
+    # Process the response lines
+    for completion in $response; do
+        local type value
+        IFS=',' read -r type value <<< "$completion"
+
+        if [[ $type == 'dir' ]]; then
+            COMPREPLY=()
+            compopt -o dirnames
+        elif [[ $type == 'file' ]]; then
+            COMPREPLY=()
+            compopt -o default
+        elif [[ $type == 'plain' ]]; then
+            if [[ -z "$current_word" || "$value" == "$current_word"* ]]; then
+                COMPREPLY+=("$value")
+            fi
+        fi
+    done
+
+    return 0
+}
+
+_sunbeam_cache_lookup() {
+    # Look up completions for a key in a single-file cache.
+    # Format: "## key" header lines followed by completion values,
+    # terminated by the next header or end-of-file.
+    local cache_file="$1"
+    local key="$2"
+    awk -v key="$key" '
+        $0 == "## " key { found=1; next }
+        /^## / { if (found) exit; found=0 }
+        found && NF { print }
+    ' "$cache_file"
+}
+
+_sunbeam_cache_check() {
+    # Check runtime cache file.
+    local file="$1"
+
+    # File exists and is not a symlink
+    [[ -f "$file" && ! -L "$file" ]] || return 1
+
+    # File is owned by the current user
+    local file_owner file_perms
+    file_owner=$(stat -c '%u' "$file" 2>/dev/null) || return 1
+    file_perms=$(stat -c '%a' "$file" 2>/dev/null) || return 1
+    [[ "$file_owner" == "$(id -u)" ]] || return 1
+
+    # File is not world-writable (last octal digit has write bit)
+    local world_bits="${file_perms: -1}"
+    (( (world_bits & 2) == 0 )) || return 1
+    return 0
+}
+
+_sunbeam_cache_write() {
+    # Update a single key in the runtime cache file.
+    # Uses a temp-file + rename pattern for crash safety.
+    # Prevents the cache from growing beyond _SUNBEAM_CACHE_MAX_SIZE.
+    local cache_file="$1"
+    local key="$2"
+    local new_response="$3"
+    local tmp_file="${cache_file}.tmp.$$"
+
+    # Check existing cache size to prevent unbounded growth
+    if [[ -f "$cache_file" ]]; then
+        local size
+        size=$(stat -c '%s' "$cache_file" 2>/dev/null) || size=0
+        if (( size > _SUNBEAM_CACHE_MAX_SIZE )); then
+            echo "sunbeam-completion: cache file is too large, skipping update" >&2
+            return 0
+        fi
+    fi
+
+    # Create a new cache file with the updated key, preserving other keys
+    {
+        if [[ -f "$cache_file" ]]; then
+            awk -v key="$key" '
+                $0 == "## " key { skip=1; next }
+                /^## / { skip=0 }
+                !skip { print }
+            ' "$cache_file"
+        fi
+        printf '## %s\n' "$key"
+        printf '%s\n' "$new_response"
+    } > "$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; return 1; }
+
+    # Rename the temp file to the cache file atomically
+    mv -f "$tmp_file" "$cache_file" 2>/dev/null || rm -f "$tmp_file"
+}
+
+_sunbeam_completion_setup() {
+    # Add completion for both 'sunbeam' and 'openstack.sunbeam' commands.
+    complete -o nosort -F _sunbeam_completion sunbeam
+    complete -o nosort -F _sunbeam_completion openstack.sunbeam
+}
+
+_sunbeam_completion_setup;

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ apps:
       - network-bind
   sunbeam:
     command: bin/sunbeam
+    completer: usr/share/bash-completion/completions/sunbeam-completion
     plugs:
       - dot-local-share-juju
       - home
@@ -200,6 +201,7 @@ parts:
       done
 
   sunbeam-and-openstackclients:
+    after: [wrappers]
     plugin: python
     source: .
     source-subdir: sunbeam-python/
@@ -231,6 +233,9 @@ parts:
       mkdir -p usr/share/bash-completion/completions
       ./bin/openstack complete > usr/share/bash-completion/completions/openstack
       echo "complete -F _openstack openstack.openstack" >> usr/share/bash-completion/completions/openstack
+      # Pre-generate sunbeam completion cache
+      cp completions/sunbeam-completion usr/share/bash-completion/completions/sunbeam-completion
+      ./bin/python3 completions/generate_completion_cache.py usr/share/bash-completion/completions/.sunbeam-completion-cache
 
   plugin-packages:
     plugin: nil

--- a/sunbeam-python/tests/functional/local/test_completion.py
+++ b/sunbeam-python/tests/functional/local/test_completion.py
@@ -1,0 +1,437 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+"""Functional tests for Sunbeam tab completion.
+
+Tests Sunbeam completion system with both the pre-built snap cache and the live fallback
+from Click that is cached at runtime.
+
+These functional tests require the OpenStack snap to be installed.
+"""
+
+import os
+import subprocess
+import time
+
+import pytest
+
+SNAP_NAME = "openstack"
+SUNBEAM_APP = f"{SNAP_NAME}.sunbeam"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_openstack_snap_installed_fixture():
+    """Ensure the OpenStack snap is installed for these functional tests."""
+    try:
+        from .utils import ensure_openstack_snap_installed
+
+        ensure_openstack_snap_installed()
+    except ImportError:
+        # Fallback: if this test is run as a standalone file
+        try:
+            subprocess.run(
+                ["snap", "list", SNAP_NAME], capture_output=True, text=True, check=True
+            )
+        except subprocess.CalledProcessError:
+            pytest.skip(f"Sunbeam snap '{SNAP_NAME}' is not installed")
+
+
+# Snap completion cache generated at build time
+SNAP_CACHE_ENTRIES = {
+    "sunbeam",
+    "sunbeam_cluster",
+    "sunbeam_cluster_refresh",
+    "sunbeam_configure",
+    "sunbeam_deployment",
+    "sunbeam_identity",
+    "sunbeam_identity_provider",
+    "sunbeam_juju",
+    "sunbeam_manifest",
+    "sunbeam_plans",
+    "sunbeam_proxy",
+    "sunbeam_utils",
+}
+
+# Sunbeam top-level commands
+EXPECTED_TOP_LEVEL_COMMANDS = {
+    "cloud-config",
+    "cluster",
+    "configure",
+    "dashboard-url",
+    "deployment",
+    "disable",
+    "enable",
+    "identity",
+    "juju",
+    "launch",
+    "list-feature-gates",
+    "list-features",
+    "manifest",
+    "openrc",
+    "plans",
+    "prepare-node-script",
+    "proxy",
+    "storage",
+    "utils",
+}
+
+# Sunbeam commands with pre-built cache with static subcommands
+CACHED_SUBCOMMANDS = {
+    "cluster": {
+        "add",
+        "add-secondary-region-node",
+        "bootstrap",
+        "join",
+        "list",
+        "refresh",
+        "remove",
+        "resize",
+    },
+    "proxy": {"clear", "set", "show"},
+    "manifest": {"generate", "list", "show"},
+}
+
+# Performance thresholds (seconds)
+STATIC_CACHE_THRESHOLD = 0.5
+RUNTIME_CACHE_THRESHOLD = 1.5
+LIVE_THRESHOLD = 5.0
+
+
+def get_snap_env(var):
+    """Get a snap environment variable value."""
+    result = subprocess.run(
+        ["snap", "run", "--shell", SUNBEAM_APP, "-c", f"echo ${var}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def run_completion(command_words, comp_cword=None):
+    """Invoke snap completion and return parsed results.
+
+    :param command_words: list of command words to complete, e.g. ["sunbeam", "cluster"]
+    :param comp_cword: index of the word being completed (default: last word index)
+
+    :return: tuple of (completions list, elapsed seconds)
+    """
+    if comp_cword is None:
+        comp_cword = len(command_words)
+
+    # Build the completion line (trailing space = completing next word)
+    comp_line = " ".join(command_words) + " "
+    comp_point = len(comp_line)
+
+    # snap run --command=complete <app> <COMP_POINT> <COMP_POINT>
+    # <COMP_CWORD> <NWORDS> <COMP_WORDBREAKS> "<COMP_LINE>" <app> [words...]
+    nwords = len(command_words)
+    special_chars = """"'><=;|&(:"""
+    cmd = [
+        "snap",
+        "run",
+        "--command=complete",
+        SUNBEAM_APP,
+        str(comp_point),
+        str(comp_point),
+        str(comp_cword),
+        str(nwords),
+        special_chars,
+        comp_line,
+        SUNBEAM_APP,
+    ] + command_words[1:]
+
+    start = time.monotonic()
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30, check=True)
+    elapsed = time.monotonic() - start
+
+    # Output format from etelpmoc.sh: first line may be "nosort",
+    # followed by blank lines, then completion values (plain names).
+    completions = []
+    for line in result.stdout.strip().splitlines():
+        line = line.strip()
+        if line and line != "nosort":
+            completions.append(line)
+
+    return completions, elapsed
+
+
+def clear_runtime_cache():
+    """Remove the runtime completion cache file."""
+    snap_user_data = get_snap_env("SNAP_USER_DATA")
+    cache_file = os.path.join(snap_user_data, ".sunbeam-completion-cache")
+    if os.path.isfile(cache_file):
+        os.remove(cache_file)
+
+
+class TestSnapCache:
+    """Tests for pre-built snap cache (read-only, built at snap build time)."""
+
+    def test_snap_cache_exists(self):
+        """Verify the .sunbeam-completion-cache file exists in the snap."""
+        snap_dir = get_snap_env("SNAP")
+        cache_path = os.path.join(
+            snap_dir,
+            "usr",
+            "share",
+            "bash-completion",
+            "completions",
+            ".sunbeam-completion-cache",
+        )
+        result = subprocess.run(
+            [
+                "snap",
+                "run",
+                "--shell",
+                SUNBEAM_APP,
+                "-c",
+                f"test -f {cache_path}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"Snap cache file not found: {cache_path}"
+
+    def test_snap_cache_entries(self):
+        """Verify expected cache section headers are present in the snap."""
+        snap_dir = get_snap_env("SNAP")
+        cache_path = os.path.join(
+            snap_dir,
+            "usr",
+            "share",
+            "bash-completion",
+            "completions",
+            ".sunbeam-completion-cache",
+        )
+        result = subprocess.run(
+            [
+                "snap",
+                "run",
+                "--shell",
+                SUNBEAM_APP,
+                "-c",
+                f"grep '^## ' {cache_path}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"grep failed (rc={result.returncode}) for cache: {cache_path}"
+        )
+        entries = {
+            line.strip().removeprefix("## ")
+            for line in result.stdout.strip().splitlines()
+            if line.strip()
+        }
+        assert entries == SNAP_CACHE_ENTRIES
+
+    def test_top_level_completions(self):
+        """Verify sunbeam top-level completions return expected commands."""
+        completions, elapsed = run_completion(["sunbeam"])
+        assert elapsed < STATIC_CACHE_THRESHOLD, (
+            f"Top-level completion too slow: {elapsed:.3f}s "
+            f"(threshold: {STATIC_CACHE_THRESHOLD}s)"
+        )
+        completions_set = set(completions)
+        missing = EXPECTED_TOP_LEVEL_COMMANDS - completions_set
+        assert not missing, f"Missing top-level commands: {missing}"
+
+    @pytest.mark.parametrize(
+        "parent,expected_subs",
+        list(CACHED_SUBCOMMANDS.items()),
+        ids=list(CACHED_SUBCOMMANDS.keys()),
+    )
+    def test_cached_subcommand_completions(self, parent, expected_subs):
+        """Verify cached subcommand completions are fast and correct."""
+        completions, elapsed = run_completion(["sunbeam", parent])
+        assert elapsed < STATIC_CACHE_THRESHOLD, (
+            f"Cached completion for '{parent}' too slow: "
+            f"{elapsed:.3f}s (threshold: {STATIC_CACHE_THRESHOLD}s)"
+        )
+        completions_set = set(completions)
+        missing = expected_subs - completions_set
+        assert not missing, f"Missing subcommands for '{parent}': {missing}"
+
+    def test_static_cache_average_performance(self):
+        """Report average performance across all static cache lookups."""
+        timings = []
+        # Top-level
+        _, elapsed = run_completion(["sunbeam"])
+        timings.append(("sunbeam", elapsed))
+        # Subcommands
+        for parent in CACHED_SUBCOMMANDS:
+            _, elapsed = run_completion(["sunbeam", parent])
+            timings.append((f"sunbeam {parent}", elapsed))
+
+        avg = sum(t for _, t in timings) / len(timings)
+        report = ", ".join(f"{name}: {t:.3f}s" for name, t in timings)
+        print(f"\nStatic cache avg: {avg:.3f}s [{report}]")
+        assert avg < STATIC_CACHE_THRESHOLD, (
+            f"Static cache average too slow: {avg:.3f}s "
+            f"(threshold: {STATIC_CACHE_THRESHOLD}s)"
+        )
+
+
+class TestLiveFallbackAndRuntimeCache:
+    """Tests for live fallback completion and runtime caching."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        """Clear runtime cache before each test."""
+        clear_runtime_cache()
+
+    def test_live_fallback_returns_results(self):
+        """Verify live fallback works for commands not in snap cache."""
+        # 'enable' has dynamic subcommands, not in snap cache
+        completions, elapsed = run_completion(["sunbeam", "enable"])
+        assert elapsed < LIVE_THRESHOLD, (
+            f"Live fallback too slow: {elapsed:.3f}s (threshold: {LIVE_THRESHOLD}s)"
+        )
+        assert len(completions) > 0, "Live fallback returned no completions"
+
+    def test_live_average_performance(self):
+        """Report average performance for live (uncached) completion lookups."""
+        timings = []
+        commands = ["enable", "disable"]
+        for cmd in commands:
+            clear_runtime_cache()
+            _, elapsed = run_completion(["sunbeam", cmd])
+            timings.append((f"sunbeam {cmd}", elapsed))
+
+        avg = sum(t for _, t in timings) / len(timings)
+        report = ", ".join(f"{name}: {t:.3f}s" for name, t in timings)
+        print(f"\nLive fallback avg: {avg:.3f}s [{report}]")
+        assert avg < LIVE_THRESHOLD, (
+            f"Live fallback average too slow: {avg:.3f}s (threshold: {LIVE_THRESHOLD}s)"
+        )
+
+    def test_runtime_cache_created(self):
+        """Verify runtime cache entry is created after live fallback."""
+        run_completion(["sunbeam", "enable"])
+
+        snap_user_data = get_snap_env("SNAP_USER_DATA")
+        cache_file = os.path.join(snap_user_data, ".sunbeam-completion-cache")
+        result = subprocess.run(
+            [
+                "snap",
+                "run",
+                "--shell",
+                SUNBEAM_APP,
+                "-c",
+                f"grep -q '^## sunbeam_enable$' {cache_file}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"Runtime cache entry 'sunbeam_enable' not found in: {cache_file}"
+        )
+
+    def test_runtime_cached_faster_than_live(self):
+        """Verify second call (runtime cached) is faster than first (live)."""
+        # First call: live fallback
+        _, elapsed_live = run_completion(["sunbeam", "enable"])
+
+        # Second call: should hit runtime cache
+        _, elapsed_cached = run_completion(["sunbeam", "enable"])
+
+        assert elapsed_cached < RUNTIME_CACHE_THRESHOLD, (
+            f"Runtime cached completion too slow: "
+            f"{elapsed_cached:.3f}s (threshold: {RUNTIME_CACHE_THRESHOLD}s)"
+        )
+        assert elapsed_cached < elapsed_live, (
+            f"Cached ({elapsed_cached:.3f}s) not faster than live ({elapsed_live:.3f}s)"
+        )
+
+    def test_runtime_cache_average_performance(self):
+        """Report average performance for runtime cache lookups."""
+        timings = []
+        commands = ["enable", "disable"]
+        for cmd in commands:
+            # First call populates runtime cache
+            run_completion(["sunbeam", cmd])
+            # Second call reads from runtime cache
+            _, elapsed = run_completion(["sunbeam", cmd])
+            timings.append((f"sunbeam {cmd}", elapsed))
+
+        avg = sum(t for _, t in timings) / len(timings)
+        report = ", ".join(f"{name}: {t:.3f}s" for name, t in timings)
+        print(f"\nRuntime cache avg: {avg:.3f}s [{report}]")
+        assert avg < RUNTIME_CACHE_THRESHOLD, (
+            f"Runtime cache average too slow: {avg:.3f}s "
+            f"(threshold: {RUNTIME_CACHE_THRESHOLD}s)"
+        )
+
+    def test_runtime_cache_consistent_results(self):
+        """Verify cached results match live results."""
+        completions_live, _ = run_completion(["sunbeam", "enable"])
+        completions_cached, _ = run_completion(["sunbeam", "enable"])
+
+        assert set(completions_live) == set(completions_cached), (
+            f"Cached results differ from live: "
+            f"live={sorted(completions_live)}, cached={sorted(completions_cached)}"
+        )
+
+
+class TestCompleterScript:
+    """Tests for the completer script itself."""
+
+    def test_completer_script_installed(self):
+        """Verify the sunbeam completer script is in the snap."""
+        snap_dir = get_snap_env("SNAP")
+        completer = os.path.join(
+            snap_dir,
+            "usr",
+            "share",
+            "bash-completion",
+            "completions",
+            "sunbeam-completion",
+        )
+        result = subprocess.run(
+            [
+                "snap",
+                "run",
+                "--shell",
+                SUNBEAM_APP,
+                "-c",
+                f"test -f {completer}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"Completer script not found: {completer}"
+
+    def test_completer_registers_both_commands(self):
+        """Verify completer registers both 'sunbeam' and 'openstack.sunbeam'."""
+        snap_dir = get_snap_env("SNAP")
+        completer = os.path.join(
+            snap_dir,
+            "usr",
+            "share",
+            "bash-completion",
+            "completions",
+            "sunbeam-completion",
+        )
+        result = subprocess.run(
+            [
+                "snap",
+                "run",
+                "--shell",
+                SUNBEAM_APP,
+                "-c",
+                f"cat {completer}",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"Failed to read completer script (rc={result.returncode}): {completer}"
+        )
+        content = result.stdout
+        assert "complete" in content and "sunbeam" in content
+        assert "openstack.sunbeam" in content

--- a/sunbeam-python/tox.ini
+++ b/sunbeam-python/tox.ini
@@ -9,7 +9,8 @@ ignore_basepython_conflict = True
 [vars]
 src_path = {toxinidir}/
 tst_path = {toxinidir}/tests/
-all_path = {[vars]src_path} {[vars]tst_path}
+snap_path = {toxinidir}/../snap-wrappers/
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]snap_path}
 uv_flags = --frozen --isolated --extra=dev
 
 [testenv]


### PR DESCRIPTION
This utilizes two-tiered caching system, with the static commands are cached during Snapcraft build time, while the dynamic commands (mostly feature related) are first queried directly from Click completion and then cached during runtime.

The caches are required, because the native live completion offered by `Click` package is too slow. From testing in LXD VM, the average completion performance are as follows:

| Type | Completion performance |
| --- | --- |
| `Click` | 3.12 s |
| Runtime cache | 0.18 s |
| Static cache | 0.10 s |

The functional test in `sunbeam-python/tests/functional/local/test_completion.py` can be used to test the tab completion performance using Pytest.