### PR TITLE
chore: Use sunbeam-terraform stable/2024.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -145,6 +145,7 @@ parts:
     after: [terraform]
     plugin: dump
     source: https://github.com/canonical/sunbeam-terraform
+    source-branch: stable/2024.1
     source-depth: 1
     source-type: git
     organize:


### PR DESCRIPTION
Plan to cut the branches for snap-openstack.
First step is to use sunbeam-terraform
stable/2024.1

Modify in snapcraft.yaml to use sunbeam-terraform
repo from stable/2024.1 branch