### PR TITLE
Use targeted terraform apply for mysql and vault refresh

### DIFF
--- a/.github/workflows/build-snap.yml
+++ b/.github/workflows/build-snap.yml
@@ -145,6 +145,8 @@ jobs:
 
           # cluster refresh
           sg snap_daemon "openstack.sunbeam cluster refresh k8s"
+          sg snap_daemon "openstack.sunbeam cluster refresh mysql"
+          sg snap_daemon "openstack.sunbeam cluster refresh vault"
           sg snap_daemon "openstack.sunbeam cluster refresh"
 
       - name: Collect logs

--- a/sunbeam-python/sunbeam/steps/mysql.py
+++ b/sunbeam-python/sunbeam/steps/mysql.py
@@ -26,6 +26,11 @@ from sunbeam.core.juju import (
 )
 from sunbeam.core.manifest import Manifest
 from sunbeam.core.openstack import OPENSTACK_MODEL
+from sunbeam.core.terraform import (
+    TerraformException,
+    TerraformHelper,
+    TerraformStateLockedException,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -33,6 +38,7 @@ UPGRADE_ALL_UNITS_TIMEOUT = 3600
 UPGRADE_HIGHEST_UNIT_TIMEOUT = 900
 MYSQL_UPGRADE_CONFIG_KEY = "mysql_k8s_upgrade_state"
 MYSQL_CHARM = "mysql-k8s"
+MYSQL_APP = "mysql"
 
 
 class MySQLUpgradeState(StrEnum):
@@ -561,3 +567,105 @@ class MySQLCharmUpgradeStep(BaseStep, JujuStepHelper):
             )
         except SunbeamException as exc:
             return Result(ResultType.FAILED, str(exc))
+
+
+class ReapplyMySQLTerraformPlanStep(BaseStep, JujuStepHelper):
+    """Reapply only MySQL-related components in the Terraform plan."""
+
+    _CONFIG = "TerraformVarsOpenstack"
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+    ):
+        super().__init__(
+            "Applying MySQL Terraform changes",
+            "Applying MySQL-specific Terraform changes",
+        )
+        self.deployment = deployment
+        self.client = client
+        self.tfhelper = tfhelper
+        self.jhelper = jhelper
+        self.manifest = manifest
+        self.model = OPENSTACK_MODEL
+
+    def _get_mysql_terraform_targets(self) -> list[str]:
+        """Get terraform targets for MySQL and mysql-router resources in state."""
+        targets = [
+            # MySQL module targets
+            "-target=module.single-mysql",
+            "-target=module.many-mysql",
+        ]
+
+        try:
+            # Use terraform state to target only resources that are part of the
+            # openstack plan and currently exist for this deployment.
+            state_resources = self.tfhelper.state_list()
+            LOG.debug("Found %s openstack-plan resources", len(state_resources))
+
+            for resource in state_resources:
+                if "mysql-router" not in resource:
+                    continue
+                if not (
+                    resource.startswith("juju_application.")
+                    or resource.startswith("juju_integration.")
+                    or ".juju_application." in resource
+                    or ".juju_integration." in resource
+                ):
+                    continue
+                targets.append(f"-target={resource}")
+        except Exception as e:
+            LOG.warning("Error getting applications for mysql-router targets: %s", e)
+            # Continue with basic targets even if we can't get all mysql-router apps
+
+        LOG.debug("MySQL terraform targets: %s", targets)
+        return targets
+
+    def run(self, context: StepContext) -> Result:
+        """Apply terraform with targets for MySQL components only."""
+        try:
+            self.update_status(context, "updating MySQL components")
+
+            # Build target list for mysql and all mysql-router instances
+            targets = self._get_mysql_terraform_targets()
+
+            # Apply terraform with targets
+            LOG.info("Applying terraform with %s MySQL-specific targets", len(targets))
+            self.tfhelper.update_tfvars_and_apply_tf(
+                self.client,
+                self.manifest,
+                tfvar_config=self._CONFIG,
+                tf_apply_extra_args=targets,
+                reporter=context.reporter,
+            )
+
+        except (TerraformException, TerraformStateLockedException) as e:
+            LOG.warning("Error updating MySQL components: %r", e)
+            return Result(ResultType.FAILED, str(e))
+
+        # Get mysql-related apps to wait for
+        mysql_apps = [MYSQL_APP]
+        try:
+            apps = self.jhelper.get_application_names(self.model)
+            mysql_apps.extend([app for app in apps if app.endswith("-mysql-router")])
+        except Exception as e:
+            LOG.warning("Error getting mysql-router apps to wait for: %s", e)
+
+        # Wait only for mysql and mysql-router applications
+        try:
+            self.update_status(context, "waiting for MySQL services to settle")
+            LOG.debug("Waiting for MySQL applications: %s", mysql_apps)
+            self.jhelper.wait_until_active(
+                model=self.model,
+                apps=mysql_apps,
+                timeout=1200,
+            )
+        except (JujuWaitException, TimeoutError) as e:
+            LOG.warning("Error waiting for MySQL applications: %r", e)
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -36,7 +36,7 @@ from sunbeam.steps.k8s import (
 )
 from sunbeam.steps.microceph import DeployMicrocephApplicationStep
 from sunbeam.steps.microovn import DeployMicroOVNApplicationStep
