### PR TITLE
Deploy arm64 DPU nodes with custom MAAS image

### DIFF
--- a/sunbeam-microcluster/api/apitypes/nodes.go
+++ b/sunbeam-microcluster/api/apitypes/nodes.go
@@ -16,4 +16,6 @@ type Node struct {
 	Arch string `json:"arch" yaml:"arch"`
 	// IsDPU indicates whether the node is a MAAS-enrolled DPU.
 	IsDPU *bool `json:"is_dpu,omitempty" yaml:"is_dpu,omitempty"`
+	// ImageName is the MAAS boot resource name from the dpu-image-<name> tag.
+	ImageName string `json:"image_name,omitempty" yaml:"image_name,omitempty"`
 }

--- a/sunbeam-microcluster/api/apitypes/nodes.go
+++ b/sunbeam-microcluster/api/apitypes/nodes.go
@@ -1,6 +1,9 @@
 // Package apitypes provides shared types and structs.
 package apitypes
 
+// DefaultArch is the default node architecture when none is specified.
+const DefaultArch = "amd64"
+
 // Nodes holds list of Node type
 type Nodes []Node
 

--- a/sunbeam-microcluster/api/apitypes/nodes.go
+++ b/sunbeam-microcluster/api/apitypes/nodes.go
@@ -12,4 +12,8 @@ type Node struct {
 	MachineID int `json:"machineid" yaml:"machineid"`
 	// SystemID is the unique identifier for the node in machine provider
 	SystemID string `json:"systemid" yaml:"systemid"`
+	// Arch is the machine architecture (e.g. "amd64", "arm64").
+	Arch string `json:"arch" yaml:"arch"`
+	// IsDPU indicates whether the node is a MAAS-enrolled DPU.
+	IsDPU *bool `json:"is_dpu,omitempty" yaml:"is_dpu,omitempty"`
 }

--- a/sunbeam-microcluster/api/nodes.go
+++ b/sunbeam-microcluster/api/nodes.go
@@ -75,7 +75,7 @@ func cmdNodesPost(s state.State, r *http.Request) response.Response {
 	if req.IsDPU != nil {
 		isDPU = *req.IsDPU
 	}
-	err = sunbeam.AddNode(r.Context(), s, req.Name, req.Role, req.MachineID, req.SystemID, req.Arch, isDPU)
+	err = sunbeam.AddNode(r.Context(), s, req.Name, req.Role, req.MachineID, req.SystemID, req.Arch, isDPU, req.ImageName)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -85,18 +85,33 @@ func cmdNodesPost(s state.State, r *http.Request) response.Response {
 
 func cmdNodesPut(s state.State, r *http.Request) response.Response {
 	req := apitypes.Node{MachineID: -1}
+	raw := map[string]json.RawMessage{}
 
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	err = json.NewDecoder(r.Body).Decode(&req)
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&raw); err != nil {
+		return response.InternalError(err)
+	}
+
+	payload, err := json.Marshal(raw)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	err = sunbeam.UpdateNode(r.Context(), s, name, req.Role, req.MachineID, req.SystemID, req.Arch, req.IsDPU)
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return response.InternalError(err)
+	}
+
+	var imageName *string
+	if _, ok := raw["image_name"]; ok {
+		imageName = &req.ImageName
+	}
+
+	err = sunbeam.UpdateNode(r.Context(), s, name, req.Role, req.MachineID, req.SystemID, req.Arch, req.IsDPU, imageName)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/sunbeam-microcluster/api/nodes.go
+++ b/sunbeam-microcluster/api/nodes.go
@@ -71,7 +71,11 @@ func cmdNodesPost(s state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	err = sunbeam.AddNode(r.Context(), s, req.Name, req.Role, req.MachineID, req.SystemID)
+	isDPU := false
+	if req.IsDPU != nil {
+		isDPU = *req.IsDPU
+	}
+	err = sunbeam.AddNode(r.Context(), s, req.Name, req.Role, req.MachineID, req.SystemID, req.Arch, isDPU)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -92,7 +96,7 @@ func cmdNodesPut(s state.State, r *http.Request) response.Response {
 		return response.InternalError(err)
 	}
 
-	err = sunbeam.UpdateNode(r.Context(), s, name, req.Role, req.MachineID, req.SystemID)
+	err = sunbeam.UpdateNode(r.Context(), s, name, req.Role, req.MachineID, req.SystemID, req.Arch, req.IsDPU)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/sunbeam-microcluster/database/node.go
+++ b/sunbeam-microcluster/database/node.go
@@ -38,6 +38,8 @@ type Node struct {
 	Role      string
 	MachineID int
 	SystemID  string
+	Arch      string
+	IsDPU     bool
 }
 
 // NodeFilter is a required struct for use with lxd-generate. It is used for filtering fields on database fetches.

--- a/sunbeam-microcluster/database/node.go
+++ b/sunbeam-microcluster/database/node.go
@@ -40,6 +40,7 @@ type Node struct {
 	SystemID  string
 	Arch      string
 	IsDPU     bool
+	ImageName  string
 }
 
 // NodeFilter is a required struct for use with lxd-generate. It is used for filtering fields on database fetches.

--- a/sunbeam-microcluster/database/node.mapper.go
+++ b/sunbeam-microcluster/database/node.mapper.go
@@ -18,14 +18,14 @@ import (
 var _ = api.ServerEnvironment{}
 
 var nodeObjects = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   ORDER BY nodes.name
 `)
 
 var nodeObjectsByMember = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   WHERE ( member = ? )
@@ -33,7 +33,7 @@ SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, no
 `)
 
 var nodeObjectsByName = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   WHERE ( nodes.name = ? )
@@ -41,7 +41,7 @@ SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, no
 `)
 
 var nodeObjectsByRole = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   WHERE ( nodes.role = ? )
@@ -49,7 +49,7 @@ SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, no
 `)
 
 var nodeObjectsByMachineID = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   WHERE ( nodes.machine_id = ? )
@@ -62,8 +62,8 @@ SELECT nodes.id FROM nodes
 `)
 
 var nodeCreate = cluster.RegisterStmt(`
-INSERT INTO nodes (member_id, name, role, machine_id, system_id)
-  VALUES ((SELECT core_cluster_members.id FROM core_cluster_members WHERE core_cluster_members.name = ?), ?, ?, ?, ?)
+INSERT INTO nodes (member_id, name, role, machine_id, system_id, arch, is_dpu)
+  VALUES ((SELECT core_cluster_members.id FROM core_cluster_members WHERE core_cluster_members.name = ?), ?, ?, ?, ?, ?, ?)
 `)
 
 var nodeDeleteByName = cluster.RegisterStmt(`
@@ -72,14 +72,14 @@ DELETE FROM nodes WHERE name = ?
 
 var nodeUpdate = cluster.RegisterStmt(`
 UPDATE nodes
-  SET member_id = (SELECT core_cluster_members.id FROM core_cluster_members WHERE core_cluster_members.name = ?), name = ?, role = ?, machine_id = ?, system_id = ?
+  SET member_id = (SELECT core_cluster_members.id FROM core_cluster_members WHERE core_cluster_members.name = ?), name = ?, role = ?, machine_id = ?, system_id = ?, arch = ?, is_dpu = ?
  WHERE id = ?
 `)
 
 // nodeColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the Node entity.
 func nodeColumns() string {
-	return "nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id"
+	return "nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu"
 }
 
 // getNodes can be used to run handwritten sql.Stmts to return a slice of objects.
@@ -88,7 +88,7 @@ func getNodes(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Node, error) 
 
 	dest := func(scan func(dest ...any) error) error {
 		n := Node{}
-		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID)
+		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID, &n.Arch, &n.IsDPU)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func getNodesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]No
 
 	dest := func(scan func(dest ...any) error) error {
 		n := Node{}
-		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID)
+		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID, &n.Arch, &n.IsDPU)
 		if err != nil {
 			return err
 		}
@@ -340,7 +340,7 @@ func CreateNode(ctx context.Context, tx *sql.Tx, object Node) (int64, error) {
 		return -1, api.StatusErrorf(http.StatusConflict, "This \"nodes\" entry already exists")
 	}
 
-	args := make([]any, 5)
+	args := make([]any, 7)
 
 	// Populate the statement arguments.
 	args[0] = object.Member
