### PR TITLE
fix: ignore `property-docstring-starts-with-verb` (D421) lint rule

### DIFF
--- a/sunbeam-python/pyproject.toml
+++ b/sunbeam-python/pyproject.toml
@@ -821,6 +821,7 @@ extend-ignore = ["E203"]
     "D101", # Missing docstring in public class
     "D103", # Missing docstring in public function
     "D100", # Missing docstring in public module
+    "D421", # Property docstring should not start with a verb
     "N818", # Exception should be named with an Error suffix
 ]
 


### PR DESCRIPTION
This rule was added in the new ruff version 0.15.18 from https://github.com/astral-sh/ruff/pull/23775 and breaking the linting CIs.

We have previously ignored the D103 rules that is similar to this rule. In addition, Canonical's TiCS Pylint ruleset also ignores all of the D* rules.


(cherry picked from commit ed5a9be84f5d18c2f7d33a1e32553a588e13342e)