### PR TITLE
fix: use correct default channel for manual-tls-certificates

### DIFF
--- a/sunbeam-python/sunbeam/features/tls/common.py
+++ b/sunbeam-python/sunbeam/features/tls/common.py
@@ -50,6 +50,7 @@ from sunbeam.features.interface.v1.openstack import (
     WaitForApplicationsStep,
 )
 from sunbeam.utils import pass_method_obj
+from sunbeam.versions import MANUAL_TLS_CERTIFICATES_CHANNEL
 
 CERTIFICATE_FEATURE_KEY = "TlsProvider"
 CA_MANUAL_TLS_CERTIFICATE = "manual-tls-certificates"
@@ -109,7 +110,7 @@ class TlsFeature(OpenStackControlPlaneFeature):
         return SoftwareConfig(
             charms={
                 "manual-tls-certificates": CharmManifest(
-                    channel="latest/stable",
+                    channel=MANUAL_TLS_CERTIFICATES_CHANNEL,
                 )
             }
         )


### PR DESCRIPTION

The manual-tls-certificates charm is deployed on channel `1/stable` via terraform vars, but the manifest default in `default_software_overrides` was set to latest/stable. This causes the manifest and deployed state to diverge, which on sunbeam cluster refresh incorrectly raises "manifest has track values that require upgrades" or tries to refresh the charm to `latest/stable` as described in the LP bug.

Fixes-bug: #2154512