-from sunbeam.steps.mysql import MySQLCharmUpgradeStep
+from sunbeam.steps.mysql import MySQLCharmUpgradeStep, ReapplyMySQLTerraformPlanStep
 from sunbeam.steps.openstack import (
     OpenStackPatchLoadBalancerServicesIPPoolStep,
     OpenStackPatchLoadBalancerServicesIPStep,
@@ -607,13 +607,12 @@ class MySQLInChannelUpgradeCoordinator(UpgradeCoordinator):
                 self.reset_mysql_upgrade_state,
             ),
             TerraformInitStep(self.deployment.get_tfhelper("openstack-plan")),
-            ReapplyOpenStackTerraformPlanStep(
+            ReapplyMySQLTerraformPlanStep(
                 self.deployment,
                 self.client,
                 self.deployment.get_tfhelper("openstack-plan"),
                 self.jhelper,
                 self.manifest,
-                self.deployment.openstack_machines_model,
             ),
         ]
         return plan

--- a/sunbeam-python/sunbeam/steps/vault.py
+++ b/sunbeam-python/sunbeam/steps/vault.py
@@ -42,6 +42,34 @@ CHARM_BASE = "ubuntu@24.04"
 VAULT_UPGRADE_TIMEOUT = 600
 
 
+def _get_vault_terraform_targets(
+    tfhelper: TerraformHelper,
+) -> list[str]:
+    """Get terraform targets for Vault resources.
+
+    Uses terraform state to discover vault resources that actually
+    exist, so optional integrations are only targeted when present
+    in state.
+    """
+    targets: list[str] = []
+
+    try:
+        state_resources = tfhelper.state_list()
+        for resource in state_resources:
+            if not (
+                resource.startswith("juju_application.")
+                or resource.startswith("juju_integration.")
+            ):
+                continue
+            if "vault" in resource.lower():
+                targets.append(f"-target={resource}")
+    except Exception as e:
+        LOG.warning("Error discovering vault terraform targets: %s", e)
+
+    LOG.debug("Vault terraform targets: %s", targets)
+    return targets
+
+
 class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
     """Refresh the vault-k8s charm and unseal if running in dev mode."""
 
@@ -107,6 +135,10 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
         # the charm itself is already up-to-date.
         return Result(ResultType.COMPLETED)
 
+    def _get_vault_terraform_targets(self) -> list[str]:
+        """Get terraform targets for Vault resources."""
+        return _get_vault_terraform_targets(self.tfhelper)
+
     def run(self, context: StepContext) -> Result:
         """Run vault-k8s charm upgrade steps."""
         target_channel = self._decision.effective_channel
