### PR TITLE
cos external observability fix when deploying after a storage backend has been provisioned 

### DIFF
--- a/sunbeam-python/sunbeam/features/telemetry/feature.py
+++ b/sunbeam-python/sunbeam/features/telemetry/feature.py
@@ -143,10 +143,15 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
 
         if storage_backends.root:
             storage_manager = StorageBackendManager()
-            tfhelper_storage = deployment.get_tfhelper("storage-plan")
 
             plan3: list[BaseStep] = []
-            plan3.append(TerraformInitStep(tfhelper_storage))
+            # PATCH: the storage-backend plan ("storage-backend-plan") is registered
+            # dynamically by StorageBackendBase.register_terraform_plan() and is NOT
+            # present in versions.TERRAFORM_DIR_NAMES, so it is not loaded by the
+            # deployment's static _load_tfhelpers(). It must be registered before it
+            # can be fetched. Defer fetching until inside the loop where we have a
+            # backend_instance to register with; register + init exactly once.
+            tfhelper_storage = None
 
             # Track principal applications to avoid duplicates
             processed_principals = set()
@@ -159,14 +164,21 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                 try:
                     backend_instance = storage_manager.backends().get(backend_type)
                     if backend_instance:
+                        # Register the storage-backend plan before fetching it
+                        # (mirrors storage/base.py add_backend_instance/remove_backend).
+                        if tfhelper_storage is None:
+                            backend_instance.register_terraform_plan(deployment)
+                            tfhelper_storage = deployment.get_tfhelper(
+                                "storage-backend-plan"
+                            )
+                            plan3.append(TerraformInitStep(tfhelper_storage))
+
                         # Skip if we've already processed this principal application
                         principal_app = backend_instance.principal_application
                         if principal_app in processed_principals:
                             LOG.debug(
-                                "Skipping %s: principal application %s is already"
-                                " processed",
-                                backend_name,
-                                principal_app,
+                                f"Skipping {backend_name}: principal application "
+                                f"{principal_app} already processed"
                             )
                             continue
 
@@ -188,9 +200,8 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                         )
                 except Exception as e:
                     LOG.warning(
-                        "Failed to add specific cinder-volume step for backend %s: %r",
-                        backend_name,
-                        e,
+                        f"Failed to add specific cinder-volume step for backend "
+                        f"{backend_name}: {e}"
                     )
 
             if len(plan3) > 1:  # More than just TerraformInitStep
@@ -244,10 +255,12 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
 
         if storage_backends.root:
             storage_manager = StorageBackendManager()
-            tfhelper_storage = deployment.get_tfhelper("storage-plan")
 
             plan2: list[BaseStep] = []
-            plan2.append(TerraformInitStep(tfhelper_storage))
+            # PATCH: same as run_enable_plans - register the dynamically-registered
+            # "storage-backend-plan" before fetching it; do so once inside the loop
+            # where a backend_instance is available.
+            tfhelper_storage = None
 
             # Track principal applications to avoid duplicates
             processed_principals = set()
@@ -260,14 +273,20 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                 try:
                     backend_instance = storage_manager.backends().get(backend_type)
                     if backend_instance:
+                        # Register the storage-backend plan before fetching it.
+                        if tfhelper_storage is None:
+                            backend_instance.register_terraform_plan(deployment)
+                            tfhelper_storage = deployment.get_tfhelper(
+                                "storage-backend-plan"
+                            )
+                            plan2.append(TerraformInitStep(tfhelper_storage))
+
                         # Skip if we've already processed this principal application
                         principal_app = backend_instance.principal_application
                         if principal_app in processed_principals:
                             LOG.debug(
-                                "Skipping %s: principal application %s is already"
-                                " processed",
-                                backend_name,
-                                principal_app,
+                                f"Skipping {backend_name}: principal application "
+                                f"{principal_app} already processed"
                             )
                             continue
 
@@ -290,9 +309,8 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                         )
                 except Exception as e:
                     LOG.warning(
-                        "Failed to add specific cinder-volume step for backend %s: %r",
-                        backend_name,
-                        e,
+                        f"Failed to add specific cinder-volume step for backend "
+                        f"{backend_name}: {e}"
                     )
 
             if len(plan2) > 1:  # More than just TerraformInitStep

--- a/sunbeam-python/sunbeam/features/telemetry/feature.py
+++ b/sunbeam-python/sunbeam/features/telemetry/feature.py
@@ -145,12 +145,6 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
             storage_manager = StorageBackendManager()
 
             plan3: list[BaseStep] = []
-            # PATCH: the storage-backend plan ("storage-backend-plan") is registered
-            # dynamically by StorageBackendBase.register_terraform_plan() and is NOT
-            # present in versions.TERRAFORM_DIR_NAMES, so it is not loaded by the
-            # deployment's static _load_tfhelpers(). It must be registered before it
-            # can be fetched. Defer fetching until inside the loop where we have a
-            # backend_instance to register with; register + init exactly once.
             tfhelper_storage = None
 
             # Track principal applications to avoid duplicates
