### PR TITLE
fix: properly granting observability model access to Juju users

### DIFF
--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -888,16 +888,16 @@ class ObservabilityFeature(OpenStackControlPlaneFeature):
         client = deployment.get_client()
         jhelper = JujuHelper(deployment.juju_controller)
 
-        for node in client.cluster.list_nodes():
-            node_name = node["name"]
+        for user in client.cluster.list_juju_users():
+            user_name = user["username"]
             try:
                 plan = [
-                    JujuGrantModelAccessStep(jhelper, node_name, OBSERVABILITY_MODEL)
+                    JujuGrantModelAccessStep(jhelper, user_name, OBSERVABILITY_MODEL)
                 ]
                 run_plan(plan, console, show_hints)
             except Exception as e:
                 LOG.warning(
-                    "Failed to grant %s access to observability model: %s", node_name, e
+                    "Failed to grant %s access to observability model: %s", user_name, e
                 )
 
     def pre_disable(self, deployment: Deployment, show_hints: bool) -> None:

--- a/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
@@ -661,10 +661,10 @@ class TestObservabilityFeaturePostEnable:
         self, deployment, update_config, run_plan_obs, juju_helper_obs
     ):
         """All nodes get JujuGrantModelAccessStep called via run_plan."""
-        deployment.get_client.return_value.cluster.list_nodes.return_value = [
-            {"name": "node-1"},
-            {"name": "node-2"},
-            {"name": "node-3"},
+        deployment.get_client.return_value.cluster.list_juju_users.return_value = [
+            {"username": "node-1", "token": "t"},
+            {"username": "node-2", "token": "t"},
+            {"username": "node-3", "token": "t"},
         ]
         feature = observability_feature.EmbeddedObservabilityFeature()
 
@@ -683,10 +683,10 @@ class TestObservabilityFeaturePostEnable:
         self, deployment, update_config, run_plan_obs, juju_helper_obs
     ):
         """If granting access fails for one node, others are still processed."""
-        deployment.get_client.return_value.cluster.list_nodes.return_value = [
-            {"name": "node-1"},
-            {"name": "node-2"},
-            {"name": "node-3"},
+        deployment.get_client.return_value.cluster.list_juju_users.return_value = [
+            {"username": "node-1", "token": "t"},
+            {"username": "node-2", "token": "t"},
+            {"username": "node-3", "token": "t"},
         ]
         run_plan_obs.side_effect = [None, Exception("grant failed"), None]
         feature = observability_feature.EmbeddedObservabilityFeature()


### PR DESCRIPTION
In MAAS deployment, one Juju user is shared across all of the nodes. Previously, we use the nodes' names to grant access.

Closes-Bug: #2155095