### PR TITLE
Increase default storage for amphora flavor

### DIFF
--- a/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-loadbalancer-setup/variables.tf
+++ b/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-loadbalancer-setup/variables.tf
@@ -78,7 +78,7 @@ variable "amphora-flavor-vcpus" {
 variable "amphora-flavor-disk" {
   description = "Disk size in GB for Amphora flavor"
   type        = number
-  default     = 2
+  default     = 8
 }
 
 # lb-mgmt-cidr is unused when auto-creating the network (IPv6 CIDR is


### PR DESCRIPTION
Increase from 2GB to 8GB so that generated Ubuntu
images from scripts can easily fit on it.
This matches the behaviour from Charmed Openstack.

Closes-Bug: #2156868