### PR TITLE
fix(loadbalancer): pass region to openstack-port-cni-k8s charm

### DIFF
--- a/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-cni/main.tf
+++ b/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-cni/main.tf
@@ -49,7 +49,10 @@ resource "juju_application" "openstack-port-cni" {
     revision = var.openstack-port-cni-revision
   }
 
-  config = var.openstack-port-cni-config
+  config = merge(
+    { "region" = var.openstack-port-cni-region },
+    var.openstack-port-cni-config
+  )
 }
 
 resource "juju_integration" "port-cni-keystone" {

--- a/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-cni/variables.tf
+++ b/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-cni/variables.tf
@@ -47,3 +47,9 @@ variable "openstack-port-cni-config" {
   type        = map(string)
   default     = {}
 }
+
+variable "openstack-port-cni-region" {
+  description = "OpenStack region name passed to openstack-port-cni-k8s as the 'region' config option"
+  type        = string
+  default     = "RegionOne"
+}

--- a/sunbeam-python/sunbeam/features/loadbalancer/feature.py
+++ b/sunbeam-python/sunbeam/features/loadbalancer/feature.py
@@ -934,6 +934,7 @@ class DeployAmphoraInfraStep(BaseStep, JujuStepHelper):
                 override_tfvars={
                     "model_uuid": self.jhelper.get_model_uuid(self.model),
                     "multus-network-attachment-definitions": nad_yaml,
+                    "openstack-port-cni-region": self.deployment.get_region_name(),
                 },
             )
         except (TerraformException, TerraformStateLockedException) as e:


### PR DESCRIPTION
openstack-port-cni-k8s has a 'region' config option used when authenticating with OpenStack. Without it the daemon defaults to RegionOne, which causes authentication failures in multi-region deployments.

Add an 'openstack-port-cni-region' Terraform variable to the deploy-cni plan and merge it into the charm's config block so that a manifest-level config override cannot accidentally unset it. Pass the value from deployment.get_region_name() in DeployAmphoraInfraStep.run(), consistent with how other charms in the deployment pick up the configured region.

Partial-Fix: https://bugs.launchpad.net/snap-openstack/+bug/2155113

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>