### PR TITLE
Fix Octavia k8s health monitor communications

### DIFF
--- a/sunbeam-python/sunbeam/features/loadbalancer/feature.py
+++ b/sunbeam-python/sunbeam/features/loadbalancer/feature.py
@@ -923,7 +923,7 @@ class DeployAmphoraInfraStep(BaseStep, JujuStepHelper):
             self.network_attachment_name,
             cfg.lb_mgmt_network_id,
             cfg.lb_mgmt_subnet_id,
-            cfg.lb_mgmt_secgroup_ids,
+            [cfg.lb_health_secgroup_id] if cfg.lb_health_secgroup_id else [],
         )
         try:
             self.update_status(context, "deploying Multus and OpenStack Port CNI")

--- a/sunbeam-python/tests/unit/sunbeam/features/test_loadbalancer.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_loadbalancer.py
@@ -683,6 +683,28 @@ class TestDeployAmphoraInfraStepRun:
         # NAD should embed the stored network and subnet IDs
         assert "net-uuid" in override["multus-network-attachment-definitions"]
         assert "subnet-uuid" in override["multus-network-attachment-definitions"]
+        assert (
+            '"security_group_ids": "health-sg-uuid"'
+            in override["multus-network-attachment-definitions"]
+        )
+        assert (
+            '"security_group_ids": "sg-uuid"'
+            not in override["multus-network-attachment-definitions"]
+        )
+
+    def test_nad_yaml_omits_security_group_when_health_group_empty(self):
+        """Empty health secgroup should render as an empty security group list."""
+        result, tfhelper, jhelper = self._run(
+            {**ALL_VARIABLES, _HEALTH_SECGROUP_KEY: ""}
+        )
+        assert result.result_type == ResultType.COMPLETED
+        override = tfhelper.update_tfvars_and_apply_tf.call_args.kwargs[
+            "override_tfvars"
+        ]
+        assert (
+            '"security_group_ids": ""'
+            in override["multus-network-attachment-definitions"]
+        )
 
     def test_terraform_exception_returns_failed(self):
         deployment = Mock()


### PR DESCRIPTION
Ensure we use the correct security group so that
amphora can communicate towards Octavia OVN ports
with the port 5555 in UDP, instead of security
group meant for Amphora with different rules.

Closes-Bug: #2156324
Co-authored-by: Hemanth Nakkina <hemanth.nakkina@canonical.com>