@@ -177,8 +171,10 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                         principal_app = backend_instance.principal_application
                         if principal_app in processed_principals:
                             LOG.debug(
-                                f"Skipping {backend_name}: principal application "
-                                f"{principal_app} already processed"
+                                "Skipping %s: principal application %s "
+                                "already processed",
+                                backend_name,
+                                principal_app,
                             )
                             continue
 
@@ -200,8 +196,9 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                         )
                 except Exception as e:
                     LOG.warning(
-                        f"Failed to add specific cinder-volume step for backend "
-                        f"{backend_name}: {e}"
+                        "Failed to add specific cinder-volume step for backend %s: %s",
+                        backend_name,
+                        e,
                     )
 
             if len(plan3) > 1:  # More than just TerraformInitStep
@@ -285,8 +282,10 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                         principal_app = backend_instance.principal_application
                         if principal_app in processed_principals:
                             LOG.debug(
-                                f"Skipping {backend_name}: principal application "
-                                f"{principal_app} already processed"
+                                "Skipping %s: principal application %s "
+                                "already processed",
+                                backend_name,
+                                principal_app,
                             )
                             continue
 
@@ -309,8 +308,9 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
                         )
                 except Exception as e:
                     LOG.warning(
-                        f"Failed to add specific cinder-volume step for backend "
-                        f"{backend_name}: {e}"
+                        "Failed to add specific cinder-volume step for backend %s: %s",
+                        backend_name,
+                        e,
                     )
 
             if len(plan2) > 1:  # More than just TerraformInitStep

--- a/sunbeam-python/tests/unit/sunbeam/features/test_telemetry.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_telemetry.py
@@ -101,7 +101,7 @@ class TestTelemetryFeatureDeduplication:
             "openstack-plan": tfhelper_openstack,
             "hypervisor-plan": tfhelper_hypervisor,
             "cinder-volume-plan": tfhelper_cinder_volume,
-            "storage-plan": tfhelper_storage,
+            "storage-backend-plan": tfhelper_storage,
         }[plan]
 
         # Create feature and run enable plans
@@ -113,6 +113,18 @@ class TestTelemetryFeatureDeduplication:
         # (once for cinder-volume-noha, once for cinder-volume)
         # NOT three times (which would be without deduplication)
         assert mock_deploy_step_class.call_count == 2
+
+        # Verify the storage-backend plan was registered before being fetched.
+        # The plan is registered dynamically by the backend instance (it is not in
+        # versions.TERRAFORM_DIR_NAMES), so register_terraform_plan must run first.
+        registering_instances = [
+            inst
+            for inst in mock_backend_instances.values()
+            if inst.register_terraform_plan.called
+        ]
+        assert len(registering_instances) >= 1
+        for inst in registering_instances:
+            inst.register_terraform_plan.assert_called_with(deployment)
 
         # Verify the principals that were processed
         principals_processed = set()
@@ -160,7 +172,7 @@ class TestTelemetryFeatureDeduplication:
             "openstack-plan": tfhelper_openstack,
             "hypervisor-plan": tfhelper_hypervisor,
             "cinder-volume-plan": tfhelper_cinder_volume,
-            "storage-plan": tfhelper_storage,
+            "storage-backend-plan": tfhelper_storage,
         }[plan]
 
         # Create feature and run disable plans
@@ -171,6 +183,16 @@ class TestTelemetryFeatureDeduplication:
         # Verify DeploySpecificCinderVolumeStep was called only twice
         # (once for cinder-volume-noha, once for cinder-volume)
         assert mock_deploy_step_class.call_count == 2
+
+        # Verify the storage-backend plan was registered before being fetched.
+        registering_instances = [
+            inst
+            for inst in mock_backend_instances.values()
+            if inst.register_terraform_plan.called
+        ]
+        assert len(registering_instances) >= 1
+        for inst in registering_instances:
+            inst.register_terraform_plan.assert_called_with(deployment)
 
         # Verify the principals that were processed
         principals_processed = set()
@@ -258,7 +280,7 @@ class TestTelemetryFeatureDeduplication:
             "openstack-plan": tfhelper_openstack,
             "hypervisor-plan": tfhelper_hypervisor,
             "cinder-volume-plan": tfhelper_cinder_volume,
-            "storage-plan": tfhelper_storage,
+            "storage-backend-plan": tfhelper_storage,
         }[plan]
 
         # Create feature and run enable plans
@@ -309,7 +331,7 @@ class TestTelemetryFeatureDeduplication:
             "openstack-plan": tfhelper_openstack,
             "hypervisor-plan": tfhelper_hypervisor,
             "cinder-volume-plan": tfhelper_cinder_volume,
-            "storage-plan": tfhelper_storage,
+            "storage-backend-plan": tfhelper_storage,
         }[plan]
 
         # Create feature and run disable plans


### PR DESCRIPTION
When attempting to enable cos observability after hitatchi storage is setup it cannot continue. gets error: ValueError: storage-plan not found in tfhelpers
WARNING An unexpected error has occurred.

If cos is enabled prior to adding hitachi things work fine.


These changes to feature.py correct issues where storage-plan does not exist with storage-backend-plan which is the sunbeam storage plan used for that step

#00441075