### PR TITLE
Fix MAAS DPU deploy status

### DIFF
--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -1692,7 +1692,12 @@ class MaasDeployMachinesStep(BaseStep):
             deployed_any = True
             self._add_nodes_to_juju(context, batch)
             self._sync_updated_node_machine_ids()
-            self.update_status(context, f"waiting for {batch_label} machines to deploy")
+            wait_message = "waiting for machines to deploy"
+            timeout_message = "Timeout waiting for machines to deploy."
+            if batch_label == "DPU":
+                wait_message = "waiting for DPU machines to deploy"
+                timeout_message = "Timeout waiting for DPU machines to deploy."
+            self.update_status(context, wait_message)
             try:
                 self.jhelper.wait_all_machines_deployed(
                     self.model, MACHINE_DEPLOY_TIMEOUT
@@ -1705,7 +1710,7 @@ class MaasDeployMachinesStep(BaseStep):
                 )
                 return Result(
                     ResultType.FAILED,
-                    f"Timeout waiting for {batch_label} machines to deploy.",
+                    timeout_message,
                 )
 
         if not deployed_any:


### PR DESCRIPTION
- Fix 'Deploying machines in Juju ... waiting for non-DPU machines to deploy' to not mention non-DPU. Reverting to previous default message

[OPEN-4638](https://warthogs.atlassian.net/browse/OPEN-4638)

[OPEN-4638]: https://warthogs.atlassian.net/browse/OPEN-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