@@ -348,6 +348,8 @@ func CreateNode(ctx context.Context, tx *sql.Tx, object Node) (int64, error) {
 	args[2] = object.Role
 	args[3] = object.MachineID
 	args[4] = object.SystemID
+	args[5] = object.Arch
+	args[6] = object.IsDPU
 
 	// Prepared statement to use.
 	stmt, err := cluster.Stmt(tx, nodeCreate)
@@ -409,7 +411,7 @@ func UpdateNode(ctx context.Context, tx *sql.Tx, name string, object Node) error
 		return fmt.Errorf("Failed to get \"nodeUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Member, object.Name, object.Role, object.MachineID, object.SystemID, id)
+	result, err := stmt.Exec(object.Member, object.Name, object.Role, object.MachineID, object.SystemID, object.Arch, object.IsDPU, id)
 	if err != nil {
 		return fmt.Errorf("Update \"nodes\" entry failed: %w", err)
 	}

--- a/sunbeam-microcluster/database/node.mapper.go
+++ b/sunbeam-microcluster/database/node.mapper.go
@@ -18,14 +18,14 @@ import (
 var _ = api.ServerEnvironment{}
 
 var nodeObjects = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu, nodes.image_name
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   ORDER BY nodes.name
 `)
 
 var nodeObjectsByMember = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu, nodes.image_name
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   WHERE ( member = ? )
@@ -33,7 +33,7 @@ SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, no
 `)
 
 var nodeObjectsByName = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu, nodes.image_name
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   WHERE ( nodes.name = ? )
@@ -41,7 +41,7 @@ SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, no
 `)
 
 var nodeObjectsByRole = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu, nodes.image_name
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   WHERE ( nodes.role = ? )
@@ -49,7 +49,7 @@ SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, no
 `)
 
 var nodeObjectsByMachineID = cluster.RegisterStmt(`
-SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu
+SELECT nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu, nodes.image_name
   FROM nodes
   JOIN core_cluster_members ON nodes.member_id = core_cluster_members.id
   WHERE ( nodes.machine_id = ? )
@@ -62,8 +62,8 @@ SELECT nodes.id FROM nodes
 `)
 
 var nodeCreate = cluster.RegisterStmt(`
-INSERT INTO nodes (member_id, name, role, machine_id, system_id, arch, is_dpu)
-  VALUES ((SELECT core_cluster_members.id FROM core_cluster_members WHERE core_cluster_members.name = ?), ?, ?, ?, ?, ?, ?)
+INSERT INTO nodes (member_id, name, role, machine_id, system_id, arch, is_dpu, image_name)
+  VALUES ((SELECT core_cluster_members.id FROM core_cluster_members WHERE core_cluster_members.name = ?), ?, ?, ?, ?, ?, ?, ?)
 `)
 
 var nodeDeleteByName = cluster.RegisterStmt(`
@@ -72,14 +72,14 @@ DELETE FROM nodes WHERE name = ?
 
 var nodeUpdate = cluster.RegisterStmt(`
 UPDATE nodes
-  SET member_id = (SELECT core_cluster_members.id FROM core_cluster_members WHERE core_cluster_members.name = ?), name = ?, role = ?, machine_id = ?, system_id = ?, arch = ?, is_dpu = ?
+  SET member_id = (SELECT core_cluster_members.id FROM core_cluster_members WHERE core_cluster_members.name = ?), name = ?, role = ?, machine_id = ?, system_id = ?, arch = ?, is_dpu = ?, image_name = ?
  WHERE id = ?
 `)
 
 // nodeColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the Node entity.
 func nodeColumns() string {
-	return "nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu"
+	return "nodes.id, core_cluster_members.name AS member, nodes.name, nodes.role, nodes.machine_id, nodes.system_id, nodes.arch, nodes.is_dpu, nodes.image_name"
 }
 
 // getNodes can be used to run handwritten sql.Stmts to return a slice of objects.
@@ -88,7 +88,7 @@ func getNodes(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Node, error) 
 
 	dest := func(scan func(dest ...any) error) error {
 		n := Node{}
-		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID, &n.Arch, &n.IsDPU)
+		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID, &n.Arch, &n.IsDPU, &n.ImageName)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func getNodesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]No
 
 	dest := func(scan func(dest ...any) error) error {
 		n := Node{}
-		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID, &n.Arch, &n.IsDPU)
+		err := scan(&n.ID, &n.Member, &n.Name, &n.Role, &n.MachineID, &n.SystemID, &n.Arch, &n.IsDPU, &n.ImageName)
 		if err != nil {
 			return err
 		}
@@ -340,7 +340,7 @@ func CreateNode(ctx context.Context, tx *sql.Tx, object Node) (int64, error) {
 		return -1, api.StatusErrorf(http.StatusConflict, "This \"nodes\" entry already exists")
 	}
 
-	args := make([]any, 7)
+	args := make([]any, 8)
 
 	// Populate the statement arguments.
 	args[0] = object.Member
@@ -350,6 +350,7 @@ func CreateNode(ctx context.Context, tx *sql.Tx, object Node) (int64, error) {
 	args[4] = object.SystemID
 	args[5] = object.Arch
 	args[6] = object.IsDPU
+	args[7] = object.ImageName
 
 	// Prepared statement to use.
 	stmt, err := cluster.Stmt(tx, nodeCreate)
@@ -411,7 +412,7 @@ func UpdateNode(ctx context.Context, tx *sql.Tx, name string, object Node) error
 		return fmt.Errorf("Failed to get \"nodeUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Member, object.Name, object.Role, object.MachineID, object.SystemID, object.Arch, object.IsDPU, id)
+	result, err := stmt.Exec(object.Member, object.Name, object.Role, object.MachineID, object.SystemID, object.Arch, object.IsDPU, object.ImageName, id)
 	if err != nil {
 		return fmt.Errorf("Update \"nodes\" entry failed: %w", err)
 	}

--- a/sunbeam-microcluster/database/schema.go
+++ b/sunbeam-microcluster/database/schema.go
@@ -19,6 +19,7 @@ var SchemaExtensions = []schema.Update{
 	StorageBackendSchemaUpdate,
 	FeatureGatesSchemaUpdate,
 	AddArchAndIsDPUToNodes,
+	AddImageNameToNodes,
 }
 
 // NodesSchemaUpdate is schema for table nodes
@@ -116,6 +117,17 @@ ALTER TABLE nodes ADD COLUMN is_dpu INTEGER default 0;
   `
 
 	_, err = tx.Exec(stmt)
+
+	return err
+}
+
+// AddImageNameToNodes is schema update for table nodes
+func AddImageNameToNodes(_ context.Context, tx *sql.Tx) error {
+	stmt := `
+ALTER TABLE nodes ADD COLUMN image_name TEXT default '';
+  `
+
+	_, err := tx.Exec(stmt)
 
 	return err
 }

--- a/sunbeam-microcluster/database/schema.go
+++ b/sunbeam-microcluster/database/schema.go
@@ -18,6 +18,7 @@ var SchemaExtensions = []schema.Update{
 	AddSystemIDToNodes,
 	StorageBackendSchemaUpdate,
 	FeatureGatesSchemaUpdate,
+	AddArchAndIsDPUToNodes,
 }
 
 // NodesSchemaUpdate is schema for table nodes
@@ -95,6 +96,26 @@ ALTER TABLE nodes ADD COLUMN system_id TEXT default '';
   `
 
 	_, err := tx.Exec(stmt)
+
+	return err
+}
+
+// AddArchAndIsDPUToNodes is schema update for table nodes
+func AddArchAndIsDPUToNodes(_ context.Context, tx *sql.Tx) error {
+	stmt := `
+ALTER TABLE nodes ADD COLUMN arch TEXT default 'amd64';
+  `
+
+	_, err := tx.Exec(stmt)
+	if err != nil {
+		return err
+	}
+
+	stmt = `
+ALTER TABLE nodes ADD COLUMN is_dpu INTEGER default 0;
+  `
+
+	_, err = tx.Exec(stmt)
 
 	return err
 }

--- a/sunbeam-microcluster/sunbeam/nodes.go
+++ b/sunbeam-microcluster/sunbeam/nodes.go
@@ -37,6 +37,7 @@ func ListNodes(ctx context.Context, s state.State, roles []string) (apitypes.Nod
 				SystemID:  node.SystemID,
 				Arch:      node.Arch,
 				IsDPU:     &isDPU,
+				ImageName: node.ImageName,
 			})
 		}
 
@@ -69,6 +70,7 @@ func GetNode(ctx context.Context, s state.State, name string) (apitypes.Node, er
 		node.Arch = record.Arch
 		isDPU := record.IsDPU
 		node.IsDPU = &isDPU
+		node.ImageName = record.ImageName
 
 		return nil
 	})
@@ -77,7 +79,7 @@ func GetNode(ctx context.Context, s state.State, name string) (apitypes.Node, er
 }
 
 // AddNode adds a node to the database
-func AddNode(ctx context.Context, s state.State, name string, role []string, machineid int, systemid string, arch string, isDPU bool) error {
+func AddNode(ctx context.Context, s state.State, name string, role []string, machineid int, systemid string, arch string, isDPU bool, imageName string) error {
 	nodeRole, err := roleToStr(role)
 	if err != nil {
 		return err
@@ -87,7 +89,7 @@ func AddNode(ctx context.Context, s state.State, name string, role []string, mac
 		if arch == "" {
 			arch = "amd64"
 		}
-		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid, Arch: arch, IsDPU: isDPU})
+		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid, Arch: arch, IsDPU: isDPU, ImageName: imageName})
 		if err != nil {
 			return fmt.Errorf("Failed to record node: %w", err)
 		}
@@ -102,7 +104,7 @@ func AddNode(ctx context.Context, s state.State, name string, role []string, mac
 }
 
 // UpdateNode updates a node record in the database
-func UpdateNode(ctx context.Context, s state.State, name string, role []string, machineid int, systemid string, arch string, isDPU *bool) error {
+func UpdateNode(ctx context.Context, s state.State, name string, role []string, machineid int, systemid string, arch string, isDPU *bool, imageName *string) error {
 	nodeRole, err := roleToStr(role)
 	if err != nil {
 		return err
@@ -131,8 +133,12 @@ func UpdateNode(ctx context.Context, s state.State, name string, role []string, 
 		if isDPU != nil {
 			nodeIsDPU = *isDPU
 		}
+		nodeImageName := node.ImageName
+		if imageName != nil {
+			nodeImageName = *imageName
+		}
 
-		err = database.UpdateNode(ctx, tx, name, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid, Arch: nodeArch, IsDPU: nodeIsDPU})
+		err = database.UpdateNode(ctx, tx, name, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid, Arch: nodeArch, IsDPU: nodeIsDPU, ImageName: nodeImageName})
 		if err != nil {
 			return fmt.Errorf("Failed to update record node: %w", err)
 		}

--- a/sunbeam-microcluster/sunbeam/nodes.go
+++ b/sunbeam-microcluster/sunbeam/nodes.go
@@ -29,11 +29,14 @@ func ListNodes(ctx context.Context, s state.State, roles []string) (apitypes.Nod
 			if err != nil {
 				return err
 			}
+			isDPU := node.IsDPU
 			nodes = append(nodes, apitypes.Node{
 				Name:      node.Name,
 				Role:      nodeRole,
 				MachineID: node.MachineID,
 				SystemID:  node.SystemID,
+				Arch:      node.Arch,
+				IsDPU:     &isDPU,
 			})
 		}
 
@@ -63,6 +66,9 @@ func GetNode(ctx context.Context, s state.State, name string) (apitypes.Node, er
 		node.Role = nodeRole
 		node.MachineID = record.MachineID
 		node.SystemID = record.SystemID
+		node.Arch = record.Arch
+		isDPU := record.IsDPU
+		node.IsDPU = &isDPU
 
 		return nil
 	})
@@ -71,14 +77,17 @@ func GetNode(ctx context.Context, s state.State, name string) (apitypes.Node, er
 }
 
 // AddNode adds a node to the database
-func AddNode(ctx context.Context, s state.State, name string, role []string, machineid int, systemid string) error {
+func AddNode(ctx context.Context, s state.State, name string, role []string, machineid int, systemid string, arch string, isDPU bool) error {
 	nodeRole, err := roleToStr(role)
 	if err != nil {
 		return err
 	}
 	// Add node to the database.
 	err = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid})
+		if arch == "" {
+			arch = "amd64"
+		}
+		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid, Arch: arch, IsDPU: isDPU})
 		if err != nil {
 			return fmt.Errorf("Failed to record node: %w", err)
 		}
@@ -93,7 +102,7 @@ func AddNode(ctx context.Context, s state.State, name string, role []string, mac
 }
 
 // UpdateNode updates a node record in the database
-func UpdateNode(ctx context.Context, s state.State, name string, role []string, machineid int, systemid string) error {
+func UpdateNode(ctx context.Context, s state.State, name string, role []string, machineid int, systemid string, arch string, isDPU *bool) error {
 	nodeRole, err := roleToStr(role)
 	if err != nil {
 		return err
@@ -114,8 +123,16 @@ func UpdateNode(ctx context.Context, s state.State, name string, role []string, 
 		if systemid == "" {
 			systemid = node.SystemID
 		}
+		nodeArch := arch
+		if nodeArch == "" {
+			nodeArch = node.Arch
+		}
+		nodeIsDPU := node.IsDPU
+		if isDPU != nil {
+			nodeIsDPU = *isDPU
+		}
 
-		err = database.UpdateNode(ctx, tx, name, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid})
+		err = database.UpdateNode(ctx, tx, name, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid, Arch: nodeArch, IsDPU: nodeIsDPU})
 		if err != nil {
 			return fmt.Errorf("Failed to update record node: %w", err)
 		}

--- a/sunbeam-microcluster/sunbeam/nodes.go
+++ b/sunbeam-microcluster/sunbeam/nodes.go
@@ -87,7 +87,7 @@ func AddNode(ctx context.Context, s state.State, name string, role []string, mac
 	// Add node to the database.
 	err = s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		if arch == "" {
-			arch = "amd64"
+			arch = apitypes.DefaultArch
 		}
 		_, err := database.CreateNode(ctx, tx, database.Node{Member: s.Name(), Name: name, Role: nodeRole, MachineID: machineid, SystemID: systemid, Arch: arch, IsDPU: isDPU, ImageName: imageName})
 		if err != nil {

--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -104,6 +104,7 @@ class ExtendedAPIService(service.BaseService):
         systemid: str = "",
         arch: str = "amd64",
         is_dpu: bool = False,
+        image_name: str = "",
     ) -> None:
         """Add Node information to cluster database."""
         data = {
@@ -114,6 +115,8 @@ class ExtendedAPIService(service.BaseService):
             "arch": arch,
             "is_dpu": is_dpu,
         }
+        if image_name:
+            data["image_name"] = image_name
         self._post("/1.0/nodes", data=json.dumps(data))
 
     def list_nodes(self) -> list[dict]:
@@ -137,6 +140,7 @@ class ExtendedAPIService(service.BaseService):
         systemid: str = "",
         arch: str | None = None,
         is_dpu: bool | None = None,
+        image_name: str | None = None,
     ) -> None:
         """Update role and machineid for node."""
         data: dict = {"role": role, "machineid": machineid, "systemid": systemid}
@@ -144,6 +148,8 @@ class ExtendedAPIService(service.BaseService):
             data["arch"] = arch
         if is_dpu is not None:
             data["is_dpu"] = is_dpu
+        if image_name is not None:
+            data["image_name"] = image_name
         self._put(f"1.0/nodes/{name}", data=json.dumps(data))
 
     def add_juju_user(self, name: str, token: str) -> None:

--- a/sunbeam-python/sunbeam/clusterd/cluster.py
+++ b/sunbeam-python/sunbeam/clusterd/cluster.py
@@ -97,7 +97,13 @@ class ExtendedAPIService(service.BaseService):
     """Client for Sunbeam extended Cluster API."""
 
     def add_node_info(
-        self, name: str, role: list[str], machineid: int = -1, systemid: str = ""
+        self,
+        name: str,
+        role: list[str],
+        machineid: int = -1,
+        systemid: str = "",
+        arch: str = "amd64",
+        is_dpu: bool = False,
     ) -> None:
         """Add Node information to cluster database."""
         data = {
@@ -105,6 +111,8 @@ class ExtendedAPIService(service.BaseService):
             "role": role,
             "machineid": machineid,
             "systemid": systemid,
+            "arch": arch,
+            "is_dpu": is_dpu,
         }
         self._post("/1.0/nodes", data=json.dumps(data))
 
@@ -127,9 +135,15 @@ class ExtendedAPIService(service.BaseService):
         role: list[str] | None = None,
         machineid: int = -1,
         systemid: str = "",
+        arch: str | None = None,
+        is_dpu: bool | None = None,
     ) -> None:
         """Update role and machineid for node."""
-        data = {"role": role, "machineid": machineid, "systemid": systemid}
+        data: dict = {"role": role, "machineid": machineid, "systemid": systemid}
+        if arch is not None:
+            data["arch"] = arch
+        if is_dpu is not None:
+            data["is_dpu"] = is_dpu
         self._put(f"1.0/nodes/{name}", data=json.dumps(data))
 
     def add_juju_user(self, name: str, token: str) -> None:

--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -66,6 +66,15 @@ class JujuManifest(pydantic.BaseModel):
         pass initial model configuration.
         """,
     )
+    arm64_image_id: str | None = Field(
+        default=None,
+        description=(
+            "MAAS custom image name for arm64 nodes (e.g. DPU)."
+            " When set, any arm64 machine enrolled via MAAS will be deployed"
+            " with this image-id constraint so MAAS installs the custom image."
+            " Example: 'bf-321-v2-ovs-hack'"
+        ),
+    )
 
 
 class CharmManifest(pydantic.BaseModel):

--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -66,10 +66,10 @@ class JujuManifest(pydantic.BaseModel):
         pass initial model configuration.
         """,
     )
-    arm64_image_id: str | None = Field(
+    dpu_arm64_image_id: str | None = Field(
         default=None,
         description=(
-            "MAAS custom image name for arm64 nodes (e.g. DPU)."
+            "MAAS custom image name for arm64 DPU nodes."
             " When set, any arm64 machine enrolled via MAAS will be deployed"
             " with this image-id constraint so MAAS installs the custom image."
             " Example: 'bf-321-v2-ovs-hack'"

--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -66,15 +66,6 @@ class JujuManifest(pydantic.BaseModel):
         pass initial model configuration.
         """,
     )
-    dpu_arm64_image_id: str | None = Field(
-        default=None,
-        description=(
-            "MAAS custom image name for arm64 DPU nodes."
-            " When set, any arm64 machine enrolled via MAAS will be deployed"
-            " with this image-id constraint so MAAS installs the custom image."
-            " Example: 'bf-321-v2-ovs-hack'"
-        ),
-    )
 
 
 class CharmManifest(pydantic.BaseModel):

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -286,6 +286,8 @@ def _convert_raw_machine(machine_raw: dict, root_disk: dict | None) -> dict:
     raw_arch = machine_raw.get("architecture", "")
     architecture = raw_arch.split("/")[0] if raw_arch else DEFAULT_ARCHITECTURE
 
+    is_dpu = bool(machine_raw.get("is_dpu", False))
+
     return {
         "system_id": machine_raw["system_id"],
         "hostname": machine_raw["hostname"],
@@ -299,6 +301,7 @@ def _convert_raw_machine(machine_raw: dict, root_disk: dict | None) -> dict:
         "cores": machine_raw["cpu_count"],
         "memory": machine_raw["memory"],
         "architecture": architecture,
+        "is_dpu": is_dpu,
     }
 
 
@@ -321,21 +324,6 @@ def get_machine(client: MaasClient, machine: str) -> dict:
         machine_raw, _find_root_devices(client, machine_raw)
     )
     LOG.debug("Retrieved machine %s: %r", machine, machine_dict)
-    return machine_dict
-
-
-def get_machine_by_system_id(client: MaasClient, system_id: str) -> dict:
-    """Get machine by MAAS system_id, return consumable dict.
-
-    Unlike get_machine() which looks up by hostname, this function
-    looks up by the unique MAAS system_id (e.g. "abc123").  This is
-    used when we only have the system_id stored in clusterd.
-    """
-    machine_raw = client._client.machines.get(system_id)._data  # type: ignore
-    machine_dict = _convert_raw_machine(
-        machine_raw, _find_root_devices(client, machine_raw)
-    )
-    LOG.debug("Retrieved machine by system_id %s: %r", system_id, machine_dict)
     return machine_dict
 
 

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -31,6 +31,29 @@ console = Console()
 
 # "amd64" is the Debian/MAAS name for x86_64.
 DEFAULT_ARCHITECTURE = "amd64"
+DPU_IMAGE_TAG_PREFIX = "dpu-image-"
+
+
+def parse_image_name_from_tags(tag_names: list[str] | None) -> str | None:
+    """Return the MAAS boot resource name from a dpu-image-<name> machine tag.
+
+    :param tag_names: MAAS tag names assigned to the machine.
+    :raises ValueError: if more than one dpu-image tag is present.
+    """
+    if not tag_names:
+        return None
+    matches = [
+        tag[len(DPU_IMAGE_TAG_PREFIX) :]
+        for tag in tag_names
+        if tag.startswith(DPU_IMAGE_TAG_PREFIX)
+    ]
+    if len(matches) > 1:
+        raise ValueError(
+            "Multiple dpu-image tags found on machine: "
+            + ", ".join(matches)
+            + ". Only one dpu-image-<name> tag is allowed."
+        )
+    return matches[0] if matches else None
 
 
 class MaasClient:
@@ -39,6 +62,25 @@ class MaasClient:
     def __init__(self, url: str, token: str, resource_tag: str | None = None):
         self._client = maas_client.connect(url, apikey=token)
         self.resource_tag = resource_tag
+
+    def list_boot_resource_names(self) -> set[str]:
+        """Return the names of all boot resources registered in MAAS."""
+        try:
+            resources = self._client.boot_resources.list.__self__._handler.read()  # type: ignore # noqa
+        except maas_bones.CallError as e:
+            raise ValueError(f"Failed to list MAAS boot resources: {e}") from e
+        return {resource["name"] for resource in resources}
+
+    def ensure_boot_resource_name_exists(self, name: str) -> None:
+        """Verify that a MAAS boot resource name exists.
+
+        :param name: Boot resource name from a dpu-image-<name> tag.
+        :raises ValueError: if the image is not registered in MAAS.
+        """
+        boot_resources = self.list_boot_resource_names()
+        if name in boot_resources:
+            return
+        raise ValueError(f"Image with name {name} is missing from maas boot-resources")
 
     def ensure_tag(self, tag: str):
         """Create a tag if it does not already exist."""
@@ -287,11 +329,13 @@ def _convert_raw_machine(machine_raw: dict, root_disk: dict | None) -> dict:
     architecture = raw_arch.split("/")[0] if raw_arch else DEFAULT_ARCHITECTURE
 
     is_dpu = bool(machine_raw.get("is_dpu", False))
+    tag_names = machine_raw.get("tag_names") or []
+    image_name = parse_image_name_from_tags(tag_names)
 
-    return {
+    machine = {
         "system_id": machine_raw["system_id"],
         "hostname": machine_raw["hostname"],
-        "roles": list(set(machine_raw["tag_names"]).intersection(RoleTags.values())),
+        "roles": list(set(tag_names).intersection(RoleTags.values())),
         "zone": machine_raw["zone"]["name"],
         "status": machine_raw["status_name"],
         "root_disk": root_disk,
@@ -303,6 +347,9 @@ def _convert_raw_machine(machine_raw: dict, root_disk: dict | None) -> dict:
         "architecture": architecture,
         "is_dpu": is_dpu,
     }
+    if image_name:
+        machine["image_name"] = image_name
+    return machine
 
 
 def list_machines(client: MaasClient, **extra_args) -> list[dict]:

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -29,6 +29,9 @@ else:
 LOG = logging.getLogger(__name__)
 console = Console()
 
+# "amd64" is the Debian/MAAS name for x86_64.
+DEFAULT_ARCHITECTURE = "amd64"
+
 
 class MaasClient:
     """Facade to MAAS APIs."""
@@ -278,6 +281,11 @@ def _convert_raw_machine(machine_raw: dict, root_disk: dict | None) -> dict:
             }
         )
 
+    # MAAS returns architecture as e.g. "amd64/generic" or "arm64/generic".
+    # Normalise to the bare arch string ("amd64" / "arm64").
+    raw_arch = machine_raw.get("architecture", "")
+    architecture = raw_arch.split("/")[0] if raw_arch else DEFAULT_ARCHITECTURE
+
     return {
         "system_id": machine_raw["system_id"],
         "hostname": machine_raw["hostname"],
@@ -290,6 +298,7 @@ def _convert_raw_machine(machine_raw: dict, root_disk: dict | None) -> dict:
         "nics": nics,
         "cores": machine_raw["cpu_count"],
         "memory": machine_raw["memory"],
+        "architecture": architecture,
     }
 
 
@@ -312,6 +321,21 @@ def get_machine(client: MaasClient, machine: str) -> dict:
         machine_raw, _find_root_devices(client, machine_raw)
     )
     LOG.debug("Retrieved machine %s: %r", machine, machine_dict)
+    return machine_dict
+
+
+def get_machine_by_system_id(client: MaasClient, system_id: str) -> dict:
+    """Get machine by MAAS system_id, return consumable dict.
+
+    Unlike get_machine() which looks up by hostname, this function
+    looks up by the unique MAAS system_id (e.g. "abc123").  This is
+    used when we only have the system_id stored in clusterd.
+    """
+    machine_raw = client._client.machines.get(system_id)._data  # type: ignore
+    machine_dict = _convert_raw_machine(
+        machine_raw, _find_root_devices(client, machine_raw)
+    )
+    LOG.debug("Retrieved machine by system_id %s: %r", system_id, machine_dict)
     return machine_dict
 
 

--- a/sunbeam-python/sunbeam/provider/maas/client.py
+++ b/sunbeam-python/sunbeam/provider/maas/client.py
@@ -38,7 +38,8 @@ def parse_image_name_from_tags(tag_names: list[str] | None) -> str | None:
     """Return the MAAS boot resource name from a dpu-image-<name> machine tag.
 
     :param tag_names: MAAS tag names assigned to the machine.
-    :raises ValueError: if more than one dpu-image tag is present.
+    :raises ValueError: if more than one dpu-image tag is present, or if a
+        dpu-image tag has an empty image name (e.g. ``dpu-image-``).
     """
     if not tag_names:
         return None
@@ -52,6 +53,11 @@ def parse_image_name_from_tags(tag_names: list[str] | None) -> str | None:
             "Multiple dpu-image tags found on machine: "
             + ", ".join(matches)
             + ". Only one dpu-image-<name> tag is allowed."
+        )
+    if len(matches) == 1 and not matches[0]:
+        raise ValueError(
+            "Invalid dpu-image tag: image name is empty. "
+            "Use dpu-image-<name> with a non-empty name."
         )
     return matches[0] if matches else None
 

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -657,7 +657,12 @@ def deploy(
     plan.append(MaasAddMachinesToClusterdStep(client, maas_client))
     plan.append(
         MaasDeployMachinesStep(
-            deployment, client, jhelper, deployment.openstack_machines_model
+            deployment,
+            client,
+            jhelper,
+            deployment.openstack_machines_model,
+            maas_client=maas_client,
+            manifest=manifest,
         )
     )
     run_plan(plan, console, show_hints)

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -661,7 +661,6 @@ def deploy(
             client,
             jhelper,
             deployment.openstack_machines_model,
-            maas_client=maas_client,
             manifest=manifest,
         )
     )

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -1196,12 +1196,19 @@ def list_machines_cmd(ctx: click.Context, format: str) -> None:
         table.add_column("Roles")
         table.add_column("Zone")
         table.add_column("Status")
+        table.add_column("DPU image")
         for machine in machines:
             hostname = machine["hostname"]
             status = machine["status"]
             zone = machine["zone"]
             roles = ", ".join(machine["roles"])
-            table.add_row(hostname, roles, zone, status)
+            table.add_row(
+                hostname,
+                roles,
+                zone,
+                status,
+                machine.get("image_name", ""),
+            )
         console.print(table)
     elif format == FORMAT_YAML:
         console.print(yaml.dump(machines), end="")
@@ -1242,6 +1249,8 @@ def show_machine_cmd(ctx: click.Context, hostname: str, format: str) -> None:
         )
         table.add_row(header.format("Zone"), machine["zone"])
         table.add_row(header.format("Status"), machine["status"])
+        if image_name := machine.get("image_name"):
+            table.add_row(header.format("DPU image"), image_name)
         console.print(table)
     elif format == FORMAT_YAML:
         console.print(yaml.dump(machine), end="")

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -92,6 +92,8 @@ Roles can be assigned to a machine by applying tags in MAAS.
 More on assigning tags: https://maas.io/docs/how-to-use-machine-tags
 """
 MACHINE_DEPLOY_TIMEOUT = 3600
+# "amd64" is the Debian/MAAS name for x86_64.
+DEFAULT_ARCHITECTURE = "amd64"
 
 
 class AddMaasDeployment(BaseStep):
@@ -1502,12 +1504,16 @@ class MaasDeployMachinesStep(BaseStep):
         client: Client,
         jhelper: JujuHelper,
         model: str,
+        maas_client: "maas_client.MaasClient | None" = None,
+        manifest: "Manifest | None" = None,
     ):
         super().__init__("Deploy machines", "Deploying machines in Juju")
         self.client = client
         self.deployment = deployment
         self.jhelper = jhelper
         self.model = model
+        self.maas_client = maas_client
+        self.manifest = manifest
 
     def is_skip(self, context: StepContext) -> Result:
         """Determines if the step should be skipped or not."""
@@ -1560,15 +1566,74 @@ class MaasDeployMachinesStep(BaseStep):
             return Result(ResultType.SKIPPED)
         return Result(ResultType.COMPLETED)
 
+    def _fetch_node_architecture(self, node: dict) -> str:
+        """Fetch the architecture of a node from MAAS.
+
+        Returns the architecture string (e.g. "amd64", "arm64").
+        Falls back to DEFAULT_ARCHITECTURE if the MAAS client is
+        unavailable or the lookup fails.
+        """
+        if self.maas_client is None:
+            return DEFAULT_ARCHITECTURE
+        try:
+            machine_info = maas_client.get_machine_by_system_id(
+                self.maas_client, node["systemid"]
+            )
+            return machine_info.get("architecture", DEFAULT_ARCHITECTURE)
+        except Exception:
+            LOG.debug(
+                "Could not fetch architecture for node %r, defaulting to %s",
+                node["name"],
+                DEFAULT_ARCHITECTURE,
+                exc_info=True,
+            )
+            return DEFAULT_ARCHITECTURE
+
+    def _get_node_constraints(self, node: dict) -> list[str]:
+        """Return the Juju constraints for deploying this node.
+
+        For arm64 nodes with a custom image configured in the manifest,
+        adds image-id and arch constraints so MAAS deploys the correct
+        OS image (e.g. BF DOCA on a DPU).
+        """
+        constraints = ["tags=" + self.deployment.resource_tag]
+
+        arm64_image_id = (
+            self.manifest.core.software.juju.arm64_image_id
+            if self.manifest is not None
+            else None
+        )
+        if arm64_image_id is None:
+            return constraints
+
+        architecture = self._fetch_node_architecture(node)
+
+        if architecture == "arm64":
+            LOG.debug(
+                "Node %r is arm64 — adding image-id=%r constraint",
+                node["name"],
+                arm64_image_id,
+            )
+            constraints.append("image-id=" + arm64_image_id)
+            constraints.append("arch=arm64")
+
+        return constraints
+
     def run(self, context: StepContext) -> Result:
         """Deploy machines in Juju."""
         for node in self.nodes_to_deploy:
             self.update_status(context, f"deploying {node['name']}")
-            LOG.debug("Adding machine %s to model %s", node["name"], self.model)
+            constraints = self._get_node_constraints(node)
+            LOG.debug(
+                "Adding machine %s to model %s with constraints %s",
+                node["name"],
+                self.model,
+                constraints,
+            )
             juju_machine = self.jhelper.add_machine(
                 "system-id=" + node["systemid"],
                 self.model,
-                constraints=["tags=" + self.deployment.resource_tag],
+                constraints=constraints,
             )
             self.client.cluster.update_node_info(
                 node["name"], machineid=int(juju_machine)

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -1419,7 +1419,7 @@ class MaasRemoveDeploymentCredentialsStep(BaseStep):
 class MaasAddMachinesToClusterdStep(BaseStep):
     """Add machines from MAAS to Clusterd."""
 
-    nodes: Sequence[tuple[str, str]] | None
+    nodes: Sequence[dict] | None
     machines: Sequence[dict] | None
 
     def __init__(self, client: Client, maas_client: maas_client.MaasClient):
@@ -1448,24 +1448,41 @@ class MaasAddMachinesToClusterdStep(BaseStep):
             for machine in filtered_machines:
                 if node["name"] == machine["hostname"]:
                     filtered_machines.remove(machine)
-                    if sorted(node["role"]) != sorted(machine["roles"]):
-                        nodes_to_update.append((machine["hostname"], machine["roles"]))
+                    if (
+                        sorted(node["role"]) != sorted(machine["roles"])
+                        or node.get("arch", DEFAULT_ARCHITECTURE)
+                        != machine.get("architecture", DEFAULT_ARCHITECTURE)
+                        or node.get("is_dpu", False) != machine.get("is_dpu", False)
+                        or node.get("systemid", "") != machine["system_id"]
+                    ):
+                        nodes_to_update.append(machine)
+                    break
         self.nodes = nodes_to_update
         self.machines = filtered_machines
         return Result(ResultType.COMPLETED)
 
     def run(self, context: StepContext) -> Result:
-        """Add machines to Juju model."""
+        """Add machines to clusterd."""
         if self.machines is None or self.nodes is None:
             # only happens if is_skip() was not called before, or if run executed
             # even if is_skip reported a failure
             return Result(ResultType.FAILED, "No machines to add / node to update.")
         for machine in self.machines:
             self.client.cluster.add_node_info(
-                machine["hostname"], machine["roles"], systemid=machine["system_id"]
+                machine["hostname"],
+                machine["roles"],
+                systemid=machine["system_id"],
+                arch=machine.get("architecture", DEFAULT_ARCHITECTURE),
+                is_dpu=machine.get("is_dpu", False),
             )
-        for node in self.nodes:
-            self.client.cluster.update_node_info(*node)  # type: ignore
+        for machine in self.nodes:
+            self.client.cluster.update_node_info(
+                machine["hostname"],
+                machine["roles"],
+                systemid=machine["system_id"],
+                arch=machine.get("architecture", DEFAULT_ARCHITECTURE),
+                is_dpu=machine.get("is_dpu", False),
+            )
         return Result(ResultType.COMPLETED)
 
 
@@ -1504,7 +1521,6 @@ class MaasDeployMachinesStep(BaseStep):
         client: Client,
         jhelper: JujuHelper,
         model: str,
-        maas_client: "maas_client.MaasClient | None" = None,
         manifest: "Manifest | None" = None,
     ):
         super().__init__("Deploy machines", "Deploying machines in Juju")
@@ -1512,7 +1528,6 @@ class MaasDeployMachinesStep(BaseStep):
         self.deployment = deployment
         self.jhelper = jhelper
         self.model = model
-        self.maas_client = maas_client
         self.manifest = manifest
 
     def is_skip(self, context: StepContext) -> Result:
@@ -1566,28 +1581,9 @@ class MaasDeployMachinesStep(BaseStep):
             return Result(ResultType.SKIPPED)
         return Result(ResultType.COMPLETED)
 
-    def _fetch_node_architecture(self, node: dict) -> str:
-        """Fetch the architecture of a node from MAAS.
-
-        Returns the architecture string (e.g. "amd64", "arm64").
-        Falls back to DEFAULT_ARCHITECTURE if the MAAS client is
-        unavailable or the lookup fails.
-        """
-        if self.maas_client is None:
-            return DEFAULT_ARCHITECTURE
-        try:
-            machine_info = maas_client.get_machine_by_system_id(
-                self.maas_client, node["systemid"]
-            )
-            return machine_info.get("architecture", DEFAULT_ARCHITECTURE)
-        except Exception:
-            LOG.debug(
-                "Could not fetch architecture for node %r, defaulting to %s",
-                node["name"],
-                DEFAULT_ARCHITECTURE,
-                exc_info=True,
-            )
-            return DEFAULT_ARCHITECTURE
+    def _get_node_architecture(self, node: dict) -> str:
+        """Return the architecture stored in clusterd for this node."""
+        return node.get("arch") or DEFAULT_ARCHITECTURE
 
     def _get_node_constraints(self, node: dict) -> list[str]:
         """Return the Juju constraints for deploying this node.
@@ -1598,23 +1594,23 @@ class MaasDeployMachinesStep(BaseStep):
         """
         constraints = ["tags=" + self.deployment.resource_tag]
 
-        arm64_image_id = (
-            self.manifest.core.software.juju.arm64_image_id
+        dpu_arm64_image_id = (
+            self.manifest.core.software.juju.dpu_arm64_image_id
             if self.manifest is not None
             else None
         )
-        if arm64_image_id is None:
+        if dpu_arm64_image_id is None:
             return constraints
 
-        architecture = self._fetch_node_architecture(node)
+        architecture = self._get_node_architecture(node)
 
         if architecture == "arm64":
             LOG.debug(
                 "Node %r is arm64 — adding image-id=%r constraint",
                 node["name"],
-                arm64_image_id,
+                dpu_arm64_image_id,
             )
-            constraints.append("image-id=" + arm64_image_id)
+            constraints.append("image-id=" + dpu_arm64_image_id)
             constraints.append("arch=arm64")
 
         return constraints

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -1624,9 +1624,9 @@ class MaasDeployMachinesStep(BaseStep):
     def _get_node_constraints(self, node: dict) -> list[str]:
         """Return the Juju constraints for deploying this node.
 
-        For arm64 nodes with a dpu-image-<name> tag stored in clusterd,
-        adds image-id and arch constraints so MAAS deploys the correct
-        OS image (e.g. BF DOCA on a DPU).
+        Adds arch and image-id constraints from clusterd when the node has a
+        non-default architecture or a custom image name from a dpu-image-<name>
+        MAAS tag.
         """
         constraints = ["tags=" + self.deployment.resource_tag]
         architecture = self._get_node_architecture(node)
@@ -1637,7 +1637,7 @@ class MaasDeployMachinesStep(BaseStep):
 
         if image_name:
             LOG.debug(
-                "Node %r has custom DPU image — adding image-id=%r constraint",
+                "Node %r has custom image — adding image-id=%r constraint",
                 node["name"],
                 image_name,
             )

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -96,6 +96,24 @@ MACHINE_DEPLOY_TIMEOUT = 3600
 DEFAULT_ARCHITECTURE = "amd64"
 
 
+def _node_deploy_order_key(node: dict) -> tuple:
+    """Sort key: non-DPU nodes before DPU nodes, then by hostname."""
+    return (node.get("is_dpu", False), node.get("name", ""))
+
+
+def _partition_nodes_by_dpu(nodes: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Split nodes into non-DPU and DPU groups, each sorted for stable deploy."""
+    non_dpu = sorted(
+        (n for n in nodes if not n.get("is_dpu", False)),
+        key=lambda x: x["name"],
+    )
+    dpu = sorted(
+        (n for n in nodes if n.get("is_dpu", False)),
+        key=lambda x: x["name"],
+    )
+    return non_dpu, dpu
+
+
 class AddMaasDeployment(BaseStep):
     """Perform various checks and add MAAS-backed deployment."""
 
@@ -1453,6 +1471,7 @@ class MaasAddMachinesToClusterdStep(BaseStep):
                         or node.get("arch", DEFAULT_ARCHITECTURE)
                         != machine.get("architecture", DEFAULT_ARCHITECTURE)
                         or node.get("is_dpu", False) != machine.get("is_dpu", False)
+                        or node.get("image_name", "") != machine.get("image_name", "")
                         or node.get("systemid", "") != machine["system_id"]
                     ):
                         nodes_to_update.append(machine)
@@ -1461,12 +1480,27 @@ class MaasAddMachinesToClusterdStep(BaseStep):
         self.machines = filtered_machines
         return Result(ResultType.COMPLETED)
 
+    def _validate_machine_image_name(self, machine: dict) -> Result | None:
+        """Return a failure result when the machine's dpu-image tag is invalid."""
+        image_name = machine.get("image_name")
+        if not image_name:
+            return None
+        try:
+            self.maas_client.ensure_boot_resource_name_exists(image_name)
+        except ValueError as e:
+            return Result(ResultType.FAILED, str(e))
+        return None
+
     def run(self, context: StepContext) -> Result:
         """Add machines to clusterd."""
         if self.machines is None or self.nodes is None:
             # only happens if is_skip() was not called before, or if run executed
             # even if is_skip reported a failure
             return Result(ResultType.FAILED, "No machines to add / node to update.")
+        for machine in list(self.machines) + list(self.nodes):
+            validation = self._validate_machine_image_name(machine)
+            if validation is not None:
+                return validation
         for machine in self.machines:
             self.client.cluster.add_node_info(
                 machine["hostname"],
@@ -1474,6 +1508,7 @@ class MaasAddMachinesToClusterdStep(BaseStep):
                 systemid=machine["system_id"],
                 arch=machine.get("architecture", DEFAULT_ARCHITECTURE),
                 is_dpu=machine.get("is_dpu", False),
+                image_name=machine.get("image_name", ""),
             )
         for machine in self.nodes:
             self.client.cluster.update_node_info(
@@ -1482,6 +1517,7 @@ class MaasAddMachinesToClusterdStep(BaseStep):
                 systemid=machine["system_id"],
                 arch=machine.get("architecture", DEFAULT_ARCHITECTURE),
                 is_dpu=machine.get("is_dpu", False),
+                image_name=machine.get("image_name", ""),
             )
         return Result(ResultType.COMPLETED)
 
@@ -1574,7 +1610,7 @@ class MaasDeployMachinesStep(BaseStep):
                     nodes_to_deploy.remove(node)
                     break
 
-        self.nodes_to_deploy = sorted(nodes_to_deploy, key=lambda x: x["name"])
+        self.nodes_to_deploy = sorted(nodes_to_deploy, key=_node_deploy_order_key)
         self.nodes_to_update = nodes_to_update
 
         if not self.nodes_to_deploy and not self.nodes_to_update:
@@ -1588,36 +1624,30 @@ class MaasDeployMachinesStep(BaseStep):
     def _get_node_constraints(self, node: dict) -> list[str]:
         """Return the Juju constraints for deploying this node.
 
-        For arm64 nodes with a custom image configured in the manifest,
+        For arm64 nodes with a dpu-image-<name> tag stored in clusterd,
         adds image-id and arch constraints so MAAS deploys the correct
         OS image (e.g. BF DOCA on a DPU).
         """
         constraints = ["tags=" + self.deployment.resource_tag]
-
-        dpu_arm64_image_id = (
-            self.manifest.core.software.juju.dpu_arm64_image_id
-            if self.manifest is not None
-            else None
-        )
-        if dpu_arm64_image_id is None:
-            return constraints
-
         architecture = self._get_node_architecture(node)
+        image_name = node.get("image_name") or ""
 
         if architecture == "arm64":
-            LOG.debug(
-                "Node %r is arm64 — adding image-id=%r constraint",
-                node["name"],
-                dpu_arm64_image_id,
-            )
-            constraints.append("image-id=" + dpu_arm64_image_id)
             constraints.append("arch=arm64")
+
+        if image_name:
+            LOG.debug(
+                "Node %r has custom DPU image — adding image-id=%r constraint",
+                node["name"],
+                image_name,
+            )
+            constraints.append("image-id=" + image_name)
 
         return constraints
 
-    def run(self, context: StepContext) -> Result:
-        """Deploy machines in Juju."""
-        for node in self.nodes_to_deploy:
+    def _add_nodes_to_juju(self, context: StepContext, nodes: list[dict]) -> None:
+        """Register clusterd nodes as Juju machines in the model."""
+        for node in nodes:
             self.update_status(context, f"deploying {node['name']}")
             constraints = self._get_node_constraints(node)
             LOG.debug(
@@ -1634,7 +1664,9 @@ class MaasDeployMachinesStep(BaseStep):
             self.client.cluster.update_node_info(
                 node["name"], machineid=int(juju_machine)
             )
-        self.update_status(context, "waiting for machines to deploy")
+
+    def _sync_updated_node_machine_ids(self) -> None:
+        """Update clusterd machine IDs for nodes already present in Juju."""
         machines = self.jhelper.get_machines(self.model)
         for node in self.nodes_to_update:
             LOG.debug("Updating machine %s in model %s", node["name"], self.model)
@@ -1644,11 +1676,50 @@ class MaasDeployMachinesStep(BaseStep):
                         node["name"], machineid=int(machine_id)
                     )
                     break
-        try:
-            self.jhelper.wait_all_machines_deployed(self.model, MACHINE_DEPLOY_TIMEOUT)
-        except TimeoutError:
-            LOG.debug("Timeout waiting for machines to deploy", exc_info=True)
-            return Result(ResultType.FAILED, "Timeout waiting for machines to deploy.")
+
+    def run(self, context: StepContext) -> Result:
+        """Deploy machines in Juju."""
+        non_dpu_nodes, dpu_nodes = _partition_nodes_by_dpu(self.nodes_to_deploy)
+        deploy_batches = [
+            ("non-DPU", non_dpu_nodes),
+            ("DPU", dpu_nodes),
+        ]
+
+        deployed_any = False
+        for batch_label, batch in deploy_batches:
+            if not batch:
+                continue
+            deployed_any = True
+            self._add_nodes_to_juju(context, batch)
+            self._sync_updated_node_machine_ids()
+            self.update_status(context, f"waiting for {batch_label} machines to deploy")
+            try:
+                self.jhelper.wait_all_machines_deployed(
+                    self.model, MACHINE_DEPLOY_TIMEOUT
+                )
+            except TimeoutError:
+                LOG.debug(
+                    "Timeout waiting for %s machines to deploy",
+                    batch_label,
+                    exc_info=True,
+                )
+                return Result(
+                    ResultType.FAILED,
+                    f"Timeout waiting for {batch_label} machines to deploy.",
+                )
+
+        if not deployed_any:
+            self._sync_updated_node_machine_ids()
+            try:
+                self.jhelper.wait_all_machines_deployed(
+                    self.model, MACHINE_DEPLOY_TIMEOUT
+                )
+            except TimeoutError:
+                LOG.debug("Timeout waiting for machines to deploy", exc_info=True)
+                return Result(
+                    ResultType.FAILED, "Timeout waiting for machines to deploy."
+                )
+
         return Result(ResultType.COMPLETED)
 
 

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -1082,6 +1082,7 @@ class TestMaasAddMachinesToClusterdStep:
                 "system_id": "1st",
                 "architecture": "amd64",
                 "is_dpu": False,
+                "image_name": "",
             },
             {
                 "hostname": "machine2",
@@ -1089,6 +1090,7 @@ class TestMaasAddMachinesToClusterdStep:
                 "system_id": "2nd",
                 "architecture": "arm64",
                 "is_dpu": True,
+                "image_name": "bf-3.2.1-v2-ovs-hack",
             },
         ]
         maas_add_machines_to_clusterd_step.nodes = [
@@ -1098,6 +1100,7 @@ class TestMaasAddMachinesToClusterdStep:
                 "system_id": "1st",
                 "architecture": "amd64",
                 "is_dpu": False,
+                "image_name": "",
             },
             {
                 "hostname": "machine2",
@@ -1105,8 +1108,10 @@ class TestMaasAddMachinesToClusterdStep:
                 "system_id": "2nd",
                 "architecture": "arm64",
                 "is_dpu": True,
+                "image_name": "bf-3.2.1-v2-ovs-hack",
             },
         ]
+        maas_add_machines_to_clusterd_step.maas_client.ensure_boot_resource_name_exists.return_value = None
         result = maas_add_machines_to_clusterd_step.run(step_context)
         assert result.result_type == ResultType.COMPLETED
         maas_add_machines_to_clusterd_step.client.cluster.add_node_info.assert_any_call(
@@ -1115,6 +1120,7 @@ class TestMaasAddMachinesToClusterdStep:
             systemid="2nd",
             arch="arm64",
             is_dpu=True,
+            image_name="bf-3.2.1-v2-ovs-hack",
         )
         maas_add_machines_to_clusterd_step.client.cluster.update_node_info.assert_any_call(
             "machine2",
@@ -1122,6 +1128,32 @@ class TestMaasAddMachinesToClusterdStep:
             systemid="2nd",
             arch="arm64",
             is_dpu=True,
+            image_name="bf-3.2.1-v2-ovs-hack",
+        )
+
+    def test_run_fails_when_dpu_image_tag_does_not_exist_in_maas(
+        self, maas_add_machines_to_clusterd_step, step_context
+    ):
+        maas_add_machines_to_clusterd_step.machines = [
+            {
+                "hostname": "pc8a-rb3-n4-dpu",
+                "roles": [RoleTags.NETWORK.value],
+                "system_id": "dpu-sys",
+                "architecture": "arm64",
+                "is_dpu": True,
+                "image_name": "missing-image",
+            }
+        ]
+        maas_add_machines_to_clusterd_step.nodes = []
+        maas_add_machines_to_clusterd_step.maas_client.ensure_boot_resource_name_exists.side_effect = ValueError(
+            "Image with name missing-image is missing from maas boot-resources"
+        )
+
+        result = maas_add_machines_to_clusterd_step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert result.message == (
+            "Image with name missing-image is missing from maas boot-resources"
         )
 
 
@@ -1136,22 +1168,14 @@ class TestMaasDeployMachinesStep:
         return MaasDeployMachinesStep(deployment, client, jhelper, model)
 
     @pytest.fixture
-    def step_with_arm64_manifest(self):
-        """Step configured with a manifest that sets dpu_arm64_image_id."""
+    def step_with_dpu_image_tag(self):
+        """Step configured for a clusterd node with a dpu-image tag."""
         deployment = Mock()
         deployment.resource_tag = "test-tag"
         client = Mock()
         jhelper = Mock()
         model = "test_model"
-        manifest = Mock()
-        manifest.core.software.juju.dpu_arm64_image_id = "bf-321-v2-ovs-hack"
-        return MaasDeployMachinesStep(
-            deployment,
-            client,
-            jhelper,
-            model,
-            manifest=manifest,
-        )
+        return MaasDeployMachinesStep(deployment, client, jhelper, model)
 
     def test_is_skip_with_no_clusterd_nodes(
         self, maas_deploy_machines_step, step_context
@@ -1226,57 +1250,56 @@ class TestMaasDeployMachinesStep:
             maas_deploy_machines_step.jhelper.wait_all_machines_deployed.call_count == 1
         )
 
-    def test_get_node_constraints_returns_default_when_no_manifest(
+    def test_get_node_constraints_returns_default_without_dpu_image_tag(
         self, maas_deploy_machines_step
     ):
-        """No manifest → only default tag constraint."""
-        maas_deploy_machines_step.manifest = None
-        node = {"name": "n1", "systemid": "s1"}
+        """No image_name in clusterd → only default tag constraint."""
+        node = {"name": "n1", "systemid": "s1", "arch": "arm64"}
         constraints = maas_deploy_machines_step._get_node_constraints(node)
-        assert constraints == ["tags=test-tag"]
+        assert constraints == ["tags=test-tag", "arch=arm64"]
 
-    def test_get_node_constraints_returns_default_when_image_id_is_none(
-        self, maas_deploy_machines_step
+    def test_get_node_constraints_adds_image_id_from_clusterd(
+        self, step_with_dpu_image_tag
     ):
-        """Manifest present but dpu_arm64_image_id not set → only tag constraint."""
-        manifest = Mock()
-        manifest.core.software.juju.dpu_arm64_image_id = None
-        maas_deploy_machines_step.manifest = manifest
-        node = {"name": "n1", "systemid": "s1"}
-        constraints = maas_deploy_machines_step._get_node_constraints(node)
-        assert constraints == ["tags=test-tag"]
-
-    def test_get_node_constraints_adds_image_id_for_arm64_node(
-        self, step_with_arm64_manifest
-    ):
-        """arm64 node with dpu_arm64_image_id in manifest → adds image-id constraint."""
-        step = step_with_arm64_manifest
+        """arm64 node with image_name in clusterd → adds image-id constraint."""
+        step = step_with_dpu_image_tag
         constraints = step._get_node_constraints(
-            {"name": "n4-dpu", "systemid": "arm-sys", "arch": "arm64"}
+            {
+                "name": "n4-dpu",
+                "systemid": "arm-sys",
+                "arch": "arm64",
+                "image_name": "bf-3.2.1-v2-ovs-hack",
+            }
         )
         assert "tags=test-tag" in constraints
-        assert "image-id=bf-321-v2-ovs-hack" in constraints
+        assert "image-id=bf-3.2.1-v2-ovs-hack" in constraints
         assert "arch=arm64" in constraints
 
     def test_get_node_constraints_no_image_id_for_amd64_node(
-        self, step_with_arm64_manifest
+        self, step_with_dpu_image_tag
     ):
-        """amd64 node with dpu_arm64_image_id in manifest → no image-id constraint."""
-        step = step_with_arm64_manifest
+        """amd64 node without image_name → no image-id constraint."""
+        step = step_with_dpu_image_tag
         constraints = step._get_node_constraints(
             {"name": "n1", "systemid": "x86-sys", "arch": "amd64"}
         )
         assert constraints == ["tags=test-tag"]
-        assert "image-id=bf-321-v2-ovs-hack" not in constraints
+        assert "image-id=bf-3.2.1-v2-ovs-hack" not in constraints
 
     def test_run_uses_image_id_constraint_for_arm64_and_default_for_amd64(
-        self, step_with_arm64_manifest, step_context
+        self, step_with_dpu_image_tag, step_context
     ):
         """Mixed cluster: arm64 DPU gets image-id constraint, amd64 does not."""
-        step = step_with_arm64_manifest
+        step = step_with_dpu_image_tag
         step.nodes_to_deploy = [
             {"name": "n1-x86", "systemid": "x86-sys", "arch": "amd64"},
-            {"name": "n4-dpu", "systemid": "arm-sys", "arch": "arm64"},
+            {
+                "name": "n4-dpu",
+                "systemid": "arm-sys",
+                "arch": "arm64",
+                "is_dpu": True,
+                "image_name": "bf-3.2.1-v2-ovs-hack",
+            },
         ]
         step.nodes_to_update = []
         step.jhelper.add_machine.side_effect = ["0", "1"]
@@ -1286,13 +1309,37 @@ class TestMaasDeployMachinesStep:
 
         assert result.result_type == ResultType.COMPLETED
         calls = step.jhelper.add_machine.call_args_list
-        # First call: x86 node → only tags constraint
+        # First batch (non-DPU) deploys x86 before DPU
         assert calls[0].kwargs["constraints"] == ["tags=test-tag"]
-        # Second call: arm64 DPU → tags + image-id + arch constraints
         arm_constraints = calls[1].kwargs["constraints"]
         assert "tags=test-tag" in arm_constraints
-        assert "image-id=bf-321-v2-ovs-hack" in arm_constraints
+        assert "image-id=bf-3.2.1-v2-ovs-hack" in arm_constraints
         assert "arch=arm64" in arm_constraints
+        assert step.jhelper.wait_all_machines_deployed.call_count == 2
+
+    def test_run_deploys_non_dpu_before_dpu(
+        self, maas_deploy_machines_step, step_context
+    ):
+        step = maas_deploy_machines_step
+        step.nodes_to_deploy = [
+            {
+                "name": "pc8a-rb3-n4-dpu",
+                "systemid": "dpu-sys",
+                "is_dpu": True,
+            },
+            {"name": "pc8a-rb3-n4", "systemid": "host-sys", "is_dpu": False},
+        ]
+        step.nodes_to_update = []
+        step.jhelper.add_machine.side_effect = ["9", "10"]
+        step.jhelper.get_machines.return_value = {}
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        calls = step.jhelper.add_machine.call_args_list
+        assert calls[0].args[0] == "system-id=host-sys"
+        assert calls[1].args[0] == "system-id=dpu-sys"
+        assert step.jhelper.wait_all_machines_deployed.call_count == 2
 
 
 class TestMaasDeployInfraMachinesStep:
@@ -2396,3 +2443,29 @@ class TestIsMaasDeployment:
         # Create a mock non-MAAS deployment
         deployment = mocker.Mock(spec=Deployment)
         assert is_maas_deployment(deployment) is False
+
+
+class TestParseImageNameFromTags:
+    def test_extracts_image_name_from_tag(self):
+        from sunbeam.provider.maas.client import parse_image_name_from_tags
+
+        assert (
+            parse_image_name_from_tags(["network", "dpu-image-bf-3.2.1-v2-ovs-hack"])
+            == "bf-3.2.1-v2-ovs-hack"
+        )
+
+    def test_returns_none_when_tag_missing(self):
+        from sunbeam.provider.maas.client import parse_image_name_from_tags
+
+        assert parse_image_name_from_tags(["network", "dpu"]) is None
+
+    def test_returns_none_when_tag_names_missing(self):
+        from sunbeam.provider.maas.client import parse_image_name_from_tags
+
+        assert parse_image_name_from_tags(None) is None
+
+    def test_raises_when_multiple_dpu_image_tags(self):
+        from sunbeam.provider.maas.client import parse_image_name_from_tags
+
+        with pytest.raises(ValueError, match="Multiple dpu-image tags"):
+            parse_image_name_from_tags(["dpu-image-one", "dpu-image-two"])

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -1105,6 +1105,26 @@ class TestMaasDeployMachinesStep:
         model = "test_model"
         return MaasDeployMachinesStep(deployment, client, jhelper, model)
 
+    @pytest.fixture
+    def step_with_arm64_manifest(self):
+        """Step configured with a manifest that sets arm64_image_id."""
+        deployment = Mock()
+        deployment.resource_tag = "test-tag"
+        client = Mock()
+        jhelper = Mock()
+        model = "test_model"
+        maas_client_mock = Mock()
+        manifest = Mock()
+        manifest.core.software.juju.arm64_image_id = "bf-321-v2-ovs-hack"
+        return MaasDeployMachinesStep(
+            deployment,
+            client,
+            jhelper,
+            model,
+            maas_client=maas_client_mock,
+            manifest=manifest,
+        )
+
     def test_is_skip_with_no_clusterd_nodes(
         self, maas_deploy_machines_step, step_context
     ):
@@ -1177,6 +1197,91 @@ class TestMaasDeployMachinesStep:
         assert (
             maas_deploy_machines_step.jhelper.wait_all_machines_deployed.call_count == 1
         )
+
+    def test_get_node_constraints_returns_default_when_no_manifest(
+        self, maas_deploy_machines_step
+    ):
+        """No manifest → only default tag constraint."""
+        maas_deploy_machines_step.manifest = None
+        node = {"name": "n1", "systemid": "s1"}
+        constraints = maas_deploy_machines_step._get_node_constraints(node)
+        assert constraints == ["tags=test-tag"]
+
+    def test_get_node_constraints_returns_default_when_image_id_is_none(
+        self, maas_deploy_machines_step
+    ):
+        """Manifest present but arm64_image_id not set → only tag constraint."""
+        manifest = Mock()
+        manifest.core.software.juju.arm64_image_id = None
+        maas_deploy_machines_step.manifest = manifest
+        node = {"name": "n1", "systemid": "s1"}
+        constraints = maas_deploy_machines_step._get_node_constraints(node)
+        assert constraints == ["tags=test-tag"]
+
+    def test_get_node_constraints_adds_image_id_for_arm64_node(
+        self, step_with_arm64_manifest
+    ):
+        """arm64 node with arm64_image_id in manifest → adds image-id constraint."""
+        step = step_with_arm64_manifest
+        with patch(
+            "sunbeam.provider.maas.client.get_machine_by_system_id",
+            return_value={"architecture": "arm64"},
+        ):
+            constraints = step._get_node_constraints(
+                {"name": "n4-dpu", "systemid": "arm-sys"}
+            )
+        assert "tags=test-tag" in constraints
+        assert "image-id=bf-321-v2-ovs-hack" in constraints
+        assert "arch=arm64" in constraints
+
+    def test_get_node_constraints_no_image_id_for_amd64_node(
+        self, step_with_arm64_manifest
+    ):
+        """amd64 node with arm64_image_id in manifest → no image-id constraint."""
+        step = step_with_arm64_manifest
+        with patch(
+            "sunbeam.provider.maas.client.get_machine_by_system_id",
+            return_value={"architecture": "amd64"},
+        ):
+            constraints = step._get_node_constraints(
+                {"name": "n1", "systemid": "x86-sys"}
+            )
+        assert constraints == ["tags=test-tag"]
+        assert "image-id=bf-321-v2-ovs-hack" not in constraints
+
+    def test_run_uses_image_id_constraint_for_arm64_and_default_for_amd64(
+        self, step_with_arm64_manifest, step_context
+    ):
+        """Mixed cluster: arm64 DPU gets image-id constraint, amd64 does not."""
+        step = step_with_arm64_manifest
+        step.nodes_to_deploy = [
+            {"name": "n1-x86", "systemid": "x86-sys"},
+            {"name": "n4-dpu", "systemid": "arm-sys"},
+        ]
+        step.nodes_to_update = []
+        step.jhelper.add_machine.side_effect = ["0", "1"]
+        step.jhelper.get_machines.return_value = {}
+
+        arch_map = {"x86-sys": "amd64", "arm-sys": "arm64"}
+
+        def fake_get_machine_by_system_id(client, system_id):
+            return {"architecture": arch_map[system_id]}
+
+        with patch(
+            "sunbeam.provider.maas.client.get_machine_by_system_id",
+            side_effect=fake_get_machine_by_system_id,
+        ):
+            result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        calls = step.jhelper.add_machine.call_args_list
+        # First call: x86 node → only tags constraint
+        assert calls[0].kwargs["constraints"] == ["tags=test-tag"]
+        # Second call: arm64 DPU → tags + image-id + arch constraints
+        arm_constraints = calls[1].kwargs["constraints"]
+        assert "tags=test-tag" in arm_constraints
+        assert "image-id=bf-321-v2-ovs-hack" in arm_constraints
+        assert "arch=arm64" in arm_constraints
 
 
 class TestMaasDeployInfraMachinesStep:

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -1080,19 +1080,49 @@ class TestMaasAddMachinesToClusterdStep:
                 "hostname": "machine1",
                 "roles": [RoleTags.CONTROL.value],
                 "system_id": "1st",
+                "architecture": "amd64",
+                "is_dpu": False,
             },
             {
                 "hostname": "machine2",
                 "roles": [RoleTags.COMPUTE.value],
                 "system_id": "2nd",
+                "architecture": "arm64",
+                "is_dpu": True,
             },
         ]
         maas_add_machines_to_clusterd_step.nodes = [
-            ("machine1", [RoleTags.CONTROL.value]),
-            ("machine2", [RoleTags.COMPUTE.value]),
+            {
+                "hostname": "machine1",
+                "roles": [RoleTags.CONTROL.value],
+                "system_id": "1st",
+                "architecture": "amd64",
+                "is_dpu": False,
+            },
+            {
+                "hostname": "machine2",
+                "roles": [RoleTags.COMPUTE.value],
+                "system_id": "2nd",
+                "architecture": "arm64",
+                "is_dpu": True,
+            },
         ]
         result = maas_add_machines_to_clusterd_step.run(step_context)
         assert result.result_type == ResultType.COMPLETED
+        maas_add_machines_to_clusterd_step.client.cluster.add_node_info.assert_any_call(
+            "machine2",
+            [RoleTags.COMPUTE.value],
+            systemid="2nd",
+            arch="arm64",
+            is_dpu=True,
+        )
+        maas_add_machines_to_clusterd_step.client.cluster.update_node_info.assert_any_call(
+            "machine2",
+            [RoleTags.COMPUTE.value],
+            systemid="2nd",
+            arch="arm64",
+            is_dpu=True,
+        )
 
 
 class TestMaasDeployMachinesStep:
@@ -1107,21 +1137,19 @@ class TestMaasDeployMachinesStep:
 
     @pytest.fixture
     def step_with_arm64_manifest(self):
-        """Step configured with a manifest that sets arm64_image_id."""
+        """Step configured with a manifest that sets dpu_arm64_image_id."""
         deployment = Mock()
         deployment.resource_tag = "test-tag"
         client = Mock()
         jhelper = Mock()
         model = "test_model"
-        maas_client_mock = Mock()
         manifest = Mock()
-        manifest.core.software.juju.arm64_image_id = "bf-321-v2-ovs-hack"
+        manifest.core.software.juju.dpu_arm64_image_id = "bf-321-v2-ovs-hack"
         return MaasDeployMachinesStep(
             deployment,
             client,
             jhelper,
             model,
-            maas_client=maas_client_mock,
             manifest=manifest,
         )
 
@@ -1210,9 +1238,9 @@ class TestMaasDeployMachinesStep:
     def test_get_node_constraints_returns_default_when_image_id_is_none(
         self, maas_deploy_machines_step
     ):
-        """Manifest present but arm64_image_id not set → only tag constraint."""
+        """Manifest present but dpu_arm64_image_id not set → only tag constraint."""
         manifest = Mock()
-        manifest.core.software.juju.arm64_image_id = None
+        manifest.core.software.juju.dpu_arm64_image_id = None
         maas_deploy_machines_step.manifest = manifest
         node = {"name": "n1", "systemid": "s1"}
         constraints = maas_deploy_machines_step._get_node_constraints(node)
@@ -1221,15 +1249,11 @@ class TestMaasDeployMachinesStep:
     def test_get_node_constraints_adds_image_id_for_arm64_node(
         self, step_with_arm64_manifest
     ):
-        """arm64 node with arm64_image_id in manifest → adds image-id constraint."""
+        """arm64 node with dpu_arm64_image_id in manifest → adds image-id constraint."""
         step = step_with_arm64_manifest
-        with patch(
-            "sunbeam.provider.maas.client.get_machine_by_system_id",
-            return_value={"architecture": "arm64"},
-        ):
-            constraints = step._get_node_constraints(
-                {"name": "n4-dpu", "systemid": "arm-sys"}
-            )
+        constraints = step._get_node_constraints(
+            {"name": "n4-dpu", "systemid": "arm-sys", "arch": "arm64"}
+        )
         assert "tags=test-tag" in constraints
         assert "image-id=bf-321-v2-ovs-hack" in constraints
         assert "arch=arm64" in constraints
@@ -1237,15 +1261,11 @@ class TestMaasDeployMachinesStep:
     def test_get_node_constraints_no_image_id_for_amd64_node(
         self, step_with_arm64_manifest
     ):
-        """amd64 node with arm64_image_id in manifest → no image-id constraint."""
+        """amd64 node with dpu_arm64_image_id in manifest → no image-id constraint."""
         step = step_with_arm64_manifest
-        with patch(
-            "sunbeam.provider.maas.client.get_machine_by_system_id",
-            return_value={"architecture": "amd64"},
-        ):
-            constraints = step._get_node_constraints(
-                {"name": "n1", "systemid": "x86-sys"}
-            )
+        constraints = step._get_node_constraints(
+            {"name": "n1", "systemid": "x86-sys", "arch": "amd64"}
+        )
         assert constraints == ["tags=test-tag"]
         assert "image-id=bf-321-v2-ovs-hack" not in constraints
 
@@ -1255,23 +1275,14 @@ class TestMaasDeployMachinesStep:
         """Mixed cluster: arm64 DPU gets image-id constraint, amd64 does not."""
         step = step_with_arm64_manifest
         step.nodes_to_deploy = [
-            {"name": "n1-x86", "systemid": "x86-sys"},
-            {"name": "n4-dpu", "systemid": "arm-sys"},
+            {"name": "n1-x86", "systemid": "x86-sys", "arch": "amd64"},
+            {"name": "n4-dpu", "systemid": "arm-sys", "arch": "arm64"},
         ]
         step.nodes_to_update = []
         step.jhelper.add_machine.side_effect = ["0", "1"]
         step.jhelper.get_machines.return_value = {}
 
-        arch_map = {"x86-sys": "amd64", "arm-sys": "arm64"}
-
-        def fake_get_machine_by_system_id(client, system_id):
-            return {"architecture": arch_map[system_id]}
-
-        with patch(
-            "sunbeam.provider.maas.client.get_machine_by_system_id",
-            side_effect=fake_get_machine_by_system_id,
-        ):
-            result = step.run(step_context)
+        result = step.run(step_context)
 
         assert result.result_type == ResultType.COMPLETED
         calls = step.jhelper.add_machine.call_args_list

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -2469,3 +2469,9 @@ class TestParseImageNameFromTags:
 
         with pytest.raises(ValueError, match="Multiple dpu-image tags"):
             parse_image_name_from_tags(["dpu-image-one", "dpu-image-two"])
+
+    def test_raises_when_dpu_image_tag_has_empty_name(self):
+        from sunbeam.provider.maas.client import parse_image_name_from_tags
+
+        with pytest.raises(ValueError, match="image name is empty"):
+            parse_image_name_from_tags(["network", "dpu-image-"])


### PR DESCRIPTION
## Summary

Adds support for deploying arm64 DPU nodes with a custom MAAS image, driven by a **MAAS machine tag** rather than manifest config.

**Design:** `MAAS → clusterd → Juju` — `MaasAddMachinesToClusterdStep` reads and validates from MAAS; `MaasDeployMachinesStep` reads only from clusterd (no MAAS fallback).

## Changes

**sunbeam-microcluster**
- Add `arch`, `is_dpu`, and `image_name` fields to clusterd node schema/API
- DB migration `AddImageNameToNodes`

**sunbeam-python**
- Parse `dpu-image-<name>` MAAS tags in `_convert_raw_machine()`
- Validate boot resource exists in MAAS before enrolling (`ensure_boot_resource_name_exists`)
- Persist `architecture`, `is_dpu`, and `image_name` in `MaasAddMachinesToClusterdStep`
- `MaasDeployMachinesStep` adds Juju constraints `arch=arm64` and `image-id=<name>` from clusterd
- Deploy DPU nodes in a separate batch after non-DPU nodes
- Show `image_name` in `deployment machine list/show` CLI output
- Remove manifest-based `arm64_image_id` (no manifest field required)

## Usage

Tag the DPU machine in MAAS:


## Links

*Jira card:* [OPEN-4268](https://warthogs.atlassian.net/browse/OPEN-4268)

<img width="1214" height="590" alt="Image" src="https://github.com/user-attachments/assets/e448fa77-353e-4ae6-8a2a-4910b6a2c618" />
<img width="910" height="176" alt="Image1" src="https://github.com/user-attachments/assets/3aff9b0e-69a5-4dc1-93b5-5081994ee3da" />


[OPEN-4268]: https://warthogs.atlassian.net/browse/OPEN-4268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