### PR TITLE
microovn: deploy role distributor

### DIFF
--- a/cloud/etc/deploy-microovn/main.tf
+++ b/cloud/etc/deploy-microovn/main.tf
@@ -145,6 +145,21 @@ resource "juju_integration" "microovn-openstack-network-agents" {
   }
 }
 
+resource "juju_integration" "role-distributor-microovn" {
+  count      = var.role_distributor_application_name != null ? 1 : 0
+  model_uuid = data.juju_model.machine_model.uuid
+
+  application {
+    name     = var.role_distributor_application_name
+    endpoint = "role-assignment"
+  }
+
+  application {
+    name     = juju_application.microovn.name
+    endpoint = "role-assignment"
+  }
+}
+
 resource "juju_integration" "microovn-to-ovn-proxy" {
   count      = length(juju_application.sunbeam-ovn-proxy.*.name) > 0 ? 1 : 0
   model_uuid = data.juju_model.machine_model.uuid

--- a/cloud/etc/deploy-microovn/variables.tf
+++ b/cloud/etc/deploy-microovn/variables.tf
@@ -93,6 +93,12 @@ variable "token_distributor_machine_ids" {
   default     = []
 }
 
+variable "role_distributor_application_name" {
+  description = "Role distributor application name"
+  type        = string
+  default     = null
+}
+
 variable "machine_model_uuid" {
   description = "UUID of Juju model to use for deployment"
   type        = string

--- a/cloud/etc/deploy-role-distributor/main.tf
+++ b/cloud/etc/deploy-role-distributor/main.tf
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+terraform {
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "= 1.3.1"
+    }
+  }
+}
+
+provider "juju" {}
+
+data "juju_model" "machine_model" {
+  uuid = var.machine_model_uuid
+}
+
+resource "juju_application" "role-distributor" {
+  name       = "role-distributor"
+  model_uuid = data.juju_model.machine_model.uuid
+  machines   = length(var.role_distributor_machine_ids) == 0 ? null : toset(var.role_distributor_machine_ids)
+  units      = length(var.role_distributor_machine_ids) == 0 ? 1 : null
+
+  charm {
+    name     = "role-distributor"
+    channel  = var.charm_role_distributor_channel
+    base     = "ubuntu@24.04"
+    revision = var.charm_role_distributor_revision
+  }
+
+  config = var.charm_role_distributor_config
+}
+
+output "role-distributor-application-name" {
+  value = juju_application.role-distributor.name
+}

--- a/cloud/etc/deploy-role-distributor/variables.tf
+++ b/cloud/etc/deploy-role-distributor/variables.tf
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+variable "charm_role_distributor_channel" {
+  description = "Operator channel for role-distributor deployment"
+  type        = string
+  default     = "latest/stable"
+}
+
+variable "charm_role_distributor_revision" {
+  description = "Operator channel revision for role-distributor deployment"
+  type        = number
+  default     = null
+}
+
+variable "charm_role_distributor_config" {
+  description = "Operator config for role-distributor deployment"
+  type        = map(string)
+  default     = {}
+}
+
+variable "role_distributor_machine_ids" {
+  description = "List of machine ids to include"
+  type        = list(string)
+  default     = []
+}
+
+variable "machine_ids" {
+  description = "Compatibility variable ignored by this plan"
+  type        = list(string)
+  default     = []
+}
+
+variable "machine_model_uuid" {
+  description = "UUID of Juju model to use for deployment"
+  type        = string
+}

--- a/manifests/2024.1/beta.yml
+++ b/manifests/2024.1/beta.yml
@@ -51,6 +51,8 @@ core:
           snap-channel: 2024.1/beta
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2024.1/beta
 features:

--- a/manifests/2024.1/candidate.yml
+++ b/manifests/2024.1/candidate.yml
@@ -51,6 +51,8 @@ core:
           snap-channel: 2024.1/candidate
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2024.1/candidate
 features:

--- a/manifests/2024.1/edge.yml
+++ b/manifests/2024.1/edge.yml
@@ -51,6 +51,8 @@ core:
           snap-channel: 2024.1/edge
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2024.1/edge
 features:

--- a/manifests/2024.1/stable.yml
+++ b/manifests/2024.1/stable.yml
@@ -51,6 +51,8 @@ core:
           snap-channel: 2024.1/stable
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2024.1/stable
 features:

--- a/manifests/2025.1/beta.yml
+++ b/manifests/2025.1/beta.yml
@@ -47,6 +47,8 @@ core:
           snap-channel: 2025.1/beta
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2025.1/beta
 features:

--- a/manifests/2025.1/candidate.yml
+++ b/manifests/2025.1/candidate.yml
@@ -47,6 +47,8 @@ core:
           snap-channel: 2025.1/candidate
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2025.1/candidate
 features:

--- a/manifests/2025.1/edge.yml
+++ b/manifests/2025.1/edge.yml
@@ -49,6 +49,8 @@ core:
           snap-channel: 2025.1/edge
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2025.1/edge
 features:

--- a/manifests/2025.1/stable.yml
+++ b/manifests/2025.1/stable.yml
@@ -49,6 +49,8 @@ core:
           snap-channel: 2025.1/stable
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2025.1/stable
 features:

--- a/manifests/2026.1/beta.yml
+++ b/manifests/2026.1/beta.yml
@@ -47,6 +47,8 @@ core:
           snap-channel: 2026.1/beta
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2026.1/beta
 features:

--- a/manifests/2026.1/candidate.yml
+++ b/manifests/2026.1/candidate.yml
@@ -47,6 +47,8 @@ core:
           snap-channel: 2026.1/candidate
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2026.1/candidate
 features:

--- a/manifests/2026.1/edge.yml
+++ b/manifests/2026.1/edge.yml
@@ -49,6 +49,8 @@ core:
           snap-channel: 2026.1/edge
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2026.1/edge
 features:

--- a/manifests/2026.1/stable.yml
+++ b/manifests/2026.1/stable.yml
@@ -49,6 +49,8 @@ core:
           snap-channel: 2026.1/stable
       microcluster-token-distributor:
         channel: latest/edge
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
         channel: 2026.1/stable
 features:

