### PR TITLE
observability: map collector storage manifest

### DIFF
--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -1011,6 +1011,8 @@ class ObservabilityFeature(OpenStackControlPlaneFeature):
                         "channel": "opentelemetry-collector-channel",
                         "revision": "opentelemetry-collector-revision",
                         "config": "opentelemetry-collector-config",
+                        "storage": "opentelemetry-collector-storage",
+                        "storage-map": "opentelemetry-collector-storage-map",
                     }
                 }
             },

--- a/sunbeam-python/tests/unit/sunbeam/core/test_terraform.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_terraform.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+import yaml
 
 import sunbeam.core.deployment as deployment_mod
 import sunbeam.core.manifest as manifest_mod
@@ -65,6 +66,22 @@ core:
             tls-ca: dGVzdC1jYQ==
           traefik-rgw:
             tls-ca: dGVzdC1jYQ==
+"""
+
+test_manifest_with_observability_collector_storage = """
+features:
+  observability:
+    embedded:
+      software:
+        charms:
+          opentelemetry-collector-k8s:
+            storage:
+              persisted: 8G
+            storage-map:
+              opentelemetry-collector:
+                persisted: 8G
+              opentelemetry-collector-infra:
+                persisted: 16G
 """
 
 
@@ -786,6 +803,45 @@ class TestTerraformHelper:
             applied_tfvars = write_tfvars.call_args.args[0]
 
             assert "rabbitmq-storage" not in applied_tfvars
+
+    def test_manifest_observability_collector_storage_passed_to_tfvars(
+        self,
+        mocker,
+        snap,
+        tmp_path,
+    ):
+        """Test collector storage is passed from feature manifest to tfvars."""
+        mocker.patch.object(terraform_mod, "Snap", return_value=snap)
+        manifest = manifest_mod.Manifest.model_validate(
+            yaml.safe_load(test_manifest_with_observability_collector_storage)
+        )
+        tfhelper = TerraformHelper(
+            path=tmp_path,
+            plan="openstack-plan",
+            tfvar_map={
+                "charms": {
+                    "opentelemetry-collector-k8s": {
+                        "storage": "opentelemetry-collector-storage",
+                        "storage-map": "opentelemetry-collector-storage-map",
+                    }
+                }
+            },
+        )
+
+        with (
+            patch.object(tfhelper, "write_tfvars") as write_tfvars,
+            patch.object(tfhelper, "apply"),
+        ):
+            tfhelper.update_tfvars_and_apply_tf(Mock(), manifest)
+            applied_tfvars = write_tfvars.call_args.args[0]
+
+            assert applied_tfvars["opentelemetry-collector-storage"] == {
+                "persisted": "8G"
+            }
+            assert applied_tfvars["opentelemetry-collector-storage-map"] == {
+                "opentelemetry-collector": {"persisted": "8G"},
+                "opentelemetry-collector-infra": {"persisted": "16G"},
+            }
 
 
 class TestApplyTfvars:

--- a/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
@@ -818,6 +818,17 @@ class TestCosStorage:
 class TestObservabilityFeaturePostEnable:
     """Test the post_enable grant access logic."""
 
+    def test_manifest_tfvar_map_supports_collector_storage(self):
+        """OpenStack plan maps collector storage manifest fields to tfvars."""
+        feature = observability_feature.EmbeddedObservabilityFeature()
+
+        collector_map = feature.manifest_attributes_tfvar_map()[feature.tfplan][
+            "charms"
+        ]["opentelemetry-collector-k8s"]
+
+        assert collector_map["storage"] == "opentelemetry-collector-storage"
+        assert collector_map["storage-map"] == "opentelemetry-collector-storage-map"
+
     def test_post_enable_grants_access_to_all_nodes(
         self, deployment, update_config, run_plan_obs, juju_helper_obs
     ):


### PR DESCRIPTION
Allow opentelemetry-collector-k8s manifest storage settings to flow into the OpenStack Terraform plan variables added for collector storage.

The mapping supports both the common storage directive and the per-application storage-map override used by sunbeam-terraform.

Assisted-By: Codex (gpt-5)
Closes-Bug: #2156859

Requires:
- [x] https://github.com/canonical/sunbeam-terraform/pull/145