@@ -148,11 +180,16 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
                 context, "Updating terraform plan with new vault channel"
             )
             migrate_vault_config_in_db(self.client, self.tfvar_config, target_channel)
+
+            # Build target list for vault and its integrations
+            targets = self._get_vault_terraform_targets()
+
             self.tfhelper.update_tfvars_and_apply_tf(
                 self.client,
                 self.manifest,
                 tfvar_config=self.tfvar_config,
                 override_tfvars={"vault-channel": target_channel},
+                tf_apply_extra_args=targets,
             )
         except (TerraformException, TerraformStateLockedException) as e:
             return Result(
@@ -220,3 +257,70 @@ class VaultCharmUpgradeStep(BaseStep, JujuStepHelper):
                 "Run unseal and authorize steps manually.",
             )
         return Result(ResultType.COMPLETED, "Vault upgraded and auto-unsealed.")
+
+
+class ReapplyVaultTerraformPlanStep(BaseStep, JujuStepHelper):
+    """Reapply only Vault-related components in the Terraform plan."""
+
+    _CONFIG = OPENSTACK_TERRAFORM_VARS
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+    ):
+        super().__init__(
+            "Applying Vault Terraform changes",
+            "Applying Vault-specific Terraform changes",
+        )
+        self.application = "vault"
+        self.deployment = deployment
+        self.client = client
+        self.tfhelper = tfhelper
+        self.jhelper = jhelper
+        self.manifest = manifest
+        self.model = OPENSTACK_MODEL
+
+    def _get_vault_terraform_targets(self) -> list[str]:
+        """Get terraform targets for Vault resources."""
+        return _get_vault_terraform_targets(self.tfhelper)
+
+    def run(self, context: StepContext) -> Result:
+        """Apply terraform with targets for Vault components only."""
+        try:
+            self.update_status(context, "updating Vault components")
+
+            # Build target list for vault and its integrations
+            targets = self._get_vault_terraform_targets()
+
+            # Apply terraform with targets
+            LOG.info("Applying terraform with %s Vault-specific targets", len(targets))
+            self.tfhelper.update_tfvars_and_apply_tf(
+                self.client,
+                self.manifest,
+                tfvar_config=self._CONFIG,
+                tf_apply_extra_args=targets,
+                reporter=context.reporter,
+            )
+
+        except (TerraformException, TerraformStateLockedException) as e:
+            LOG.warning("Error updating Vault components: %r", e)
+            return Result(ResultType.FAILED, str(e))
+
+        # Wait only for vault application
+        try:
+            self.update_status(context, "waiting for Vault to settle")
+            LOG.debug("Waiting for Vault application")
+            self.jhelper.wait_until_active(
+                model=self.model,
+                apps=[self.application],
+                timeout=600,
+            )
+        except (JujuWaitException, TimeoutError) as e:
+            LOG.warning("Error waiting for Vault application: %r", e)
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_mysql.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_mysql.py
@@ -311,3 +311,155 @@ class TestMySQLCharmUpgradeStep:
             step.model, step.application, 2
         )
         assert step.state == MySQLUpgradeState.SCALED_BACK