--- a/sunbeam-python/sunbeam/core/role_assignments.py
+++ b/sunbeam-python/sunbeam/core/role_assignments.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import yaml
+
+from sunbeam.clusterd.client import Client
+
+MICROOVN_APPLICATION = "microovn"
+
+
+RoleMapping = dict[str, dict[str, dict[str, dict[str, dict[str, list[str]]]]]]
+
+
+def build_microovn_role_mapping(
+    client: Client,
+    model_name: str,
+    split_roles: bool,
+    machine_ids: Iterable[str],
+    *,
+    assign_central_roles: bool,
+) -> RoleMapping:
+    """Build the role-distributor mapping for MicroOVN."""
+    machine_roles: dict[str, list[str]] = {}
+    microovn_machine_ids = {str(machine_id) for machine_id in machine_ids}
+
+    for role in ("control", "compute", "network"):
+        for node in client.cluster.list_nodes_by_role(role):
+            machine_id = node.get("machineid")
+            if machine_id in (-1, None):
+                continue
+            machine_id_str = str(machine_id)
+            if machine_id_str not in microovn_machine_ids:
+                continue
+            node_roles = set(node.get("role", []))
+            machine_roles[machine_id_str] = _microovn_roles_for_node(
+                node_roles,
+                split_roles,
+                assign_central_roles,
+            )
+
+    return _build_mapping(
+        model_name,
+        MICROOVN_APPLICATION,
+        machine_roles,
+    )
+
+
+def dump_role_mapping(mapping: RoleMapping) -> str:
+    """Serialize role-distributor mapping to stable YAML."""
+    return yaml.safe_dump(mapping, sort_keys=True)
+
+
+def _build_mapping(
+    model_name: str,
+    application_name: str,
+    machine_roles: dict[str, list[str]],
+) -> RoleMapping:
+    return {
+        model_name: {
+            application_name: {
+                "machines": {
+                    machine_id: {"roles": roles}
+                    for machine_id, roles in sorted(machine_roles.items())
+                }
+            }
+        }
+    }
+
+
+def _microovn_roles_for_node(
+    node_roles: Iterable[str],
+    split_roles: bool,
+    assign_central_roles: bool,
+) -> list[str]:
+    role_set = set(node_roles)
+    roles = ["chassis"]
+
+    if assign_central_roles and "control" in role_set:
+        roles.append("central")
+    if "network" in role_set or ("compute" in role_set and not split_roles):
+        roles.append("gateway")
+
+    return roles

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -189,6 +189,11 @@ from sunbeam.steps.openstack import (
     PromptRegionStep,
     ReapplyOpenStackTerraformPlanStep,
 )
