### PR TITLE
feat: default to OpenStack 2026.1

### DIFF
--- a/cloud/etc/deploy-cinder-volume/variables.tf
+++ b/cloud/etc/deploy-cinder-volume/variables.tf
@@ -4,7 +4,7 @@
 variable "charm_cinder_volume_channel" {
   description = "Operator channel for cinder_volume deployment"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_cinder_volume_revision" {
@@ -21,13 +21,13 @@ variable "charm_cinder_volume_config" {
 
 variable "cinder_volume_channel" {
   description = "Cinder Volume channel to deploy, not the operator channel"
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_cinder_volume_ceph_channel" {
   description = "Operator channel for cinder_volume_ceph deployment"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_cinder_volume_ceph_revision" {

--- a/cloud/etc/deploy-microovn/variables.tf
+++ b/cloud/etc/deploy-microovn/variables.tf
@@ -3,7 +3,7 @@
 
 variable "charm_microovn_channel" {
   type    = string
-  default = "24.03/stable"
+  default = "25.03/stable"
 }
 
 variable "charm_microovn_revision" {
@@ -21,7 +21,7 @@ variable "charm_microovn_config" {
 variable "charm_openstack_network_agents_channel" {
   description = "Operator channel for openstack-network-agents deployment"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_openstack_network_agents_revision" {
@@ -66,7 +66,7 @@ variable "charm_microcluster_token_distributor_config" {
 variable "charm_sunbeam_ovn_proxy_channel" {
   description = "Operator channel for sunbeam-ovn-proxy deployment"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_sunbeam_ovn_proxy_revision" {

--- a/cloud/etc/deploy-openstack-hypervisor/variables.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/variables.tf
@@ -10,13 +10,13 @@ variable "machine_ids" {
 variable "snap_channel" {
   description = "Snap channel to deploy openstack-hypervisor snap from"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_channel" {
   description = "Charm channel to deploy openstack-hypervisor charm from"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_revision" {

--- a/cloud/etc/deploy-storage/modules/cinder-volume/variables.tf
+++ b/cloud/etc/deploy-storage/modules/cinder-volume/variables.tf
@@ -9,7 +9,7 @@ variable "application_name" {
 variable "charm_channel" {
   description = "Operator channel for cinder_volume deployment"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_revision" {

--- a/cloud/etc/deploy-sunbeam-machine/variables.tf
+++ b/cloud/etc/deploy-sunbeam-machine/variables.tf
@@ -10,7 +10,7 @@ variable "machine_ids" {
 variable "charm_channel" {
   description = "Charm channel to deploy sunbeam-machine charm from"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_revision" {
@@ -39,7 +39,7 @@ variable "endpoint_bindings" {
 variable "charm_epa_orchestrator_channel" {
   description = "Operator channel for epa-orchestrator deployment"
   type        = string
-  default     = "2024.1/stable"
+  default     = "2026.1/stable"
 }
 
 variable "charm_epa_orchestrator_revision" {

--- a/manifests/2026.1/beta.yml
+++ b/manifests/2026.1/beta.yml
@@ -1,0 +1,145 @@
+core:
+  software:
+    charms:
+      cinder-volume:
+        channel: 2026.1/beta
+        config:
+          snap-channel: 2026.1/beta
+      cinder-volume-ceph:
+        channel: 2026.1/beta
+      cinder-k8s:
+        channel: 2026.1/beta
+      glance-k8s:
+        channel: 2026.1/beta
+      horizon-k8s:
+        channel: 2026.1/beta
+      keystone-k8s:
+        channel: 2026.1/beta
+      neutron-k8s:
+        channel: 2026.1/beta
+      nova-k8s:
+        channel: 2026.1/beta
+      openstack-hypervisor:
+        channel: 2026.1/beta
+        config:
+          snap-channel: 2026.1/beta
+      ovn-central-k8s:
+        channel: 26.03/beta
+      ovn-relay-k8s:
+        channel: 26.03/beta
+      placement-k8s:
+        channel: 2026.1/beta
+      sunbeam-clusterd:
+        channel: 2026.1/beta
+        config:
+          snap-channel: 2026.1/beta
+      sunbeam-machine:
+        channel: 2026.1/beta
+      microceph:
+        channel: squid/stable
+        config:
+          snap-channel: squid/stable
+      microovn:
+        channel: 25.03/stable
+      openstack-network-agents:
+        channel: 2026.1/beta
+        config:
+          snap-channel: 2026.1/beta
+      microcluster-token-distributor:
+        channel: latest/edge
+      sunbeam-ovn-proxy:
+        channel: 2026.1/beta
+features:
+  baremetal:
+    software:
+      charms:
+        ironic-conductor-k8s:
+          channel: 2026.1/beta
+        ironic-k8s:
+          channel: 2026.1/beta
+        nova-ironic-k8s:
+          channel: 2026.1/beta
+        neutron-baremetal-switch-config-k8s:
+          channel: 2026.1/beta
+        neutron-generic-switch-config-k8s:
+          channel: 2026.1/beta
+  caas:
+    software:
+      charms:
+        magnum-k8s:
+          channel: 2026.1/beta
+  dns:
+    software:
+      charms:
+        designate-bind-k8s:
+          channel: 9/beta
+        designate-k8s:
+          channel: 2026.1/beta
+  images-sync:
+    software:
+      charms:
+        openstack-images-sync-k8s:
+          channel: 2026.1/beta
+  instance-recovery:
+    software:
+      charms:
+        consul-k8s:
+          channel: 1.19/beta
+        consul-client:
+          channel: 1.19/beta
+        masakari-k8s:
+          channel: 2026.1/beta
+  ldap:
+    software:
+      charms:
+        keystone-ldap-k8s:
+          channel: 2026.1/beta
+  loadbalancer:
+    software:
+      charms:
+        multus:
+          channel: latest/stable
+        octavia-k8s:
+          channel: 2026.1/beta
+        openstack-port-cni-k8s:
+          channel: 2026.1/beta
+  orchestration:
+    software:
+      charms:
+        heat-k8s:
+          channel: 2026.1/beta
+  resource-optimization:
+    software:
+      charms:
+        watcher-k8s:
+          channel: 2026.1/beta
+  secrets:
+    software:
+      charms:
+        barbican-k8s:
+          channel: 2026.1/beta
+  shared-filesystem:
+    software:
+      charms:
+        manila-k8s:
+          channel: 2026.1/beta
+        manila-cephfs-k8s:
+          channel: 2026.1/beta
+        manila-data:
+          channel: 2026.1/beta
+  telemetry:
+    software:
+      charms:
+        aodh-k8s:
+          channel: 2026.1/beta
+        ceilometer-k8s:
+          channel: 2026.1/beta
+        gnocchi-k8s:
+          channel: 2026.1/beta
+        openstack-exporter-k8s:
+          channel: 2026.1/beta
+  validation:
+    software:
+      charms:
+        tempest-k8s:
+          channel: 2026.1/beta

--- a/manifests/2026.1/candidate.yml
+++ b/manifests/2026.1/candidate.yml
@@ -1,0 +1,145 @@
+core:
+  software:
+    charms:
+      cinder-volume:
+        channel: 2026.1/candidate
+        config:
+          snap-channel: 2026.1/candidate
+      cinder-volume-ceph:
+        channel: 2026.1/candidate
+      cinder-k8s:
+        channel: 2026.1/candidate
+      glance-k8s:
+        channel: 2026.1/candidate
+      horizon-k8s:
+        channel: 2026.1/candidate
+      keystone-k8s:
+        channel: 2026.1/candidate
+      neutron-k8s:
+        channel: 2026.1/candidate
+      nova-k8s:
+        channel: 2026.1/candidate
+      openstack-hypervisor:
+        channel: 2026.1/candidate
+        config:
+          snap-channel: 2026.1/candidate
+      ovn-central-k8s:
+        channel: 26.03/candidate
+      ovn-relay-k8s:
+        channel: 26.03/candidate
+      placement-k8s:
+        channel: 2026.1/candidate
+      sunbeam-clusterd:
+        channel: 2026.1/candidate
+        config:
+          snap-channel: 2026.1/candidate
+      sunbeam-machine:
+        channel: 2026.1/candidate
+      microceph:
+        channel: squid/stable
+        config:
+          snap-channel: squid/stable
+      microovn:
+        channel: 25.03/stable
+      openstack-network-agents:
+        channel: 2026.1/candidate
+        config:
+          snap-channel: 2026.1/candidate
+      microcluster-token-distributor:
+        channel: latest/edge
+      sunbeam-ovn-proxy:
+        channel: 2026.1/candidate
+features:
+  baremetal:
+    software:
+      charms:
+        ironic-conductor-k8s:
+          channel: 2026.1/candidate
+        ironic-k8s:
+          channel: 2026.1/candidate
+        nova-ironic-k8s:
+          channel: 2026.1/candidate
+        neutron-baremetal-switch-config-k8s:
+          channel: 2026.1/candidate
+        neutron-generic-switch-config-k8s:
+          channel: 2026.1/candidate
+  caas:
+    software:
+      charms:
+        magnum-k8s:
+          channel: 2026.1/candidate
+  dns:
+    software:
+      charms:
+        designate-bind-k8s:
+          channel: 9/candidate
+        designate-k8s:
+          channel: 2026.1/candidate
+  images-sync:
+    software:
+      charms:
+        openstack-images-sync-k8s:
+          channel: 2026.1/candidate
+  instance-recovery:
+    software:
+      charms:
+        consul-k8s:
+          channel: 1.19/candidate
+        consul-client:
+          channel: 1.19/candidate
+        masakari-k8s:
+          channel: 2026.1/candidate
+  ldap:
+    software:
+      charms:
+        keystone-ldap-k8s:
+          channel: 2026.1/candidate
+  loadbalancer:
+    software:
+      charms:
+        multus:
+          channel: latest/stable
+        octavia-k8s:
+          channel: 2026.1/candidate
+        openstack-port-cni-k8s:
+          channel: 2026.1/candidate
+  orchestration:
+    software:
+      charms:
+        heat-k8s:
+          channel: 2026.1/candidate
+  resource-optimization:
+    software:
+      charms:
+        watcher-k8s:
+          channel: 2026.1/candidate
+  secrets:
+    software:
+      charms:
+        barbican-k8s:
+          channel: 2026.1/candidate
+  shared-filesystem:
+    software:
+      charms:
+        manila-k8s:
+          channel: 2026.1/candidate
+        manila-cephfs-k8s:
+          channel: 2026.1/candidate
+        manila-data:
+          channel: 2026.1/candidate
+  telemetry:
+    software:
+      charms:
+        aodh-k8s:
+          channel: 2026.1/candidate
+        ceilometer-k8s:
+          channel: 2026.1/candidate
+        gnocchi-k8s:
+          channel: 2026.1/candidate
+        openstack-exporter-k8s:
+          channel: 2026.1/candidate
+  validation:
+    software:
+      charms:
+        tempest-k8s:
+          channel: 2026.1/candidate

--- a/manifests/2026.1/edge.yml
+++ b/manifests/2026.1/edge.yml
@@ -1,15 +1,10 @@
 core:
   software:
-    juju:
-      bootstrap_args:
-        - --bootstrap-constraints
-        - root-disk=5G
-      bootstrap_model_configs:
-        openstack:
-          logging-config: "<root>=WARNING;unit=DEBUG"
     charms:
       cinder-volume:
         channel: 2026.1/edge
+        config:
+          snap-channel: 2026.1/edge
       cinder-volume-ceph:
         channel: 2026.1/edge
       cinder-k8s:
@@ -43,19 +38,19 @@ core:
       epa-orchestrator:
         channel: 2026.1/edge
       microceph:
-        channel: squid/edge
+        channel: squid/stable
         config:
-          snap-channel: squid/edge
+          snap-channel: squid/stable
       microovn:
+        channel: 25.03/stable
+      openstack-network-agents:
+        channel: 2026.1/edge
+        config:
+          snap-channel: 2026.1/edge
+      microcluster-token-distributor:
         channel: latest/edge
-      rabbitmq-k8s:
-        channel: 3.12/edge
-        storage:
-          rabbitmq-data: 1G
-      mysql-k8s:
-        channel: 8.0/stable
-        storage:
-          database: 2G
+      sunbeam-ovn-proxy:
+        channel: 2026.1/edge
 features:
   baremetal:
     software:
@@ -104,7 +99,11 @@ features:
   loadbalancer:
     software:
       charms:
+        multus:
+          channel: latest/stable
         octavia-k8s:
+          channel: 2026.1/edge
+        openstack-port-cni-k8s:
           channel: 2026.1/edge
   orchestration:
     software:
@@ -116,11 +115,6 @@ features:
       charms:
         watcher-k8s:
           channel: 2026.1/edge
-  secrets:
-    software:
-      charms:
-        barbican-k8s:
-          channel: 2026.1/edge
   shared-filesystem:
     software:
       charms:
@@ -129,6 +123,11 @@ features:
         manila-cephfs-k8s:
           channel: 2026.1/edge
         manila-data:
+          channel: 2026.1/edge
+  secrets:
+    software:
+      charms:
+        barbican-k8s:
           channel: 2026.1/edge
   telemetry:
     software:

--- a/manifests/2026.1/stable.yml
+++ b/manifests/2026.1/stable.yml
@@ -1,0 +1,147 @@
+core:
+  software:
+    charms:
+      cinder-volume:
+        channel: 2026.1/stable
+        config:
+          snap-channel: 2026.1/stable
+      cinder-volume-ceph:
+        channel: 2026.1/stable
+      cinder-k8s:
+        channel: 2026.1/stable
+      glance-k8s:
+        channel: 2026.1/stable
+      horizon-k8s:
+        channel: 2026.1/stable
+      keystone-k8s:
+        channel: 2026.1/stable
+      neutron-k8s:
+        channel: 2026.1/stable
+      nova-k8s:
+        channel: 2026.1/stable
+      openstack-hypervisor:
+        channel: 2026.1/stable
+        config:
+          snap-channel: 2026.1/stable
+      ovn-central-k8s:
+        channel: 26.03/stable
+      ovn-relay-k8s:
+        channel: 26.03/stable
+      placement-k8s:
+        channel: 2026.1/stable
+      sunbeam-clusterd:
+        channel: 2026.1/stable
+        config:
+          snap-channel: 2026.1/stable
+      sunbeam-machine:
+        channel: 2026.1/stable
+      epa-orchestrator:
+        channel: 2026.1/stable
+      microceph:
+        channel: squid/stable
+        config:
+          snap-channel: squid/stable
+      microovn:
+        channel: 25.03/stable
+      openstack-network-agents:
+        channel: 2026.1/stable
+        config:
+          snap-channel: 2026.1/stable
+      microcluster-token-distributor:
+        channel: latest/edge
+      sunbeam-ovn-proxy:
+        channel: 2026.1/stable
+features:
+  baremetal:
+    software:
+      charms:
+        ironic-conductor-k8s:
+          channel: 2026.1/stable
+        ironic-k8s:
+          channel: 2026.1/stable
+        nova-ironic-k8s:
+          channel: 2026.1/stable
+        neutron-baremetal-switch-config-k8s:
+          channel: 2026.1/stable
+        neutron-generic-switch-config-k8s:
+          channel: 2026.1/stable
+  caas:
+    software:
+      charms:
+        magnum-k8s:
+          channel: 2026.1/stable
+  dns:
+    software:
+      charms:
+        designate-bind-k8s:
+          channel: 9/stable
+        designate-k8s:
+          channel: 2026.1/stable
+  images-sync:
+    software:
+      charms:
+        openstack-images-sync-k8s:
+          channel: 2026.1/stable
+  instance-recovery:
+    software:
+      charms:
+        consul-k8s:
+          channel: 1.19/edge
+        consul-client:
+          channel: 1.19/edge
+        masakari-k8s:
+          channel: 2026.1/stable
+  ldap:
+    software:
+      charms:
+        keystone-ldap-k8s:
+          channel: 2026.1/stable
+  loadbalancer:
+    software:
+      charms:
+        multus:
+          channel: latest/stable
+        octavia-k8s:
+          channel: 2026.1/stable
+        openstack-port-cni-k8s:
+          channel: 2026.1/stable
+  orchestration:
+    software:
+      charms:
+        heat-k8s:
+          channel: 2026.1/stable
+  resource-optimization:
+    software:
+      charms:
+        watcher-k8s:
+          channel: 2026.1/stable
+  secrets:
+    software:
+      charms:
+        barbican-k8s:
+          channel: 2026.1/stable
+  shared-filesystem:
+    software:
+      charms:
+        manila-k8s:
+          channel: 2026.1/stable
+        manila-cephfs-k8s:
+          channel: 2026.1/stable
+        manila-data:
+          channel: 2026.1/stable
+  telemetry:
+    software:
+      charms:
+        aodh-k8s:
+          channel: 2026.1/stable
+        ceilometer-k8s:
+          channel: 2026.1/stable
+        gnocchi-k8s:
+          channel: 2026.1/stable
+        openstack-exporter-k8s:
+          channel: 2026.1/stable
+  validation:
+    software:
+      charms:
+        tempest-k8s:
+          channel: 2026.1/stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Dead simple OpenStack installation
 license: Apache-2.0
 description: |
   snap-openstack aims to provide a scalable, simple to deploy OpenStack solution.
-version: "2024.1"
+version: "2026.1"
 
 confinement: strict
 grade: stable
@@ -145,7 +145,6 @@ parts:
     after: [terraform]
     plugin: dump
     source: https://github.com/canonical/sunbeam-terraform
-    source-branch: stable/2024.1
     source-depth: 1
     source-type: git
     organize:
@@ -193,8 +192,8 @@ parts:
       '*': etc/manifests/
     override-prime: |
       craftctl default
-      # For backward compatibility, we symlink 2024.1 manifests to the root manifests dir
-      for manifest in $CRAFT_PRIME/etc/manifests/2024.1/*yml;
+      # Symlink current release manifests to the root manifests dir
+      for manifest in $CRAFT_PRIME/etc/manifests/2026.1/*yml;
       do
         link=$CRAFT_PRIME/etc/manifests/$(basename $manifest)
         [ -e $link ] && rm $link || true

--- a/sunbeam-python/pyproject.toml
+++ b/sunbeam-python/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sunbeam"
-version = "2024.1"
+version = "2026.1"
 requires-python = "~=3.12.0"
 license-files = ["LICENSE"]
 description = "The simple way to build and manage your OpenStack Cloud"

--- a/sunbeam-python/sunbeam/core/common.py
+++ b/sunbeam-python/sunbeam/core/common.py
@@ -670,7 +670,7 @@ def infer_version(snap: Snap) -> str:
     try:
         version = str(snap.config.get("deployment.version"))
     except UnknownConfigKey:
-        return "2024.1"
+        return "2026.1"
     return version
 
 

--- a/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-cni/variables.tf
+++ b/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-cni/variables.tf
@@ -33,7 +33,7 @@ variable "multus-network-attachment-definitions" {
 variable "openstack-port-cni-channel" {
   description = "Operator channel for openstack-port-cni-k8s deployment"
   type        = string
-  default     = "2025.1/edge"
+  default     = "2026.1/stable"
 }
 
 variable "openstack-port-cni-revision" {

--- a/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/variables.tf
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/variables.tf
@@ -4,7 +4,7 @@
 variable "charm-manila-data-channel" {
   description = "Operator channel for manila_data deployment"
   type        = string
-  default     = "2024.1/edge"
+  default     = "2026.1/stable"
 }
 
 variable "charm-manila-data-revision" {
@@ -22,7 +22,7 @@ variable "charm-manila-data-config" {
 variable "manila-data-channel" {
   description = "Manila Data snap channel to deploy, not the operator channel"
   type        = string
-  default     = "2024.1/edge"
+  default     = "2026.1/stable"
 }
 
 variable "machine_ids" {

--- a/sunbeam-python/sunbeam/features/shared_filesystem/feature.py
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/feature.py
@@ -64,7 +64,7 @@ class SharedFilesystemFeature(OpenStackControlPlaneFeature):
             charms={
                 "manila-k8s": CharmManifest(channel=OPENSTACK_CHANNEL),
                 "manila-cephfs-k8s": CharmManifest(channel=OPENSTACK_CHANNEL),
-                "manila-data": CharmManifest(channel="2024.1/edge"),
+                "manila-data": CharmManifest(channel=OPENSTACK_CHANNEL),
             },
             terraform={
                 self.tfplan_manila_data: TerraformManifest(

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -15,7 +15,7 @@ def determine_version() -> str:
         snap = Snap()
         risk = str(snap.config.get("deployment.version"))
     except Exception:
-        risk = "2024.1"
+        risk = "2026.1"
     return risk
 
 
@@ -23,11 +23,11 @@ SUPPORTED_RELEASE = "noble"
 JUJU_CHANNEL = "3.6/stable"
 JUJU_BASE = "ubuntu@24.04"
 OPENSTACK_CHANNEL = f"{determine_version()}/stable"
-OVN_CHANNEL = "24.03/stable"
+OVN_CHANNEL = "26.03/stable"
 RABBITMQ_CHANNEL = "3.12/stable"
 TRAEFIK_CHANNEL = "latest/stable"
 MICROCEPH_CHANNEL = "squid/stable"
-MICROOVN_CHANNEL = "24.03/stable"
+MICROOVN_CHANNEL = "25.03/stable"
 MYSQL_CHANNEL = "8.0/stable"
 CERT_AUTH_CHANNEL = "1/stable"
 MANUAL_TLS_CERTIFICATES_CHANNEL = "1/stable"

--- a/sunbeam-python/tests/unit/sunbeam/core/test_common.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_common.py
@@ -6,9 +6,10 @@ from unittest.mock import Mock, patch
 
 import click
 import pytest
+from snaphelpers import UnknownConfigKey
 
 from sunbeam.clusterd.service import ClusterServiceUnavailableException
-from sunbeam.core.common import Role, validate_roles
+from sunbeam.core.common import Role, infer_version, validate_roles
 from sunbeam.core.deployment import Deployment
 
 
@@ -195,3 +196,9 @@ def test_validate_roles_gated():
     with patch("sunbeam.core.common._is_role_enabled", return_value=True):
         result = validate_roles(Mock(), Mock(), ("region_controller",))
         assert result == [Role.REGION_CONTROLLER]
+
+
+def test_infer_version_defaults_to_current_release(snap):
+    snap.config.get.side_effect = UnknownConfigKey("deployment.version")
+
+    assert infer_version(snap) == "2026.1"

--- a/sunbeam-python/uv.lock
+++ b/sunbeam-python/uv.lock
@@ -2966,7 +2966,7 @@ wheels = [
 
 [[package]]
 name = "sunbeam"
-version = "2024.1"
+version = "2026.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Add 2026.1 manifests and move the snap defaults to the Gazpacho charm tracks.

Update embedded Terraform deploy defaults so base installs use 2026.1 charms and 26.03 OVN where applicable, while keeping Juju application bases on ubuntu@24.04.

Cover the snap config fallback so deployments without an explicit version infer 2026.1.

Requires:
- [x] https://github.com/canonical/sunbeam-terraform/pull/143