+
+
+class TestReapplyMySQLTerraformPlanStep:
+    def test_get_mysql_terraform_targets(
+        self, basic_deployment, basic_client, basic_jhelper, basic_manifest
+    ):
+        """Test generation of MySQL-specific terraform targets."""
+        from sunbeam.steps.mysql import ReapplyMySQLTerraformPlanStep
+
+        tfhelper = Mock()
+        step = ReapplyMySQLTerraformPlanStep(
+            basic_deployment, basic_client, tfhelper, basic_jhelper, basic_manifest
+        )
+
+        # Mock get_application_names to return some mysql-router apps
+        basic_jhelper.get_application_names.return_value = [
+            "mysql-k8s",
+            "keystone",
+            "keystone-mysql-router",
+            "nova-api",
+            "nova-api-mysql-router",
+            "glance",
+            "glance-mysql-router",
+            "manila-data-mysql-router",
+        ]
+        tfhelper.state_list.return_value = [
+            "module.keystone[0].juju_application.mysql-router",
+            "module.keystone[0].juju_integration.mysql-router-to-mysql",
+            "module.keystone[0].juju_integration.service-to-mysql-router",
+            "module.nova[0].juju_application.nova-api-mysql-router[0]",
+            "module.nova[0].juju_integration.nova-api-to-mysql-router[0]",
+            "module.nova[0].juju_integration.nova-api-mysql-router-to-metrics-endpoint[0]",
+            "module.glance[0].juju_application.mysql-router",
+            "module.glance[0].juju_integration.mysql-router-to-mysql",
+        ]
+
+        targets = step._get_mysql_terraform_targets()
+
+        # Check that basic mysql targets are included
+        assert "-target=module.single-mysql" in targets
+        assert "-target=module.many-mysql" in targets
+
+        # Check that only mysql-router resources that exist in state are targeted.
+        assert "-target=module.keystone[0].juju_application.mysql-router" in targets
+        assert (
+            "-target=module.keystone[0].juju_integration.mysql-router-to-mysql"
+            in targets
+        )
+        assert (
+            "-target=module.nova[0].juju_application.nova-api-mysql-router[0]"
+            in targets
+        )
+        assert (
+            "-target=module.nova[0].juju_integration.nova-api-mysql-router-to-metrics-endpoint[0]"
+            in targets
+        )
+        assert (
+            "-target=module.manila-data[0].juju_application.mysql-router" not in targets
+        )
+
+    def test_run_success(
+        self, basic_deployment, basic_client, basic_jhelper, basic_manifest
+    ):
+        """Test successful MySQL terraform apply with targets."""
+        from sunbeam.steps.mysql import ReapplyMySQLTerraformPlanStep
+
+        tfhelper = Mock()
+        step = ReapplyMySQLTerraformPlanStep(
+            basic_deployment, basic_client, tfhelper, basic_jhelper, basic_manifest
+        )
+
+        # Mock get_application_names
+        basic_jhelper.get_application_names.return_value = [
+            "mysql-k8s",
+            "keystone-mysql-router",
+        ]
+        tfhelper.state_list.return_value = [
+            "module.keystone[0].juju_application.mysql-router",
+            "module.keystone[0].juju_integration.mysql-router-to-mysql",
+        ]
+
+        # Mock wait_until_active
+        basic_jhelper.wait_until_active.return_value = None
+
+        context = Mock()
+        context.reporter = Mock()
+        result = step.run(context)
+
+        # Check that terraform was applied with targets
+        tfhelper.update_tfvars_and_apply_tf.assert_called_once()
+        call_args = tfhelper.update_tfvars_and_apply_tf.call_args
+        assert call_args.kwargs["tf_apply_extra_args"] is not None
+        assert (
+            len(call_args.kwargs["tf_apply_extra_args"]) > 2
+        )  # More than just base targets
+
+        # Check that we waited for the right applications
+        basic_jhelper.wait_until_active.assert_called_once()
+        call_args = basic_jhelper.wait_until_active.call_args
+        assert call_args.kwargs["apps"] == ["mysql", "keystone-mysql-router"]
+
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_terraform_failure(
+        self, basic_deployment, basic_client, basic_jhelper, basic_manifest
+    ):
+        """Test MySQL terraform apply failure."""
+        from sunbeam.core.terraform import TerraformException
+        from sunbeam.steps.mysql import ReapplyMySQLTerraformPlanStep
+
+        tfhelper = Mock()
+        step = ReapplyMySQLTerraformPlanStep(
+            basic_deployment, basic_client, tfhelper, basic_jhelper, basic_manifest
+        )
+
+        # Mock terraform failure
+        tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
+            "Terraform apply failed"
+        )
+
+        context = Mock()
+        context.reporter = Mock()
+        result = step.run(context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "Terraform apply failed" in result.message
+
+    def test_run_wait_timeout(
+        self, basic_deployment, basic_client, basic_jhelper, basic_manifest
+    ):
+        """Test MySQL terraform apply with wait timeout."""
+        from sunbeam.core.juju import JujuWaitException
+        from sunbeam.steps.mysql import ReapplyMySQLTerraformPlanStep
+
+        tfhelper = Mock()
+        step = ReapplyMySQLTerraformPlanStep(
+            basic_deployment, basic_client, tfhelper, basic_jhelper, basic_manifest
+        )
+
+        # Mock successful terraform but timeout on wait
+        basic_jhelper.get_application_names.return_value = ["mysql-k8s"]
+        tfhelper.state_list.return_value = []
+        basic_jhelper.wait_until_active.side_effect = JujuWaitException(
+            "Timeout waiting"
+        )
+
+        context = Mock()
+        context.reporter = Mock()
+        result = step.run(context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "Timeout waiting" in result.message

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_vault_upgrade.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_vault_upgrade.py
@@ -39,7 +39,7 @@ def mock_auto_unseal():
 
 
 @pytest.fixture
-def step(basic_deployment, basic_client, basic_manifest, basic_jhelper, basic_tfhelper):
+def step(basic_deployment, basic_client, basic_manifest, basic_jhelper, basic_tfhelper):  # noqa: C901
     return VaultCharmUpgradeStep(
         basic_deployment, basic_client, basic_manifest, basic_jhelper, basic_tfhelper
     )
@@ -387,6 +387,53 @@ class TestVaultCharmUpgradeStep:
             step.client, step.tfvar_config, VAULT_CHANNEL
         )
 
+    def test_terraform_with_targets(
+        self,
+        step,
+        basic_jhelper,
+        basic_tfhelper,
+        step_context,
+        basic_client,
+        mock_migrate,
+        vaulthelper,
+        mock_auto_unseal,
+    ):
+        """Test that terraform is applied with vault-specific targets."""
+        # Setup check_charm_needs_refresh to proceed with upgrade
+        with patch("sunbeam.steps.vault.check_charm_needs_refresh") as mock_check:
+            mock_check.return_value = CharmRefreshDecision(
+                result=Result(ResultType.COMPLETED),
+                effective_channel="2.1/stable",
+            )
+            step.is_skip(step_context)
+
+            # Mock vault as sealed
+            vaulthelper.get_vault_status.return_value = {"sealed": True}
+
+            # Mock terraform state to return vault resources
+            basic_tfhelper.state_list.return_value = [
+                "juju_application.vault",
+                "juju_integration.vault-to-ca",
+                "juju_integration.barbican-to-vault",
+                "juju_application.certificate-authority",
+            ]
+
+            # Execute
+            result = step.run(step_context)
+
+            # Verify terraform was called with targets
+            basic_tfhelper.update_tfvars_and_apply_tf.assert_called()
+            call_args = basic_tfhelper.update_tfvars_and_apply_tf.call_args
+
+            # Check that targets were provided
+            assert "tf_apply_extra_args" in call_args.kwargs
+            targets = call_args.kwargs["tf_apply_extra_args"]
+            assert "-target=juju_application.vault" in targets
+            assert "-target=juju_integration.vault-to-ca" in targets
+            assert "-target=juju_integration.barbican-to-vault" in targets
+
+            assert result.result_type == ResultType.COMPLETED
+
     def test_run_calls_migrate_with_manifest_channel(
         self,
         step,
@@ -413,3 +460,86 @@ class TestVaultCharmUpgradeStep:
         mock_migrate.assert_called_once_with(
             step.client, step.tfvar_config, "1.19/stable"
         )
+
+
+class TestReapplyVaultTerraformPlanStep:
+    VAULT_STATE_RESOURCES = [
+        "juju_application.vault-k8s",
+        "juju_integration.vault-to-ca",
+        "juju_integration.barbican-to-vault",
+    ]
+
+    def test_get_vault_terraform_targets(
+        self, basic_deployment, basic_client, basic_jhelper, basic_manifest
+    ):
+        """Test generation of Vault-specific terraform targets."""
+        from sunbeam.steps.vault import ReapplyVaultTerraformPlanStep
+
+        tfhelper = Mock()
+        tfhelper.state_list.return_value = self.VAULT_STATE_RESOURCES
+        step = ReapplyVaultTerraformPlanStep(
+            basic_deployment, basic_client, tfhelper, basic_jhelper, basic_manifest
+        )
+
+        targets = step._get_vault_terraform_targets()
+
+        # Check that vault targets are included
+        assert "-target=juju_application.vault-k8s" in targets
+        assert "-target=juju_integration.vault-to-ca" in targets
+        assert "-target=juju_integration.barbican-to-vault" in targets
+
+    def test_run_success(
+        self, basic_deployment, basic_client, basic_jhelper, basic_manifest
+    ):
+        """Test successful Vault terraform apply with targets."""
+        from sunbeam.steps.vault import ReapplyVaultTerraformPlanStep
+
+        tfhelper = Mock()
+        tfhelper.state_list.return_value = self.VAULT_STATE_RESOURCES
+        step = ReapplyVaultTerraformPlanStep(
+            basic_deployment, basic_client, tfhelper, basic_jhelper, basic_manifest
+        )
+
+        # Mock wait_until_active
+        basic_jhelper.wait_until_active.return_value = None
+
+        context = Mock()
+        context.reporter = Mock()
+        result = step.run(context)
+
+        # Check that terraform was applied with targets
+        tfhelper.update_tfvars_and_apply_tf.assert_called_once()
+        call_args = tfhelper.update_tfvars_and_apply_tf.call_args
+        assert call_args.kwargs["tf_apply_extra_args"] is not None
+        assert len(call_args.kwargs["tf_apply_extra_args"]) >= 3  # All vault targets
+
+        # Check that we waited for vault
+        basic_jhelper.wait_until_active.assert_called_once()
+        call_args = basic_jhelper.wait_until_active.call_args
+        assert call_args.kwargs["apps"] == ["vault"]
+
+        assert result.result_type == ResultType.COMPLETED
+
+    def test_run_terraform_failure(
+        self, basic_deployment, basic_client, basic_jhelper, basic_manifest
+    ):
+        """Test Vault terraform apply failure."""
+        from sunbeam.core.terraform import TerraformException
+        from sunbeam.steps.vault import ReapplyVaultTerraformPlanStep
+
+        tfhelper = Mock()
+        step = ReapplyVaultTerraformPlanStep(
+            basic_deployment, basic_client, tfhelper, basic_jhelper, basic_manifest
+        )
+
+        # Mock terraform failure
+        tfhelper.update_tfvars_and_apply_tf.side_effect = TerraformException(
+            "Terraform apply failed"
+        )
+
+        context = Mock()
+        context.reporter = Mock()
+        result = step.run(context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "Terraform apply failed" in result.message


### PR DESCRIPTION
During mysql and vault refresh commands, use terraform -target option to only update the specific components instead of applying the entire openstack terraform plan.

For mysql refresh:
- Target module.single-mysql and module.many-mysql
- Target all *-mysql-router applications and their integrations
- Dynamically discover mysql-router instances from deployed apps

For vault refresh:
- Target module.vault and vault-related integrations
- Target certificate-authority resources that vault depends on

This approach avoids terraform errors when new relations are added in newer releases (like the octavia:amqp to rabbitmq:amqp relation issue in bug 2157052).

Fixes: https://bugs.launchpad.net/snap-openstack/+bug/2157052