+from sunbeam.steps.role_distributor import (
+    DeployRoleDistributorApplicationStep,
+    ReapplyRoleDistributorApplicationStep,
+    RemoveRoleDistributorUnitsStep,
+)
 from sunbeam.steps.sso import (
     DeployIdentityProvidersStep,
     SetKeystoneSAMLCertAndKeyStep,
@@ -834,6 +839,18 @@ def bootstrap(  # noqa: C901
     microovn_tfhelper = deployment.get_tfhelper("microovn-plan")
     microovn_necessary = ovn_manager.is_microovn_necessary(roles)
     if microovn_necessary:
+        role_distributor_tfhelper = deployment.get_tfhelper("role-distributor-plan")
+        plan1.append(TerraformInitStep(role_distributor_tfhelper))
+        plan1.append(
+            DeployRoleDistributorApplicationStep(
+                deployment,
+                client,
+                role_distributor_tfhelper,
+                jhelper,
+                manifest,
+                deployment.openstack_machines_model,
+            )
+        )
         plan1.append(TerraformInitStep(microovn_tfhelper))
         plan1.append(
             DeployMicroOVNApplicationStep(
@@ -1585,6 +1602,18 @@ def join(  # noqa: C901
     plan4.append(TerraformInitStep(cinder_volume_tfhelper))
     if microovn_necessary:
         microovn_tfhelper = deployment.get_tfhelper("microovn-plan")
+        role_distributor_tfhelper = deployment.get_tfhelper("role-distributor-plan")
+        plan4.append(TerraformInitStep(role_distributor_tfhelper))
+        plan4.append(
+            DeployRoleDistributorApplicationStep(
+                deployment,
+                client,
+                role_distributor_tfhelper,
+                jhelper,
+                manifest,
+                deployment.openstack_machines_model,
+            )
+        )
         plan4.append(TerraformInitStep(microovn_tfhelper))
         plan4.append(
             DeployMicroOVNApplicationStep(
@@ -1862,6 +1891,7 @@ def remove(ctx: click.Context, name: str, force: bool, show_hints: bool) -> None
     deployment: LocalDeployment = ctx.obj
     client = deployment.get_client()
     jhelper = JujuHelper(deployment.juju_controller)
+    microovn_machine_ids = deployment.get_ovn_manager().get_machines()
 
     preflight_checks = [DaemonGroupCheck(), JujuLoginCheck(deployment.juju_account)]
     run_preflight_checks(preflight_checks, console)
@@ -1968,6 +1998,31 @@ def remove(ctx: click.Context, name: str, force: bool, show_hints: bool) -> None
             ClusterRemoveNodeStep(client, name),
         ]
     )
+    if microovn_machine_ids:
+        manifest = deployment.get_manifest()
+        role_distributor_tfhelper = deployment.get_tfhelper("role-distributor-plan")
+        remove_k8s_unit_index = next(
+            i for i, step in enumerate(plan) if isinstance(step, CordonK8SUnitStep)
+        )
+        plan.insert(
+            remove_k8s_unit_index,
+            RemoveRoleDistributorUnitsStep(
+                client, name, jhelper, deployment.openstack_machines_model
+            ),
+        )
+        plan.extend(
+            [
+                TerraformInitStep(role_distributor_tfhelper),
+                ReapplyRoleDistributorApplicationStep(
+                    deployment,
+                    client,
+                    role_distributor_tfhelper,
+                    jhelper,
+                    manifest,
+                    deployment.openstack_machines_model,
+                ),
+            ]
+        )
 
     run_plan(plan, console, show_hints)
     click.echo(f"Removed node {name} from the cluster")
@@ -2112,7 +2167,19 @@ def configure_cmd(
             or (split_roles_enabled() and "control" in node["role"])
         )
     ):
+        role_distributor_tfhelper = deployment.get_tfhelper("role-distributor-plan")
         microovn_tfhelper = deployment.get_tfhelper("microovn-plan")
+        plan.append(TerraformInitStep(role_distributor_tfhelper))
+        plan.append(
+            DeployRoleDistributorApplicationStep(
+                deployment,
+                client,
+                role_distributor_tfhelper,
+                jhelper,
+                manifest,
+                deployment.openstack_machines_model,
+            )
+        )
         plan.append(
             LocalSetOpenStackNetworkAgentsStep(
                 client,

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -193,6 +193,11 @@ from sunbeam.steps.openstack import (
     PromptRegionStep,
     ReapplyOpenStackTerraformPlanStep,
 )
+from sunbeam.steps.role_distributor import (
+    DeployRoleDistributorApplicationStep,
+    ReapplyRoleDistributorApplicationStep,
+    RemoveRoleDistributorUnitsStep,
+)
 from sunbeam.steps.sso import (
     DeployIdentityProvidersStep,
     SetKeystoneSAMLCertAndKeyStep,
@@ -637,6 +642,7 @@ def deploy(
     tfhelper_cinder_volume = deployment.get_tfhelper("cinder-volume-plan")
     tfhelper_openstack_deploy = deployment.get_tfhelper("openstack-plan")
     tfhelper_hypervisor_deploy = deployment.get_tfhelper("hypervisor-plan")
+    tfhelper_role_distributor = deployment.get_tfhelper("role-distributor-plan")
     tfhelper_microovn = deployment.get_tfhelper("microovn-plan")
 
     ovn_manager = deployment.get_ovn_manager()
@@ -836,6 +842,17 @@ def deploy(
         nb_network, nb_compute, nb_control
     )
     if microovn_necessary:
+        plan2.append(TerraformInitStep(tfhelper_role_distributor))
+        plan2.append(
+            DeployRoleDistributorApplicationStep(
+                deployment,
+                client,
+                tfhelper_role_distributor,
+                jhelper,
+                manifest,
+                deployment.openstack_machines_model,
+            )
+        )
         plan2.append(TerraformInitStep(tfhelper_microovn))
         plan2.append(
             DeployMicroOVNApplicationStep(
@@ -1658,6 +1675,7 @@ def remove_node(ctx: click.Context, name: str, force: bool, show_hints: bool) ->
     deployment: MaasDeployment = ctx.obj
     client = deployment.get_client()
     jhelper = JujuHelper(deployment.juju_controller)
+    microovn_machine_ids = deployment.get_ovn_manager().get_machines()
 
     preflight_checks = [
         LocalShareCheck(),
@@ -1769,6 +1787,32 @@ def remove_node(ctx: click.Context, name: str, force: bool, show_hints: bool) ->
         MaasRemoveMachineFromClusterdStep(client, name),
         SetCephMgrPoolSizeStep(client, jhelper, deployment.openstack_machines_model),
     ]
+    if microovn_machine_ids:
+        manifest = deployment.get_manifest()
+        role_distributor_tfhelper = deployment.get_tfhelper("role-distributor-plan")
+        cordon_k8s_unit_index = next(
+            i for i, step in enumerate(plan) if isinstance(step, CordonK8SUnitStep)
+        )
+        plan.insert(
+            cordon_k8s_unit_index,
+            RemoveRoleDistributorUnitsStep(
+                client, name, jhelper, deployment.openstack_machines_model
+            ),
+        )
+        ceph_pool_size_index = next(
+            i for i, step in enumerate(plan) if isinstance(step, SetCephMgrPoolSizeStep)
+        )
+        plan[ceph_pool_size_index:ceph_pool_size_index] = [
+            TerraformInitStep(role_distributor_tfhelper),
+            ReapplyRoleDistributorApplicationStep(
+                deployment,
+                client,
+                role_distributor_tfhelper,
+                jhelper,
+                manifest,
+                deployment.openstack_machines_model,
+            ),
+        ]
 
     run_plan(plan, console, show_hints)
     click.echo(

--- a/sunbeam-python/sunbeam/steps/microovn.py
+++ b/sunbeam-python/sunbeam/steps/microovn.py
@@ -43,6 +43,16 @@ APPLICATION = "microovn"
 MICROOVN_APP_TIMEOUT = 1200
 MICROOVN_UNIT_TIMEOUT = 1200
 AGENT_APP = "openstack-network-agents"
+ROLE_DISTRIBUTOR_APP = "role-distributor"
+
+
+def _role_distributor_application_name(jhelper: JujuHelper, model: str) -> str | None:
+    """Return role-distributor application name when deployed."""
+    try:
+        jhelper.get_application(ROLE_DISTRIBUTOR_APP, model)
+    except ApplicationNotFoundException:
+        return None
+    return ROLE_DISTRIBUTOR_APP
 
 
 class DeployMicroOVNApplicationStep(DeployMachineApplicationStep):
@@ -119,6 +129,9 @@ class DeployMicroOVNApplicationStep(DeployMachineApplicationStep):
                 "charm_openstack_network_agents_config": {
                     "snap-channel": versions.OPENSTACK_CHANNEL
                 },
+                "role_distributor_application_name": (
+                    _role_distributor_application_name(self.jhelper, self.model)
+                ),
                 "openstack_network_agents_endpoint_bindings": [
                     {"space": self.deployment.get_space(Networks.MANAGEMENT)},
                     {
@@ -145,12 +158,15 @@ class ReapplyMicroOVNOptionalIntegrationsStep(DeployMicroOVNApplicationStep):
 
     def tf_apply_extra_args(self) -> list[str]:
         """Extra args for terraform apply to reapply only optional CMR integrations."""
-        return [
+        extra_args = [
             "-target=juju_integration.microovn-microcluster-token-distributor",
             "-target=juju_integration.microovn-certs",
             "-target=juju_integration.microovn-ovsdb-cms",
             "-target=juju_integration.microovn-openstack-network-agents",
         ]
+        if _role_distributor_application_name(self.jhelper, self.model):
+            extra_args.append("-target=juju_integration.role-distributor-microovn")
+        return extra_args
 
 
 class ReapplyMicroOVNTerraformPlanStep(BaseStep):

--- a/sunbeam-python/sunbeam/steps/role_distributor.py
+++ b/sunbeam-python/sunbeam/steps/role_distributor.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import tenacity
+
+from sunbeam.clusterd.client import Client
+from sunbeam.core.common import (
+    BaseStep,
+    Result,
+    ResultType,
+    StepContext,
+    convert_retry_failure_as_result,
+)
+from sunbeam.core.deployment import Deployment
+from sunbeam.core.juju import JujuHelper
+from sunbeam.core.manifest import CharmManifest, Manifest
+from sunbeam.core.ovn import OvnProvider
+from sunbeam.core.role_assignments import (
+    build_microovn_role_mapping,
+    dump_role_mapping,
+)
+from sunbeam.core.steps import DeployMachineApplicationStep, RemoveMachineUnitsStep
+from sunbeam.core.terraform import (
+    TerraformException,
+    TerraformHelper,
+    TerraformStateLockedException,
+)
+from sunbeam.feature_gates import split_roles_enabled
+
+CONFIG_KEY = "TerraformVarsRoleDistributorPlan"
+APPLICATION = "role-distributor"
+ROLE_DISTRIBUTOR_UNIT_TIMEOUT = 600
+NO_CONTROL_MACHINE_MESSAGE = "role-distributor requires at least one control machine"
+
+LOG = logging.getLogger(__name__)
+
+
+def _manifest_config(manifest: Manifest) -> dict[str, Any]:
+    charm_manifest: CharmManifest | None = manifest.core.software.charms.get(
+        APPLICATION
+    )
+    if not charm_manifest or not charm_manifest.config:
+        return {}
+    config = dict(charm_manifest.config)
+    config.pop("role-mapping", None)
+    return config
+
+
+def _role_distributor_extra_tfvars(
+    deployment: Deployment,
+    client: Client,
+    manifest: Manifest,
+    model: str,
+    microovn_machine_ids: list[str] | None = None,
+    role_distributor_machine_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    if microovn_machine_ids is None:
+        microovn_machine_ids = _microovn_machine_ids(deployment)
+    if role_distributor_machine_ids is None:
+        role_distributor_machine_ids = _control_machine_ids(client)
+
+    role_mapping = build_microovn_role_mapping(
+        client,
+        model,
+        split_roles_enabled(),
+        microovn_machine_ids,
+        assign_central_roles=(
+            deployment.get_ovn_manager().get_provider() == OvnProvider.MICROOVN
+        ),
+    )
+
+    config = _manifest_config(manifest)
+    config["role-mapping"] = dump_role_mapping(role_mapping)
+
+    return {
+        "role_distributor_machine_ids": role_distributor_machine_ids[:1],
+        # Prevent the generic machine application step from computing and
+        # persisting a second machine placement variable for this plan.
+        "machine_ids": [],
+        "charm_role_distributor_config": config,
+    }
+
+
+def _microovn_machine_ids(deployment: Deployment) -> list[str]:
+    """Return machines that currently consume MicroOVN role assignments."""
+    return deployment.get_ovn_manager().get_machines()
+
+
+def _control_machine_ids(client: Client) -> list[str]:
+    """Return valid control-node machine IDs for role-distributor placement."""
+    return sorted(
+        {
+            str(node.get("machineid"))
+            for node in client.cluster.list_nodes_by_role("control")
+            if node.get("machineid") not in (-1, None)
+        }
+    )
+
+
+class DeployRoleDistributorApplicationStep(DeployMachineApplicationStep):
+    """Deploy role-distributor and publish topology-derived assignments."""
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+        model: str,
+    ):
+        super().__init__(
+            deployment,
+            client,
+            tfhelper,
+            jhelper,
+            manifest,
+            CONFIG_KEY,
+            APPLICATION,
+            model,
+            [],
+            "Deploy role distributor",
+            "Deploying role distributor",
+        )
+
+    def get_accepted_application_status(self) -> list[str]:
+        """Accept waiting while requirer charms join the relation."""
+        return ["active", "waiting"]
+
+    def is_skip(self, context: StepContext) -> Result:
+        """Skip when there are no MicroOVN machines to assign roles to."""
+        if not _microovn_machine_ids(self.deployment):
+            return Result(ResultType.SKIPPED)
+        if not _control_machine_ids(self.client):
+            return Result(ResultType.FAILED, NO_CONTROL_MACHINE_MESSAGE)
+        return Result(ResultType.COMPLETED)
+
+    def extra_tfvars(self) -> dict[str, Any]:
+        """Extra terraform vars to pass to terraform apply."""
+        return _role_distributor_extra_tfvars(
+            self.deployment,
+            self.client,
+            self.manifest,
+            self.model,
+        )
+
+
+class ReapplyRoleDistributorApplicationStep(BaseStep):
+    """Reapply role-distributor placement and topology-derived config."""
+
+    _CONFIG = CONFIG_KEY
+
+    def __init__(
+        self,
+        deployment: Deployment,
+        client: Client,
+        tfhelper: TerraformHelper,
+        jhelper: JujuHelper,
+        manifest: Manifest,
+        model: str,
+    ):
+        super().__init__(
+            "Reapply role distributor Terraform plan",
+            "Reapplying role distributor Terraform plan",
+        )
+        self.deployment = deployment
+        self.client = client
+        self.tfhelper = tfhelper
+        self.jhelper = jhelper
+        self.manifest = manifest
+        self.model = model
+
+    @tenacity.retry(
+        wait=tenacity.wait_fixed(60),
+        stop=tenacity.stop_after_delay(300),
+        retry=tenacity.retry_if_exception_type(TerraformStateLockedException),
+        retry_error_callback=convert_retry_failure_as_result,
+    )
+    def run(self, context: StepContext) -> Result:
+        """Apply Terraform configuration for role-distributor."""
+        microovn_machine_ids = _microovn_machine_ids(self.deployment)
+        if not microovn_machine_ids:
+            return Result(ResultType.SKIPPED)
+        role_distributor_machine_ids = _control_machine_ids(self.client)
+        if not role_distributor_machine_ids:
+            return Result(ResultType.FAILED, NO_CONTROL_MACHINE_MESSAGE)
+
+        extra_tfvars = _role_distributor_extra_tfvars(
+            self.deployment,
+            self.client,
+            self.manifest,
+            self.model,
+            microovn_machine_ids,
+            role_distributor_machine_ids,
+        )
+        extra_tfvars["machine_model_uuid"] = self.jhelper.get_model_uuid(self.model)
+
+        try:
+            self.tfhelper.update_tfvars_and_apply_tf(
+                self.client,
+                self.manifest,
+                tfvar_config=self._CONFIG,
+                override_tfvars=extra_tfvars,
+                reporter=context.reporter,
+            )
+        except TerraformException as e:
+            return Result(ResultType.FAILED, str(e))
+
+        try:
+            self.jhelper.wait_application_ready(
+                APPLICATION,
+                self.model,
+                accepted_status=["active", "waiting"],
+                timeout=ROLE_DISTRIBUTOR_UNIT_TIMEOUT,
+            )
+        except TimeoutError as e:
+            LOG.warning("Timed out waiting for role-distributor reapply: %r", e)
+            return Result(ResultType.FAILED, str(e))
+
+        return Result(ResultType.COMPLETED)
+
+
+class RemoveRoleDistributorUnitsStep(RemoveMachineUnitsStep):
+    """Remove role-distributor unit from a machine before node removal."""
+
+    def __init__(
+        self, client: Client, names: list[str] | str, jhelper: JujuHelper, model: str
+    ):
+        super().__init__(
+            client,
+            names,
+            jhelper,
+            CONFIG_KEY,
+            APPLICATION,
+            model,
+            "Remove role-distributor unit",
+            "Removing role-distributor unit from machine",
+        )
+
+    def get_unit_timeout(self) -> int:
+        """Return unit timeout in seconds."""
+        return ROLE_DISTRIBUTOR_UNIT_TIMEOUT

--- a/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
+++ b/sunbeam-python/sunbeam/steps/upgrades/intra_channel.py
@@ -43,6 +43,7 @@ from sunbeam.steps.openstack import (
     ReapplyOpenStackTerraformPlanStep,
     build_overlay_dict,
 )
+from sunbeam.steps.role_distributor import DeployRoleDistributorApplicationStep
 from sunbeam.steps.sunbeam_machine import DeploySunbeamMachineApplicationStep
 from sunbeam.steps.upgrades.base import UpgradeCoordinator, UpgradeFeatures
 
@@ -532,6 +533,22 @@ class LatestInChannelCoordinator(UpgradeCoordinator):
             )
 
         if len(network_nodes):
+            role_distributor_tfhelper = self.deployment.get_tfhelper(
+                "role-distributor-plan"
+            )
+            plan.extend(
+                [
+                    TerraformInitStep(role_distributor_tfhelper),
+                    DeployRoleDistributorApplicationStep(
+                        self.deployment,
+                        self.client,
+                        role_distributor_tfhelper,
+                        self.jhelper,
+                        self.manifest,
+                        self.deployment.openstack_machines_model,
+                    ),
+                ]
+            )
             plan.extend(
                 [
                     TerraformInitStep(self.deployment.get_tfhelper("microovn-plan")),

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -28,6 +28,7 @@ RABBITMQ_CHANNEL = "3.12/stable"
 TRAEFIK_CHANNEL = "latest/stable"
 MICROCEPH_CHANNEL = "squid/stable"
 MICROOVN_CHANNEL = "25.03/stable"
+ROLE_DISTRIBUTOR_CHANNEL = "latest/stable"
 MYSQL_CHANNEL = "8.0/stable"
 CERT_AUTH_CHANNEL = "1/stable"
 MANUAL_TLS_CERTIFICATES_CHANNEL = "1/stable"
@@ -74,6 +75,7 @@ MISC_CHARMS_K8S = {
 MACHINE_CHARMS = {
     "microceph": MICROCEPH_CHANNEL,
     "microovn": MICROOVN_CHANNEL,
+    "role-distributor": ROLE_DISTRIBUTOR_CHANNEL,
     "openstack-network-agents": OPENSTACK_CHANNEL,
     # TODO: ensure correct channel for the distributor
     "microcluster-token-distributor": "latest/edge",
@@ -105,6 +107,7 @@ TERRAFORM_DIR_NAMES = {
     "sunbeam-machine-plan": "deploy-sunbeam-machine",
     "k8s-plan": "deploy-k8s",
     "microceph-plan": "deploy-microceph",
+    "role-distributor-plan": "deploy-role-distributor",
     "microovn-plan": "deploy-microovn",
     "cinder-volume-plan": "deploy-cinder-volume",
     "openstack-plan": "deploy-openstack",
@@ -238,6 +241,14 @@ DEPLOY_MICROCEPH_TFVAR_MAP: VarMap = {
         }
     }
 }
+DEPLOY_ROLE_DISTRIBUTOR_TFVAR_MAP: VarMap = {
+    "charms": {
+        "role-distributor": {
+            "channel": "charm_role_distributor_channel",
+            "revision": "charm_role_distributor_revision",
+        }
+    }
+}
 DEPLOY_MICROOVN_TFVAR_MAP: VarMap = {
     "charms": {
         "microovn": {
@@ -305,6 +316,7 @@ MANIFEST_ATTRIBUTES_TFVAR_MAP: dict[str, VarMap] = {
     "sunbeam-machine-plan": DEPLOY_SUNBEAM_MACHINE_TFVAR_MAP,
     "k8s-plan": DEPLOY_K8S_TFVAR_MAP,
     "microceph-plan": DEPLOY_MICROCEPH_TFVAR_MAP,
+    "role-distributor-plan": DEPLOY_ROLE_DISTRIBUTOR_TFVAR_MAP,
     "microovn-plan": DEPLOY_MICROOVN_TFVAR_MAP,
     "openstack-plan": DEPLOY_OPENSTACK_TFVAR_MAP,
     "hypervisor-plan": DEPLOY_OPENSTACK_HYPERVISOR_TFVAR_MAP,

--- a/sunbeam-python/tests/unit/sunbeam/core/test_role_assignments.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_role_assignments.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+
+from sunbeam.core.role_assignments import (
+    build_microovn_role_mapping,
+    dump_role_mapping,
+)
+
+
+def test_microovn_role_mapping_without_split_roles_assigns_compute_gateways():
+    client = _client_with_nodes(
+        {
+            "control": [{"machineid": "0", "role": ["control"]}],
+            "compute": [
+                {"machineid": "1", "role": ["compute"]},
+                {"machineid": "2", "role": ["compute", "network"]},
+            ],
+            "network": [{"machineid": "2", "role": ["compute", "network"]}],
+        }
+    )
+
+    mapping = build_microovn_role_mapping(
+        client,
+        model_name="openstack-machines",
+        split_roles=False,
+        machine_ids=["0", "1", "2"],
+        assign_central_roles=True,
+    )
+
+    assert mapping == {
+        "openstack-machines": {
+            "microovn": {
+                "machines": {
+                    "0": {"roles": ["chassis", "central"]},
+                    "1": {"roles": ["chassis", "gateway"]},
+                    "2": {"roles": ["chassis", "gateway"]},
+                }
+            }
+        }
+    }
+
+
+def test_microovn_role_mapping_with_split_roles_keeps_gateways_on_network_nodes():
+    client = _client_with_nodes(
+        {
+            "control": [{"machineid": "0", "role": ["control"]}],
+            "compute": [{"machineid": "1", "role": ["compute"]}],
+            "network": [{"machineid": "2", "role": ["network"]}],
+        }
+    )
+
+    mapping = build_microovn_role_mapping(
+        client,
+        model_name="openstack-machines",
+        split_roles=True,
+        machine_ids=["0", "1", "2"],
+        assign_central_roles=True,
+    )
+
+    assert mapping["openstack-machines"]["microovn"]["machines"] == {
+        "0": {"roles": ["chassis", "central"]},
+        "1": {"roles": ["chassis"]},
+        "2": {"roles": ["chassis", "gateway"]},
+    }
+
+
+def test_microovn_role_mapping_filters_to_actual_microovn_machines():
+    client = _client_with_nodes(
+        {
+            "control": [{"machineid": "0", "role": ["control"]}],
+            "compute": [{"machineid": "1", "role": ["compute"]}],
+            "network": [{"machineid": "2", "role": ["network"]}],
+        }
+    )
+
+    mapping = build_microovn_role_mapping(
+        client,
+        model_name="openstack-machines",
+        split_roles=False,
+        machine_ids=["2"],
+        assign_central_roles=True,
+    )
+
+    assert mapping["openstack-machines"]["microovn"]["machines"] == {
+        "2": {"roles": ["chassis", "gateway"]},
+    }
+
+
+def test_microovn_role_mapping_can_disable_central_roles():
+    client = _client_with_nodes(
+        {
+            "control": [{"machineid": "0", "role": ["control", "network"]}],
+            "compute": [],
+            "network": [{"machineid": "0", "role": ["control", "network"]}],
+        }
+    )
+
+    mapping = build_microovn_role_mapping(
+        client,
+        model_name="openstack-machines",
+        split_roles=True,
+        machine_ids=["0"],
+        assign_central_roles=False,
+    )
+
+    assert mapping["openstack-machines"]["microovn"]["machines"] == {
+        "0": {"roles": ["chassis", "gateway"]},
+    }
+
+
+def test_microovn_role_mapping_allows_central_and_gateway_for_provider_microovn():
+    client = _client_with_nodes(
+        {
+            "control": [{"machineid": "0", "role": ["control", "network"]}],
+            "compute": [],
+            "network": [{"machineid": "0", "role": ["control", "network"]}],
+        }
+    )
+
+    mapping = build_microovn_role_mapping(
+        client,
+        model_name="openstack-machines",
+        split_roles=True,
+        machine_ids=["0"],
+        assign_central_roles=True,
+    )
+
+    assert mapping["openstack-machines"]["microovn"]["machines"] == {
+        "0": {"roles": ["chassis", "central", "gateway"]},
+    }
+
+
+def test_dump_role_mapping_serializes_valid_yaml():
+    mapping = {
+        "openstack-machines": {
+            "microovn": {
+                "machines": {
+                    "0": {"roles": ["chassis", "central"]},
+                }
+            }
+        }
+    }
+
+    dumped = dump_role_mapping(mapping)
+
+    assert yaml.safe_load(dumped) == mapping
+
+
+def _client_with_nodes(nodes_by_role):
+    class Cluster:
+        def list_nodes_by_role(self, role):
+            return nodes_by_role.get(role, [])
+
+    class Client:
+        cluster = Cluster()
+
+    return Client()

--- a/sunbeam-python/tests/unit/sunbeam/provider/local/test_commands.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/local/test_commands.py
@@ -8,8 +8,13 @@ import pytest
 from click.testing import CliRunner
 
 from sunbeam.core.common import ResultType, Role
-from sunbeam.provider.local.commands import add, join
-from sunbeam.steps.juju import JujuGrantModelAccessStep
+from sunbeam.provider.local.commands import add, join, remove
+from sunbeam.steps.clusterd import ClusterRemoveNodeStep
+from sunbeam.steps.juju import JujuGrantModelAccessStep, RemoveJujuMachineStep
+from sunbeam.steps.role_distributor import (
+    ReapplyRoleDistributorApplicationStep,
+    RemoveRoleDistributorUnitsStep,
+)
 
 
 @pytest.fixture()
@@ -212,3 +217,70 @@ class TestJoinNodeValidation:
         assert run_plan.call_count == 1
         first_plan = run_plan.call_args_list[0][0][0]
         assert first_plan[0].__class__.__name__ == "ClusterJoinNodeStep"
+
+
+class TestRemoveNodeRoleDistributor:
+    def test_remove_cleans_role_distributor_before_machine_removal_and_reapplies(
+        self,
+        daemon_group_check,
+        run_preflight,
+        run_plan_cmd,
+        juju_helper_cmd,
+    ):
+        deployment = Mock()
+        deployment.openstack_machines_model = "openstack-machines"
+        deployment.get_manifest.return_value = Mock()
+        deployment.get_tfhelper.return_value = Mock()
+        deployment.get_ovn_manager.return_value.get_machines.return_value = ["1"]
+
+        runner = CliRunner()
+        result = runner.invoke(remove, ["node-1"], obj=deployment)
+
+        assert result.exit_code == 0, result.output
+
+        plan = run_plan_cmd.call_args_list[0][0][0]
+        role_remove_idx = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, RemoveRoleDistributorUnitsStep)
+        )
+        juju_remove_idx = next(
+            i for i, step in enumerate(plan) if isinstance(step, RemoveJujuMachineStep)
+        )
+        cluster_remove_idx = next(
+            i for i, step in enumerate(plan) if isinstance(step, ClusterRemoveNodeStep)
+        )
+        role_reapply_idx = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, ReapplyRoleDistributorApplicationStep)
+        )
+
+        assert role_remove_idx < juju_remove_idx
+        assert cluster_remove_idx < role_reapply_idx
+
+    def test_remove_skips_role_distributor_when_microovn_has_no_machines(
+        self,
+        daemon_group_check,
+        run_preflight,
+        run_plan_cmd,
+        juju_helper_cmd,
+    ):
+        deployment = Mock()
+        deployment.openstack_machines_model = "openstack-machines"
+        deployment.get_manifest.return_value = Mock()
+        deployment.get_tfhelper.return_value = Mock()
+        deployment.get_ovn_manager.return_value.get_machines.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(remove, ["node-1"], obj=deployment)
+
+        assert result.exit_code == 0, result.output
+
+        plan = run_plan_cmd.call_args_list[0][0][0]
+        assert not any(
+            isinstance(step, RemoveRoleDistributorUnitsStep) for step in plan
+        )
+        assert not any(
+            isinstance(step, ReapplyRoleDistributorApplicationStep) for step in plan
+        )

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -18,6 +18,7 @@ from sunbeam.core.deployment import Networks
 from sunbeam.core.deployments import DeploymentsConfig
 from sunbeam.core.juju import ControllerNotFoundException
 from sunbeam.provider.maas.commands import (
+    remove_node,
     validate_deployment_cmd,
     validate_machine_cmd,
 )
@@ -40,6 +41,7 @@ from sunbeam.provider.maas.steps import (
     MaasDeployInfraMachinesStep,
     MaasDeployK8SApplicationStep,
     MaasDeployMachinesStep,
+    MaasRemoveMachineFromClusterdStep,
     MaasScaleJujuStep,
     MachineComputeNicCheck,
     MachineNetworkCheck,
@@ -52,6 +54,11 @@ from sunbeam.provider.maas.steps import (
     UnitNotFoundException,
     ZoneBalanceCheck,
     ZonesCheck,
+)
+from sunbeam.steps.juju import RemoveJujuMachineStep
+from sunbeam.steps.role_distributor import (
+    ReapplyRoleDistributorApplicationStep,
+    RemoveRoleDistributorUnitsStep,
 )
 
 
@@ -2419,6 +2426,79 @@ class TestMaasDeploymentProperties:
             )
             assert deployment.storage_ippool_label == expected_label
             assert deployment.storage_ip_pool == expected_label
+
+
+class TestRemoveNodeRoleDistributor:
+    @patch("sunbeam.provider.maas.commands.JujuHelper")
+    @patch("sunbeam.provider.maas.commands.run_preflight_checks")
+    @patch("sunbeam.provider.maas.commands.run_plan")
+    def test_remove_cleans_role_distributor_before_machine_removal_and_reapplies(
+        self,
+        run_plan_cmd,
+        run_preflight,
+        juju_helper,
+    ):
+        deployment = Mock()
+        deployment.openstack_machines_model = "openstack-machines"
+        deployment.get_manifest.return_value = Mock()
+        deployment.get_tfhelper.return_value = Mock()
+        deployment.get_ovn_manager.return_value.get_machines.return_value = ["1"]
+
+        runner = CliRunner()
+        result = runner.invoke(remove_node, ["node-1"], obj=deployment)
+
+        assert result.exit_code == 0, result.output
+
+        plan = run_plan_cmd.call_args_list[1][0][0]
+        role_remove_idx = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, RemoveRoleDistributorUnitsStep)
+        )
+        juju_remove_idx = next(
+            i for i, step in enumerate(plan) if isinstance(step, RemoveJujuMachineStep)
+        )
+        clusterd_remove_idx = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, MaasRemoveMachineFromClusterdStep)
+        )
+        role_reapply_idx = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, ReapplyRoleDistributorApplicationStep)
+        )
+
+        assert role_remove_idx < juju_remove_idx
+        assert clusterd_remove_idx < role_reapply_idx
+
+    @patch("sunbeam.provider.maas.commands.JujuHelper")
+    @patch("sunbeam.provider.maas.commands.run_preflight_checks")
+    @patch("sunbeam.provider.maas.commands.run_plan")
+    def test_remove_skips_role_distributor_when_microovn_has_no_machines(
+        self,
+        run_plan_cmd,
+        run_preflight,
+        juju_helper,
+    ):
+        deployment = Mock()
+        deployment.openstack_machines_model = "openstack-machines"
+        deployment.get_manifest.return_value = Mock()
+        deployment.get_tfhelper.return_value = Mock()
+        deployment.get_ovn_manager.return_value.get_machines.return_value = []
+
+        runner = CliRunner()
+        result = runner.invoke(remove_node, ["node-1"], obj=deployment)
+
+        assert result.exit_code == 0, result.output
+
+        plan = run_plan_cmd.call_args_list[1][0][0]
+        assert not any(
+            isinstance(step, RemoveRoleDistributorUnitsStep) for step in plan
+        )
+        assert not any(
+            isinstance(step, ReapplyRoleDistributorApplicationStep) for step in plan
+        )
 
 
 class TestIsMaasDeployment:

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_microovn.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_microovn.py
@@ -60,7 +60,12 @@ class TestDeployMicroOVNApplicationStep:
         assert timeout == 1200
 
     def test_extra_tfvars(
-        self, deploy_microovn_step, basic_deployment, basic_client, ovn_manager
+        self,
+        deploy_microovn_step,
+        basic_deployment,
+        basic_client,
+        basic_jhelper,
+        ovn_manager,
     ):
         openstack_tfhelper = Mock()
         openstack_tfhelper.output.return_value = {
@@ -68,6 +73,7 @@ class TestDeployMicroOVNApplicationStep:
         }
         basic_deployment.get_tfhelper.return_value = openstack_tfhelper
         ovn_manager.get_machines.return_value = ["1", "2"]
+        basic_jhelper.get_application.return_value = Mock()
 
         extra_tfvars = deploy_microovn_step.extra_tfvars()
 
@@ -75,6 +81,7 @@ class TestDeployMicroOVNApplicationStep:
         assert "microovn_machine_ids" in extra_tfvars
         assert set(extra_tfvars["microovn_machine_ids"]) == {"1", "2"}
         assert extra_tfvars["token_distributor_machine_ids"] == ["1"]
+        assert extra_tfvars["role_distributor_application_name"] == "role-distributor"
 
     def test_extra_tfvars_no_network_nodes(
         self, deploy_microovn_step, basic_deployment, basic_client, ovn_manager
@@ -91,6 +98,25 @@ class TestDeployMicroOVNApplicationStep:
         assert "ca-offer-url" in extra_tfvars
         assert "endpoint_bindings" in extra_tfvars
         assert extra_tfvars["ca-offer-url"] == "provider:admin/default.ca"
+
+    def test_extra_tfvars_disables_role_distributor_when_missing(
+        self,
+        deploy_microovn_step,
+        basic_deployment,
+        basic_jhelper,
+        ovn_manager,
+    ):
+        openstack_tfhelper = Mock()
+        openstack_tfhelper.output.return_value = {}
+        basic_deployment.get_tfhelper.return_value = openstack_tfhelper
+        ovn_manager.get_machines.return_value = ["1"]
+        basic_jhelper.get_application.side_effect = ApplicationNotFoundException(
+            "Application missing from model: 'test-model'"
+        )
+
+        extra_tfvars = deploy_microovn_step.extra_tfvars()
+
+        assert extra_tfvars["role_distributor_application_name"] is None
 
     def test_extra_tfvars_network_agents_endpoint_bindings(
         self, deploy_microovn_step, basic_deployment, ovn_manager
@@ -133,6 +159,7 @@ class TestReapplyMicroOVNOptionalIntegrationsStep:
 
     def test_tf_apply_extra_args(self, reapply_microovn_step):
         reapply_microovn_step.tfhelper.output.return_value = {}
+        reapply_microovn_step.jhelper.get_application.return_value = Mock()
         extra_args = reapply_microovn_step.tf_apply_extra_args()
 
         expected_args = [
@@ -140,8 +167,26 @@ class TestReapplyMicroOVNOptionalIntegrationsStep:
             "-target=juju_integration.microovn-certs",
             "-target=juju_integration.microovn-ovsdb-cms",
             "-target=juju_integration.microovn-openstack-network-agents",
+            "-target=juju_integration.role-distributor-microovn",
         ]
         assert extra_args == expected_args
+
+    def test_tf_apply_extra_args_omits_role_distributor_when_missing(
+        self, reapply_microovn_step
+    ):
+        reapply_microovn_step.tfhelper.output.return_value = {}
+        reapply_microovn_step.jhelper.get_application.side_effect = (
+            ApplicationNotFoundException("Application missing from model: 'test-model'")
+        )
+
+        extra_args = reapply_microovn_step.tf_apply_extra_args()
+
+        assert extra_args == [
+            "-target=juju_integration.microovn-microcluster-token-distributor",
+            "-target=juju_integration.microovn-certs",
+            "-target=juju_integration.microovn-ovsdb-cms",
+            "-target=juju_integration.microovn-openstack-network-agents",
+        ]
 
 
 class TestEnableMicroOVNStep:

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_role_distributor.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_role_distributor.py
@@ -1,0 +1,393 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock, patch
+
+import yaml
+
+from sunbeam.core import ovn
+from sunbeam.core.common import ResultType
+from sunbeam.steps.role_distributor import (
+    DeployRoleDistributorApplicationStep,
+    ReapplyRoleDistributorApplicationStep,
+    RemoveRoleDistributorUnitsStep,
+)
+from sunbeam.versions import DEPLOY_ROLE_DISTRIBUTOR_TFVAR_MAP
+
+
+def test_role_distributor_config_is_not_generic_manifest_tfvar():
+    role_distributor_tfvars = DEPLOY_ROLE_DISTRIBUTOR_TFVAR_MAP["charms"][
+        "role-distributor"
+    ]
+
+    assert "config" not in role_distributor_tfvars
+
+
+class TestDeployRoleDistributorApplicationStep:
+    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=True)
+    def test_extra_tfvars_emits_role_mapping_config(
+        self,
+        split_roles_enabled,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        test_model,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = [
+            "1",
+            "2",
+        ]
+        basic_client.cluster.list_nodes_by_role.side_effect = lambda role: {
+            "control": [{"machineid": "0", "role": ["control"]}],
+            "compute": [{"machineid": "1", "role": ["compute"]}],
+            "network": [{"machineid": "2", "role": ["network"]}],
+        }.get(role, [])
+
+        step = DeployRoleDistributorApplicationStep(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            "openstack-machines",
+        )
+
+        extra_tfvars = step.extra_tfvars()
+
+        role_mapping = yaml.safe_load(
+            extra_tfvars["charm_role_distributor_config"]["role-mapping"]
+        )
+        assert role_mapping["openstack-machines"]["microovn"]["machines"] == {
+            "1": {"roles": ["chassis"]},
+            "2": {"roles": ["chassis", "gateway"]},
+        }
+        assert extra_tfvars["role_distributor_machine_ids"] == ["0"]
+        split_roles_enabled.assert_called_once()
+
+    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=True)
+    def test_extra_tfvars_does_not_assign_central_for_ovn_k8s(
+        self,
+        split_roles_enabled,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        test_model,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = ["0"]
+        basic_deployment.get_ovn_manager.return_value.get_provider.return_value = (
+            ovn.OvnProvider.OVN_K8S
+        )
+        basic_client.cluster.list_nodes_by_role.side_effect = lambda role: {
+            "control": [{"machineid": "0", "role": ["control", "network"]}],
+            "compute": [],
+            "network": [{"machineid": "0", "role": ["control", "network"]}],
+        }.get(role, [])
+
+        step = DeployRoleDistributorApplicationStep(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            "openstack-machines",
+        )
+
+        extra_tfvars = step.extra_tfvars()
+
+        role_mapping = yaml.safe_load(
+            extra_tfvars["charm_role_distributor_config"]["role-mapping"]
+        )
+        assert role_mapping["openstack-machines"]["microovn"]["machines"] == {
+            "0": {"roles": ["chassis", "gateway"]},
+        }
+        split_roles_enabled.assert_called_once()
+
+    def test_get_accepted_application_status_allows_waiting(
+        self,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        test_model,
+    ):
+        step = DeployRoleDistributorApplicationStep(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            "openstack-machines",
+        )
+
+        assert step.get_accepted_application_status() == ["active", "waiting"]
+
+    def test_extra_tfvars_uses_manifest_config_except_role_mapping(
+        self,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        test_model,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = []
+        basic_client.cluster.list_nodes_by_role.return_value = []
+        basic_manifest.core.software.charms.get.return_value = Mock(
+            config={
+                "log-level": "DEBUG",
+                "role-mapping": "operator supplied mapping",
+            }
+        )
+
+        step = DeployRoleDistributorApplicationStep(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            "openstack-machines",
+        )
+
+        config = step.extra_tfvars()["charm_role_distributor_config"]
+
+        assert config["log-level"] == "DEBUG"
+        assert yaml.safe_load(config["role-mapping"]) == {
+            "openstack-machines": {"microovn": {"machines": {}}}
+        }
+
+    def test_is_skip_skips_when_no_microovn_machines(
+        self,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        test_model,
+        step_context,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = []
+        step = DeployRoleDistributorApplicationStep(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            "openstack-machines",
+        )
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+
+    def test_is_skip_fails_when_targets_exist_without_control_machine(
+        self,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        test_model,
+        step_context,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = ["1"]
+        basic_client.cluster.list_nodes_by_role.return_value = []
+        step = DeployRoleDistributorApplicationStep(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            "openstack-machines",
+        )
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "control" in result.message
+
+
+class TestReapplyRoleDistributorApplicationStep:
+    def _create_step(
+        self,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+    ):
+        return ReapplyRoleDistributorApplicationStep(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            "openstack-machines",
+        )
+
+    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=False)
+    def test_run_skips_tf_apply_when_no_targets(
+        self,
+        split_roles_enabled,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        step_context,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = []
+        basic_client.cluster.list_nodes_by_role.return_value = []
+        step = self._create_step(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+        )
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        basic_tfhelper.update_tfvars_and_apply_tf.assert_not_called()
+        basic_jhelper.wait_application_ready.assert_not_called()
+        split_roles_enabled.assert_not_called()
+
+    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=False)
+    def test_run_waits_for_role_distributor_when_targets_remain(
+        self,
+        split_roles_enabled,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        step_context,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = [
+            "1",
+            "2",
+        ]
+        basic_client.cluster.list_nodes_by_role.side_effect = lambda role: {
+            "control": [{"machineid": "0", "role": ["control"]}],
+            "compute": [{"machineid": "1", "role": ["compute"]}],
+            "network": [{"machineid": "2", "role": ["network"]}],
+        }.get(role, [])
+        step = self._create_step(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+        )
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.wait_application_ready.assert_called_once_with(
+            "role-distributor",
+            "openstack-machines",
+            accepted_status=["active", "waiting"],
+            timeout=600,
+        )
+
+        _, _, kwargs = basic_tfhelper.update_tfvars_and_apply_tf.mock_calls[0]
+        role_mapping = yaml.safe_load(
+            kwargs["override_tfvars"]["charm_role_distributor_config"]["role-mapping"]
+        )
+        assert role_mapping["openstack-machines"]["microovn"]["machines"] == {
+            "1": {"roles": ["chassis", "gateway"]},
+            "2": {"roles": ["chassis", "gateway"]},
+        }
+        assert kwargs["override_tfvars"]["role_distributor_machine_ids"] == ["0"]
+        split_roles_enabled.assert_called_once()
+
+    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=False)
+    def test_run_relocates_to_remaining_control_machine(
+        self,
+        split_roles_enabled,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        step_context,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = [
+            "2",
+            "3",
+        ]
+        basic_client.cluster.list_nodes_by_role.side_effect = lambda role: {
+            "control": [{"machineid": "2", "role": ["control"]}],
+            "compute": [{"machineid": "3", "role": ["compute"]}],
+            "network": [],
+        }.get(role, [])
+        step = self._create_step(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+        )
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        _, _, kwargs = basic_tfhelper.update_tfvars_and_apply_tf.mock_calls[0]
+        assert kwargs["override_tfvars"]["role_distributor_machine_ids"] == ["2"]
+        split_roles_enabled.assert_called_once()
+
+    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=False)
+    def test_run_fails_when_targets_exist_without_control_machine(
+        self,
+        split_roles_enabled,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        step_context,
+    ):
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = ["1"]
+        basic_client.cluster.list_nodes_by_role.side_effect = lambda role: {
+            "control": [],
+            "compute": [{"machineid": "1", "role": ["compute"]}],
+            "network": [],
+        }.get(role, [])
+        step = self._create_step(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+        )
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        assert "control" in result.message
+        basic_tfhelper.update_tfvars_and_apply_tf.assert_not_called()
+        basic_jhelper.wait_application_ready.assert_not_called()
+        split_roles_enabled.assert_not_called()
+
+
+class TestRemoveRoleDistributorUnitsStep:
+    def test_remove_step_targets_role_distributor(
+        self,
+        basic_client,
+        basic_jhelper,
+    ):
+        step = RemoveRoleDistributorUnitsStep(
+            basic_client,
+            "node-1",
+            basic_jhelper,
+            "openstack-machines",
+        )
+
+        assert step.config == "TerraformVarsRoleDistributorPlan"
+        assert step.application == "role-distributor"
+        assert step.names == ["node-1"]

--- a/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/upgrades/test_intra_channel.py
@@ -4,19 +4,22 @@
 import sys
 from unittest.mock import Mock, call, patch
 
-from sunbeam.core.common import Result, ResultType
+from sunbeam.core.common import Result, ResultType, Role
 from sunbeam.core.juju import (
     ActionFailedException,
     ApplicationNotFoundException,
     JujuWaitException,
 )
 from sunbeam.core.openstack import OPENSTACK_MODEL
+from sunbeam.core.terraform import TerraformInitStep
 from sunbeam.steps.k8s import (
     EnsureCiliumDeviceByHostStep,
     EnsureDefaultL2AdvertisementMutedStep,
     EnsureL2AdvertisementByHostStep,
 )
+from sunbeam.steps.microovn import DeployMicroOVNApplicationStep
 from sunbeam.steps.openstack import OpenStackPatchLoadBalancerServicesIPPoolStep
+from sunbeam.steps.role_distributor import DeployRoleDistributorApplicationStep
 from sunbeam.steps.upgrades.base import UpgradeFeatures
 from sunbeam.steps.upgrades.intra_channel import (
     SNAP_APPS_INFRA_MODEL,
@@ -961,6 +964,62 @@ class TestLatestInChannelCoordinator:
         assert EnsureCiliumDeviceByHostStep in step_types
         assert ReapplyInfraModelConfigStep in step_types
         assert UpgradeFeatures in step_types
+
+    @patch(f"{_INTRA_CHANNEL}.is_maas_deployment")
+    def test_get_plan_deploys_role_distributor_before_microovn(self, mock_is_maas):
+        """MicroOVN upgrade path must create role-distributor first."""
+        mock_is_maas.return_value = False
+        role_distributor_tfhelper = Mock()
+        microovn_tfhelper = Mock()
+
+        def get_tfhelper(plan_name):
+            if plan_name == "role-distributor-plan":
+                return role_distributor_tfhelper
+            if plan_name == "microovn-plan":
+                return microovn_tfhelper
+            return Mock()
+
+        self.deployment.get_tfhelper.side_effect = get_tfhelper
+        ovn_manager = self.deployment.get_ovn_manager()
+        ovn_manager.get_roles_for_microovn.return_value = {Role.NETWORK}
+        self.client.cluster.list_nodes_by_role.return_value = [
+            {"machineid": "0", "role": ["network"]}
+        ]
+
+        coordinator = LatestInChannelCoordinator(
+            self.deployment, self.client, self.jhelper, self.manifest
+        )
+        plan = coordinator.get_plan()
+
+        role_distributor_init_index = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, TerraformInitStep)
+            and step.tfhelper is role_distributor_tfhelper
+        )
+        role_distributor_deploy_index = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, DeployRoleDistributorApplicationStep)
+        )
+        microovn_init_index = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, TerraformInitStep)
+            and step.tfhelper is microovn_tfhelper
+        )
+        microovn_deploy_index = next(
+            i
+            for i, step in enumerate(plan)
+            if isinstance(step, DeployMicroOVNApplicationStep)
+        )
+
+        assert (
+            role_distributor_init_index
+            < role_distributor_deploy_index
+            < microovn_init_index
+            < microovn_deploy_index
+        )
 
 
 class TestReapplyInfraModelConfigStep:


### PR DESCRIPTION
Deploy the role-distributor Terraform plan before MicroOVN and wire it to MicroOVN through the role-assignment relation so the snap can manage OVN role placement explicitly.

Generate the MicroOVN role mapping from clusterd topology, constrain it to machines that run MicroOVN, and refresh the mapping after node removal only when MicroOVN is still present.