### PR TITLE
fix(maas): advertise optional storage metallb pool over l2

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -780,6 +780,17 @@ def deploy(
             deployment.public_ip_pool,
         )
     )
+    plan2.append(
+        EnsureL2AdvertisementByHostStep(
+            deployment,
+            client,
+            jhelper,
+            deployment.openstack_machines_model,
+            Networks.STORAGE,
+            deployment.storage_ip_pool,
+            optional_if_pool_missing=True,
+        )
+    )
     plan2.append(AddK8SCloudStep(deployment, jhelper))
     plan2.append(PatchCoreDNSStep(deployment, jhelper))
 
@@ -1717,6 +1728,15 @@ def remove_node(ctx: click.Context, name: str, force: bool, show_hints: bool) ->
             deployment.openstack_machines_model,
             Networks.PUBLIC,
             deployment.public_ip_pool,
+        ),
+        EnsureL2AdvertisementByHostStep(
+            deployment,
+            client,
+            jhelper,
+            deployment.openstack_machines_model,
+            Networks.STORAGE,
+            deployment.storage_ip_pool,
+            optional_if_pool_missing=True,
         ),
         RemoveSunbeamMachineUnitsStep(
             client, name, jhelper, deployment.openstack_machines_model

--- a/sunbeam-python/sunbeam/steps/k8s.py
+++ b/sunbeam-python/sunbeam/steps/k8s.py
@@ -1732,6 +1732,7 @@ class EnsureL2AdvertisementByHostStep(_PerHostK8SResourceStep):
         network: Networks,
         pool: str,
         fqdn: str | None = None,
+        optional_if_pool_missing: bool = False,
     ):
         super().__init__(
             "Ensure L2 advertisement",
@@ -1745,10 +1746,39 @@ class EnsureL2AdvertisementByHostStep(_PerHostK8SResourceStep):
             fqdn=fqdn,
         )
         self.pool = pool
+        self.optional_if_pool_missing = optional_if_pool_missing
+        self.lbpool_resource = K8SHelper.get_lightkube_loadbalancer_resource()
         self.l2_advertisement_resource = (
             K8SHelper.get_lightkube_l2_advertisement_resource()
         )
         self.l2_advertisement_namespace = K8SHelper.get_loadbalancer_namespace()
+
+    def is_skip(self, context: StepContext) -> Result:
+        """Skip optional advertisements when the IPAddressPool is absent."""
+        self.to_update = []
+        self.to_delete = []
+        if self.optional_if_pool_missing:
+            try:
+                kube = get_kube_client(self.client, self.kube_namespace)
+                kube.get(
+                    self.lbpool_resource,
+                    name=self.pool,
+                    namespace=self.l2_advertisement_namespace,
+                )
+            except KubeClientError as e:
+                LOG.debug("Failed to create k8s client", exc_info=True)
+                return Result(ResultType.FAILED, str(e))
+            except l_exceptions.ApiError as e:
+                if e.status.code == 404:
+                    LOG.debug(
+                        "Skipping L2 advertisement for missing optional pool %s",
+                        self.pool,
+                    )
+                    return Result(ResultType.SKIPPED)
+                LOG.debug("Failed to get ipaddresspool %s", self.pool, exc_info=True)
+                return Result(ResultType.FAILED, str(e))
+
+        return super().is_skip(context)
 
     def _labels(self, name: str, space: str) -> dict[str, str]:
         """Return labels for the L2 advertisement."""

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -492,6 +492,15 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
                         Networks.PUBLIC,
                         self.deployment.public_ip_pool,  # type: ignore [attr-defined]
                     ),
+                    EnsureL2AdvertisementByHostStep(
+                        self.deployment,
+                        self.client,
+                        self.jhelper,
+                        self.deployment.openstack_machines_model,
+                        Networks.STORAGE,
+                        self.deployment.storage_ip_pool,  # type: ignore [attr-defined]
+                        optional_if_pool_missing=True,
+                    ),
                     OpenStackPatchLoadBalancerServicesIPPoolStep(
                         self.client,
                         self.deployment.public_api_label,  # type: ignore [attr-defined]

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_k8s.py
@@ -417,6 +417,24 @@ class TestEnsureL2AdvertisementByHostStep:
         assert result.result_type == ResultType.COMPLETED
         assert len(step.to_delete) == 1
 
+    def test_is_skip_optional_pool_missing(self, step, step_context):
+        api_error = ApiError.__new__(ApiError)
+        api_error.status = Mock(code=404)
+        step.optional_if_pool_missing = True
+        step.to_update = [{"name": "stale-node", "machineid": "99"}]
+        step.to_delete = [{"name": "stale-deleted"}]
+        step._get_outdated_resources = Mock()
+        with patch(
+            "sunbeam.steps.k8s.get_kube_client", return_value=Mock()
+        ) as kube_mock:
+            kube_mock.return_value.get.side_effect = api_error
+            result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        assert step.to_update == []
+        assert step.to_delete == []
+        step._get_outdated_resources.assert_not_called()
+
     def test_is_skip_single_node_fqdn_preserves_other_resources(
         self, deployment, client, jhelper, step_context
     ):

--- a/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
@@ -14,6 +14,7 @@ from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.steps.k8s import (
     EnsureCiliumDeviceByHostStep,
     EnsureDefaultL2AdvertisementMutedStep,
+    EnsureL2AdvertisementByHostStep,
 )
 from sunbeam.steps.openstack import OpenStackPatchLoadBalancerServicesIPPoolStep
 from sunbeam.steps.upgrades.base import UpgradeFeatures
@@ -906,6 +907,7 @@ class TestLatestInChannelCoordinator:
         """MAAS deployment plan should include LB IP pool and pool management steps."""
         mock_is_maas.return_value = True
         self.deployment.public_api_label = "test-public-api"
+        self.deployment.storage_ip_pool = "test-storage-ippool"
 
         mock_maas_client = Mock()
         mock_maas_client_module = Mock()
@@ -931,6 +933,14 @@ class TestLatestInChannelCoordinator:
         assert EnsureCiliumDeviceByHostStep in step_types
         assert OpenStackPatchLoadBalancerServicesIPPoolStep in step_types
         assert EnsureDefaultL2AdvertisementMutedStep in step_types
+        l2_steps = [
+            step for step in plan if isinstance(step, EnsureL2AdvertisementByHostStep)
+        ]
+        assert len(l2_steps) == 3
+        storage_l2_steps = [step for step in l2_steps if step.network.name == "STORAGE"]
+        assert len(storage_l2_steps) == 1
+        assert storage_l2_steps[0].pool == "test-storage-ippool"
+        assert storage_l2_steps[0].optional_if_pool_missing is True
         # k8s charm refresh is handled by `sunbeam cluster refresh k8s`, not here
         assert (
             mock_maas_steps_module.MaasDeployK8SApplicationStep.return_value not in plan


### PR DESCRIPTION
MAAS deployments can create an optional storage MetalLB IPAddressPool when a reserved MAAS range is labeled <deployment>-storage-ippool.

That pool was created, but the MAAS plans only reconciled per-host L2Advertisement resources for the internal and public pools. As a result, the storage pool could exist without any matching L2Advertisement resources, preventing it from being announced.

Add storage L2Advertisement reconciliation to the MAAS bootstrap, node removal, and intra-channel upgrade flows.

Treat the storage advertisement as optional and skip it cleanly when the storage IPAddressPool does not exist, since the storage MAAS range is not mandatory.

Assisted-by: Codex:gpt-5-codex