### PR TITLE
Drop retired feature gates

### DIFF
--- a/.github/assets/testing/edge.yml
+++ b/.github/assets/testing/edge.yml
@@ -47,7 +47,7 @@ core:
         config:
           snap-channel: squid/edge
       microovn:
-        channel: latest/edge
+        channel: 26.03/edge
       rabbitmq-k8s:
         channel: 3.12/edge
         storage:

--- a/sunbeam-python/sunbeam/core/role_assignments.py
+++ b/sunbeam-python/sunbeam/core/role_assignments.py
@@ -18,7 +18,6 @@ RoleMapping = dict[str, dict[str, dict[str, dict[str, dict[str, list[str]]]]]]
 def build_microovn_role_mapping(
     client: Client,
     model_name: str,
-    split_roles: bool,
     machine_ids: Iterable[str],
     *,
     assign_central_roles: bool,
@@ -38,7 +37,6 @@ def build_microovn_role_mapping(
             node_roles = set(node.get("role", []))
             machine_roles[machine_id_str] = _microovn_roles_for_node(
                 node_roles,
-                split_roles,
                 assign_central_roles,
             )
 
@@ -73,7 +71,6 @@ def _build_mapping(
 
 def _microovn_roles_for_node(
     node_roles: Iterable[str],
-    split_roles: bool,
     assign_central_roles: bool,
 ) -> list[str]:
     role_set = set(node_roles)
@@ -81,7 +78,7 @@ def _microovn_roles_for_node(
 
     if assign_central_roles and "control" in role_set:
         roles.append("central")
-    if "network" in role_set or ("compute" in role_set and not split_roles):
+    if "network" in role_set:
         roles.append("gateway")
 
     return roles

--- a/sunbeam-python/sunbeam/feature_gates.py
+++ b/sunbeam-python/sunbeam/feature_gates.py
@@ -223,23 +223,14 @@ class FeatureGateMixin:
 # Example gates:
 # - feature.multi-region: Gates multi-region deployment options and
 #                         region_controller role
-# - feature.microovn-sdn: Gates MicroOVN SDN provider option
 # - feature.experimental: Gates experimental features
 #
 FEATURE_GATES: dict[str, dict[str, bool | list[str]]] = {
     "feature.multi-region": {
         "generally_available": False,  # TODO: Set to True when multi-region is GA
     },
-    "feature.microovn-sdn": {
-        "generally_available": False,  # TODO: Set to True when MicroOVN is GA
-    },
-    "feature.split-roles": {
-        "generally_available": False,  # TODO: Set to True when split-roles is GA
-        "requires": ["feature.microovn-sdn"],
-    },
     "feature.loadbalancer-amphora": {
         "generally_available": False,  # TODO: Set to True when Amphora support is GA
-        "requires": ["feature.microovn-sdn"],
     },
 }
 
@@ -282,16 +273,6 @@ def is_feature_gate_enabled(
         return bool(snap.config.get(gate_key))
     except (UnknownConfigKey, SnapCtlError):
         return False
-
-
-def split_roles_enabled(snap: Optional[Snap] = None) -> bool:
-    """Check if the split-roles feature gate is enabled.
-
-    When enabled, compute and network roles become independent:
-    - Compute + network can co-locate on the same node
-    - Compute-only nodes do not act as OVN gateways
-    """
-    return is_feature_gate_enabled("feature.split-roles", snap)
 
 
 def _get_feature_gate_states(snap: Snap) -> dict[str, bool]:

--- a/sunbeam-python/sunbeam/features/loadbalancer/feature.py
+++ b/sunbeam-python/sunbeam/features/loadbalancer/feature.py
@@ -274,7 +274,7 @@ def _amphora_questions() -> dict[str, questions.Question]:
             default_value=True,
             description=(
                 "Enables the Amphora VM-based load-balancer backend for Octavia."
-                " Requires the microovn-sdn and loadbalancer-amphora feature gates."
+                " Requires the loadbalancer-amphora feature gate."
             ),
         ),
         _AMP_IMAGE_TAG_KEY: questions.PromptQuestion(

--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -83,8 +83,6 @@ from sunbeam.core.terraform import TerraformInitStep
 from sunbeam.feature_gates import (
     feature_gate_command,
     feature_gate_option,
-    get_feature_gate_from_cluster,
-    split_roles_enabled,
 )
 from sunbeam.provider.base import ProviderBase
 from sunbeam.provider.common.multiregion import connect_to_region_controller
@@ -608,7 +606,7 @@ def deploy_and_migrate_juju_controller(
     "--role",
     "roles",
     multiple=True,
-    default=["control", "compute"],
+    default=["control", "compute", "network"],
     callback=validate_roles,
     help="Specify additional roles for the bootstrap node. "
     "Possible values: compute, storage, network, region_controller. "
@@ -674,13 +672,8 @@ def bootstrap(  # noqa: C901
     is_control_node = any(role.is_control_node() for role in roles)
     is_compute_node = any(role.is_compute_node() for role in roles)
     is_storage_node = any(role.is_storage_node() for role in roles)
-    is_network_node = any(role.is_network_node() for role in roles)
     is_region_controller = any(role.is_region_controller() for role in roles)
 
-    if is_network_node and is_compute_node and not split_roles_enabled():
-        raise click.ClickException(
-            "A node cannot be both a compute and network node at the same time."
-        )
     if is_region_controller and len(roles) > 1:
         raise click.ClickException(
             "The region controller role is mutually exclusive with all other roles."
@@ -1408,7 +1401,6 @@ def join(  # noqa: C901
     is_control_node = any(role.is_control_node() for role in roles)
     is_compute_node = any(role.is_compute_node() for role in roles)
     is_storage_node = any(role.is_storage_node() for role in roles)
-    is_network_node = any(role.is_network_node() for role in roles)
     is_region_controller = any(role.is_region_controller() for role in roles)
 
     if is_region_controller and len(roles) > 1:
@@ -1461,17 +1453,6 @@ def join(  # noqa: C901
 
     plan1 = [ClusterJoinNodeStep(client, token, ip, name, roles_str)]
     run_plan(plan1, console, show_hints)
-
-    if is_network_node and is_compute_node:
-        split_roles_in_cluster = get_feature_gate_from_cluster(
-            "feature.split-roles",
-            client,
-        )
-        if not split_roles_in_cluster:
-            raise click.ClickException(
-                "A node cannot be both a compute and network node at the same "
-                "time because feature.split-roles is not enabled in cluster state."
-            )
 
     try:
         deployments_from_db = read_config(client, DEPLOYMENTS_CONFIG_KEY)
@@ -1645,9 +1626,7 @@ def join(  # noqa: C901
                 deployment.get_ovn_manager(),
             )
         )
-        if ovn_manager.is_network_agent_dataplane_node(roles) or (
-            split_roles_enabled() and microovn_necessary
-        ):
+        if ovn_manager.is_network_agent_dataplane_node(roles) or microovn_necessary:
             plan4.append(
                 LocalSetOpenStackNetworkAgentsStep(
                     client,
@@ -2160,10 +2139,7 @@ def configure_cmd(
 
     if "network" in node["role"] or (
         is_microovn_deployment
-        and (
-            "compute" in node["role"]
-            or (split_roles_enabled() and "control" in node["role"])
-        )
+        and ("compute" in node["role"] or "control" in node["role"])
     ):
         role_distributor_tfhelper = deployment.get_tfhelper("role-distributor-plan")
         microovn_tfhelper = deployment.get_tfhelper("microovn-plan")

--- a/sunbeam-python/sunbeam/provider/local/steps.py
+++ b/sunbeam-python/sunbeam/provider/local/steps.py
@@ -35,7 +35,6 @@ from sunbeam.core.juju import (
     UnitNotFoundException,
 )
 from sunbeam.core.manifest import Manifest
-from sunbeam.feature_gates import split_roles_enabled
 from sunbeam.provider.common import nic_utils
 from sunbeam.steps import hypervisor, microovn
 from sunbeam.steps.cluster_status import ClusterStatusStep
@@ -90,6 +89,10 @@ class LocalSetExternalNetworkUnitsOptionsStep(SetExternalNetworkUnitsOptionsStep
 
     def has_prompts(self) -> bool:
         """Returns true if the step has prompts that it can ask the user."""
+        return True
+
+    def needs_external_nic(self, host: str) -> bool:
+        """Whether this step needs an external NIC for the host."""
         return True
 
     def _pick_candidate(
@@ -271,13 +274,9 @@ class LocalSetExternalNetworkUnitsOptionsStep(SetExternalNetworkUnitsOptionsStep
             # bypass validation
             host = self.names[0]
 
-            # When split-roles is active, compute-only nodes (no NETWORK role)
-            # don't need an external NIC or bridge-mapping.
-            if split_roles_enabled():
-                node = self.client.cluster.get_node_info(host)
-                if "network" not in node.get("role", []):
-                    self.bridge_mappings[host] = None
-                    return
+            if not self.needs_external_nic(host):
+                self.bridge_mappings[host] = None
+                return
 
             physnet_mapping = []
             for physnet, network in preseed.items():
@@ -320,6 +319,12 @@ class LocalSetOpenStackNetworkAgentsStep(
     APP = microovn.AGENT_APP
     DISPLAY_NAME = "network agents"
     ACTION = "set-network-agents-local-settings"
+    SUPPORTS_CHASSIS_AS_GW = True
+
+    def needs_external_nic(self, host: str) -> bool:
+        """Only network nodes need an external NIC for network agents."""
+        node = self.client.cluster.get_node_info(host)
+        return "network" in node.get("role", [])
 
     def _fetch_nics(self) -> dict:
         """Fetch nics from the network agent."""

--- a/sunbeam-python/sunbeam/provider/maas/commands.py
+++ b/sunbeam-python/sunbeam/provider/maas/commands.py
@@ -69,7 +69,7 @@ from sunbeam.core.juju import (
 from sunbeam.core.manifest import AddManifestStep
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.terraform import TerraformInitStep
-from sunbeam.feature_gates import feature_gate_option, split_roles_enabled
+from sunbeam.feature_gates import feature_gate_option
 from sunbeam.provider.base import ProviderBase
 from sunbeam.provider.common.multiregion import connect_to_region_controller
 from sunbeam.provider.maas.client import (
@@ -1075,10 +1075,11 @@ def configure_cmd(
         map(_name_mapper, client.cluster.list_nodes_by_role(RoleTags.NETWORK.value))
     )
     ovn_manager = deployment.get_ovn_manager()
-    # When split-roles is active, all nodes with microovn + network-agents
-    # need the action called. Only network nodes get enable-chassis-as-gw=true;
-    # compute-only and control-only get enable-chassis-as-gw=false.
-    if split_roles_enabled():
+    network_agents_names = network
+    if ovn_manager.get_provider() == ovn.OvnProvider.MICROOVN:
+        # All nodes with MicroOVN network agents need the action called. Only
+        # network nodes get enable-chassis-as-gw=true; compute-only and
+        # control-only nodes get enable-chassis-as-gw=false.
         control = list(
             map(
                 _name_mapper,
@@ -1086,8 +1087,6 @@ def configure_cmd(
             )
         )
         network_agents_names = list(dict.fromkeys(network + compute + control))
-    else:
-        network_agents_names = network
     plan = [
         AddManifestStep(client, manifest_path),
         JujuLoginStep(deployment.juju_account),

--- a/sunbeam-python/sunbeam/provider/maas/steps.py
+++ b/sunbeam-python/sunbeam/provider/maas/steps.py
@@ -56,7 +56,6 @@ from sunbeam.core.juju import (
 from sunbeam.core.manifest import Manifest
 from sunbeam.core.steps import CreateLoadBalancerIPPoolsStep
 from sunbeam.core.terraform import TerraformHelper
-from sunbeam.feature_gates import split_roles_enabled
 from sunbeam.lazy import LazyImport
 from sunbeam.provider.common import nic_utils
 from sunbeam.steps import clusterd
@@ -455,14 +454,11 @@ class MachineComputeNicCheck(DiagnosticsCheck):
             )
 
         is_network_node = maas_deployment.RoleTags.NETWORK.value in assigned_roles
-        is_compute_node = maas_deployment.RoleTags.COMPUTE.value in assigned_roles
-        needs_neutron_nic = is_network_node or (
-            is_compute_node and not split_roles_enabled()
-        )
+        needs_neutron_nic = is_network_node
 
         has_nic = self._has_neutron_nic()
 
-        if not needs_neutron_nic and has_nic and split_roles_enabled():
+        if not needs_neutron_nic and has_nic:
             return DiagnosticsResult.warn(
                 self.name,
                 "machine has a neutron-tagged NIC but does not have"
@@ -484,7 +480,6 @@ class MachineComputeNicCheck(DiagnosticsCheck):
                 machine=self.machine["hostname"],
             )
 
-        role_hint = "network" if split_roles_enabled() else "compute/network"
         return DiagnosticsResult.fail(
             self.name,
             "no neutron NIC found",
@@ -494,7 +489,7 @@ class MachineComputeNicCheck(DiagnosticsCheck):
                 '{self.NEUTRON_TAG_PREFIX}<physnet>' """
                 f"""(e.g. {self.NEUTRON_TAG_PREFIX}physnet1)
                 to be a part of an openstack deployment. Either add a
-                neutron-tagged NIC to the machine or remove the {role_hint} role.
+                neutron-tagged NIC to the machine or remove the network role.
                 More on assigning tags: https://maas.io/docs/how-to-use-network-tags
                 """
             ),
@@ -2208,21 +2203,14 @@ class MaasSetExternalNetworkUnitsOptionsStep(SetExternalNetworkUnitsOptionsStep)
 
         for machine, nic in bridge_mappings.items():
             if nic is None:
-                if split_roles_enabled():
-                    node = self.client.cluster.get_node_info(machine)
-                    node_roles = node.get("role", [])
-                    if "network" in node_roles:
-                        return Result(
-                            ResultType.FAILED,
-                            f"Machine {machine} does not have any"
-                            " neutron:* nic defined.",
-                        )
-                else:
+                node = self.client.cluster.get_node_info(machine)
+                node_roles = node.get("role", [])
+                if "network" in node_roles:
                     return Result(
                         ResultType.FAILED,
                         f"Machine {machine} does not have any neutron:* nic defined.",
                     )
-            elif split_roles_enabled():
+            else:
                 node = self.client.cluster.get_node_info(machine)
                 node_roles = node.get("role", [])
                 if "network" not in node_roles:
@@ -2254,6 +2242,7 @@ class MaasSetOpenStackNetworkAgentsStep(
     APP = "openstack-network-agents"
     DISPLAY_NAME = "network agents"
     ACTION = "set-network-agents-local-settings"
+    SUPPORTS_CHASSIS_AS_GW = True
 
 
 class MaasUserQuestions(BaseUserQuestions):

--- a/sunbeam-python/sunbeam/steps/configure.py
+++ b/sunbeam-python/sunbeam/steps/configure.py
@@ -499,6 +499,7 @@ class SetExternalNetworkUnitsOptionsStep(BaseStep, UnitGetterMixin):
     APP: str
     DISPLAY_NAME: str
     ACTION: str
+    SUPPORTS_CHASSIS_AS_GW: bool = False
 
     def __init__(
         self,
@@ -546,10 +547,6 @@ class SetExternalNetworkUnitsOptionsStep(BaseStep, UnitGetterMixin):
 
     def run(self, context: StepContext) -> Result:
         """Apply individual unit settings."""
-        from sunbeam.feature_gates import split_roles_enabled
-
-        split_roles = split_roles_enabled()
-
         for name in self.names:
             self.update_status(context, f"setting configuration for {name}")
             bridge_mapping = self.bridge_mappings.get(name)
@@ -557,13 +554,8 @@ class SetExternalNetworkUnitsOptionsStep(BaseStep, UnitGetterMixin):
             node_roles = node.get("role", [])
             is_network_node = "network" in node_roles
 
-            if bridge_mapping is None and not split_roles:
-                LOG.debug("No NIC found for %s, skipping", name)
-                continue
-
-            # When split-roles is active, only network nodes get
-            # bridge mappings; other nodes only need enable-chassis-as-gw.
-            if split_roles and not is_network_node:
+            # Only network nodes get bridge mappings.
+            if not is_network_node:
                 bridge_mapping = None
 
             self.machine_id = str(node.get("machineid"))
@@ -572,7 +564,7 @@ class SetExternalNetworkUnitsOptionsStep(BaseStep, UnitGetterMixin):
             action_params: dict[str, str | bool] = {}
             if bridge_mapping is not None:
                 action_params["bridge-mapping"] = bridge_mapping
-            if split_roles:
+            if self.SUPPORTS_CHASSIS_AS_GW:
                 action_params["enable-chassis-as-gw"] = is_network_node
 
             try:

--- a/sunbeam-python/sunbeam/steps/microovn.py
+++ b/sunbeam-python/sunbeam/steps/microovn.py
@@ -33,7 +33,6 @@ from sunbeam.core.terraform import (
     TerraformHelper,
     TerraformStateLockedException,
 )
-from sunbeam.feature_gates import is_feature_gate_enabled
 from sunbeam.steps.configure import get_external_network_configs
 
 LOG = logging.getLogger(__name__)
@@ -354,18 +353,12 @@ class SetOvnProviderStep(BaseStep):
     def get_config_from_snap(self, snap: Snap) -> ovn.OvnProvider:
         """Get OVN provider from snap configuration.
 
-        Returns MICROOVN only if both conditions are met:
-        1. The feature gate 'feature.microovn-sdn' is enabled
-        2. The provider config 'ovn.provider' is set to 'microovn'
+        Returns MICROOVN only when the provider config 'ovn.provider' is set
+        to 'microovn'.
 
         :param snap: the snap instance
         :return: the OVN provider
         """
-        # Check if MicroOVN feature gate is enabled
-        if not is_feature_gate_enabled("feature.microovn-sdn", snap):
-            return ovn.DEFAULT_PROVIDER
-
-        # Check if provider is explicitly set to microovn
         try:
             provider_value = snap.config.get(ovn.SNAP_PROVIDER_CONFIG_KEY)
             if provider_value:

--- a/sunbeam-python/sunbeam/steps/microovn.py
+++ b/sunbeam-python/sunbeam/steps/microovn.py
@@ -54,6 +54,14 @@ def _role_distributor_application_name(jhelper: JujuHelper, model: str) -> str |
     return ROLE_DISTRIBUTOR_APP
 
 
+def _microovn_accepted_statuses(ovn_manager: ovn.OvnManager) -> list[str]:
+    """Return statuses accepted while waiting for MicroOVN."""
+    statuses = ["active", "unknown"]
+    if ovn_manager.get_provider() == ovn.OvnProvider.OVN_K8S:
+        statuses.append("blocked")
+    return statuses
+
+
 class DeployMicroOVNApplicationStep(DeployMachineApplicationStep):
     """Deploy MicroOVN application using Terraform."""
 
@@ -85,6 +93,10 @@ class DeployMicroOVNApplicationStep(DeployMachineApplicationStep):
     def get_application_timeout(self) -> int:
         """Return application timeout in seconds."""
         return MICROOVN_APP_TIMEOUT
+
+    def get_accepted_application_status(self) -> list[str]:
+        """Accepted status to pass wait_application_ready function."""
+        return _microovn_accepted_statuses(self.ovn_manager)
 
     def extra_tfvars(self) -> dict:
         """Extra terraform vars to pass to terraform apply."""
@@ -229,7 +241,7 @@ class ReapplyMicroOVNTerraformPlanStep(BaseStep):
                 network_configs
             )
 
-        statuses = ["active", "unknown"]
+        statuses = _microovn_accepted_statuses(self.ovn_manager)
         try:
             self.tfhelper.update_tfvars_and_apply_tf(
                 self.client,

--- a/sunbeam-python/sunbeam/steps/role_distributor.py
+++ b/sunbeam-python/sunbeam/steps/role_distributor.py
@@ -30,7 +30,6 @@ from sunbeam.core.terraform import (
     TerraformHelper,
     TerraformStateLockedException,
 )
-from sunbeam.feature_gates import split_roles_enabled
 
 CONFIG_KEY = "TerraformVarsRoleDistributorPlan"
 APPLICATION = "role-distributor"
@@ -67,7 +66,6 @@ def _role_distributor_extra_tfvars(
     role_mapping = build_microovn_role_mapping(
         client,
         model,
-        split_roles_enabled(),
         microovn_machine_ids,
         assign_central_roles=(
             deployment.get_ovn_manager().get_provider() == OvnProvider.MICROOVN

--- a/sunbeam-python/tests/unit/sunbeam/core/test_role_assignments.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_role_assignments.py
@@ -9,40 +9,7 @@ from sunbeam.core.role_assignments import (
 )
 
 
-def test_microovn_role_mapping_without_split_roles_assigns_compute_gateways():
-    client = _client_with_nodes(
-        {
-            "control": [{"machineid": "0", "role": ["control"]}],
-            "compute": [
-                {"machineid": "1", "role": ["compute"]},
-                {"machineid": "2", "role": ["compute", "network"]},
-            ],
-            "network": [{"machineid": "2", "role": ["compute", "network"]}],
-        }
-    )
-
-    mapping = build_microovn_role_mapping(
-        client,
-        model_name="openstack-machines",
-        split_roles=False,
-        machine_ids=["0", "1", "2"],
-        assign_central_roles=True,
-    )
-
-    assert mapping == {
-        "openstack-machines": {
-            "microovn": {
-                "machines": {
-                    "0": {"roles": ["chassis", "central"]},
-                    "1": {"roles": ["chassis", "gateway"]},
-                    "2": {"roles": ["chassis", "gateway"]},
-                }
-            }
-        }
-    }
-
-
-def test_microovn_role_mapping_with_split_roles_keeps_gateways_on_network_nodes():
+def test_microovn_role_mapping_keeps_gateways_on_network_nodes():
     client = _client_with_nodes(
         {
             "control": [{"machineid": "0", "role": ["control"]}],
@@ -54,7 +21,6 @@ def test_microovn_role_mapping_with_split_roles_keeps_gateways_on_network_nodes(
     mapping = build_microovn_role_mapping(
         client,
         model_name="openstack-machines",
-        split_roles=True,
         machine_ids=["0", "1", "2"],
         assign_central_roles=True,
     )
@@ -78,7 +44,6 @@ def test_microovn_role_mapping_filters_to_actual_microovn_machines():
     mapping = build_microovn_role_mapping(
         client,
         model_name="openstack-machines",
-        split_roles=False,
         machine_ids=["2"],
         assign_central_roles=True,
     )
@@ -100,7 +65,6 @@ def test_microovn_role_mapping_can_disable_central_roles():
     mapping = build_microovn_role_mapping(
         client,
         model_name="openstack-machines",
-        split_roles=True,
         machine_ids=["0"],
         assign_central_roles=False,
     )
@@ -122,7 +86,6 @@ def test_microovn_role_mapping_allows_central_and_gateway_for_provider_microovn(
     mapping = build_microovn_role_mapping(
         client,
         model_name="openstack-machines",
-        split_roles=True,
         machine_ids=["0"],
         assign_central_roles=True,
     )

--- a/sunbeam-python/tests/unit/sunbeam/provider/local/test_commands.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/local/test_commands.py
@@ -146,19 +146,8 @@ class TestAddNodeGrantModels:
 
 
 class TestJoinNodeValidation:
-    """Test join validation behavior for gated roles."""
+    """Test join validation behavior for role combinations."""
 
-    @pytest.mark.parametrize(
-        ("split_roles_in_cluster", "expected_exception", "expected_message"),
-        [
-            (
-                False,
-                click.ClickException,
-                "feature\\.split-roles is not enabled in cluster state",
-            ),
-            (True, RuntimeError, "after-validation"),
-        ],
-    )
     @patch("sunbeam.provider.local.commands.read_config")
     @patch("sunbeam.provider.local.commands.DeploymentsConfig.load")
     @patch("sunbeam.provider.local.commands.deployment_path", return_value="/tmp")
@@ -175,10 +164,8 @@ class TestJoinNodeValidation:
     )
     @patch("sunbeam.provider.local.commands.run_plan")
     @patch("sunbeam.provider.local.commands.run_preflight_checks")
-    @patch("sunbeam.provider.local.commands.get_feature_gate_from_cluster")
     def test_join_validates_compute_and_network_after_cluster_join(
         self,
-        _get_feature_gate_from_cluster,
         run_preflight_checks,
         run_plan,
         _get_local_cidr_matching_token,
@@ -189,23 +176,18 @@ class TestJoinNodeValidation:
         _deployment_path,
         deployments_load,
         read_config,
-        split_roles_in_cluster,
-        expected_exception,
-        expected_message,
     ):
-        """Join should validate compute+network against cluster split-roles state."""
+        """Join should allow compute+network roles."""
         deployment = Mock()
         deployment.get_client.return_value = Mock()
         deployment.juju_controller = Mock()
         deployment.juju_account = Mock()
         deployments_load.return_value = Mock()
         snap_cls.return_value.paths.user_data = "/tmp"
-        _get_feature_gate_from_cluster.return_value = split_roles_in_cluster
-        if split_roles_in_cluster:
-            read_config.side_effect = RuntimeError("after-validation")
+        read_config.side_effect = RuntimeError("after-validation")
 
         ctx = click.Context(join, obj=deployment)
-        with ctx, pytest.raises(expected_exception, match=expected_message):
+        with ctx, pytest.raises(RuntimeError, match="after-validation"):
             join.callback(
                 token="token",
                 roles=[Role.COMPUTE, Role.NETWORK],

--- a/sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
@@ -330,6 +330,24 @@ class TestLocalSetHypervisorUnitsOptionsStep(BaseTestSetHypervisorUnitsOptionsSt
         machine_name = self.get_machine_name()
         assert step.bridge_mappings[machine_name] == "br-physnet1:physnet1:ens1f0"
 
+    def test_network_agents_prompt_skips_compute_only_host(self):
+        self.load_answers.return_value = {"user": {"remote_access_location": "remote"}}
+        self.cclient.cluster.get_node_info.return_value = {
+            "role": ["compute"],
+        }
+        step = local_steps.LocalSetOpenStackNetworkAgentsStep(
+            self.cclient,
+            "maas0.local",
+            self.jhelper,
+            "test-model",
+        )
+
+        with patch.object(nic_utils, "fetch_nics_from_subordinate") as fetch_nics:
+            step.prompt()
+
+        assert step.bridge_mappings["maas0.local"] is None
+        fetch_nics.assert_not_called()
+
 
 class TestLocalClusterStatusStep:
     def test_run(self, deployment, jhelper, step_context):

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/conftest.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/conftest.py
@@ -3,8 +3,6 @@
 
 from unittest.mock import patch
 
-import pytest
-
 
 def pytest_configure(config):
     """Patch is_feature_gate_enabled during import of MAAS modules.
@@ -24,14 +22,3 @@ def pytest_configure(config):
         import sunbeam.provider.maas.steps  # noqa: F401
     finally:
         patcher.stop()
-
-
-@pytest.fixture(autouse=True)
-def _mock_split_roles_disabled():
-    """Default split_roles_enabled to False for all MAAS tests.
-
-    Tests that need split-roles enabled should override this
-    with their own @patch decorator.
-    """
-    with patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=False):
-        yield

--- a/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/maas/test_maas.py
@@ -13,11 +13,13 @@ from lightkube import ApiError
 from maas.client.bones import CallError
 
 import sunbeam.provider.maas.steps as maas_steps
+from sunbeam.core import ovn
 from sunbeam.core.checks import DiagnosticResultType
 from sunbeam.core.deployment import Networks
 from sunbeam.core.deployments import DeploymentsConfig
 from sunbeam.core.juju import ControllerNotFoundException
 from sunbeam.provider.maas.commands import (
+    configure_cmd,
     remove_node,
     validate_deployment_cmd,
     validate_machine_cmd,
@@ -60,6 +62,82 @@ from sunbeam.steps.role_distributor import (
     ReapplyRoleDistributorApplicationStep,
     RemoveRoleDistributorUnitsStep,
 )
+
+
+class TestMaasConfigureCommand:
+    @pytest.mark.parametrize(
+        "provider,expected_names",
+        [
+            (ovn.OvnProvider.OVN_K8S, ["net-1"]),
+            (
+                ovn.OvnProvider.MICROOVN,
+                ["net-1", "compute-1", "control-1"],
+            ),
+        ],
+    )
+    def test_network_agents_match_ovn_provider(
+        self,
+        mocker,
+        tmp_path,
+        provider,
+        expected_names,
+    ):
+        client = Mock()
+        nodes_by_role = {
+            RoleTags.NETWORK.value: [{"name": "net-1"}],
+            RoleTags.COMPUTE.value: [{"name": "compute-1"}],
+            RoleTags.CONTROL.value: [{"name": "control-1"}],
+        }
+        client.cluster.list_nodes_by_role.side_effect = nodes_by_role.__getitem__
+
+        tfhelper = Mock()
+        tfhelper.env = {}
+        tfhelper.path = tmp_path
+
+        ovn_manager = Mock()
+        ovn_manager.get_provider.return_value = provider
+
+        deployment = Mock()
+        deployment.get_client.return_value = client
+        deployment.get_manifest.return_value = Mock(core={}, features={})
+        deployment.get_tfhelper.return_value = tfhelper
+        deployment.get_ovn_manager.return_value = ovn_manager
+        deployment.juju_controller = "controller"
+        deployment.juju_account = "account"
+        deployment.openstack_machines_model = "openstack-machines"
+
+        jhelper = Mock()
+        jhelper.model_exists.return_value = True
+
+        mocker.patch("sunbeam.provider.maas.commands.run_preflight_checks")
+        mocker.patch(
+            "sunbeam.provider.maas.commands.MaasClient.from_deployment",
+            return_value=Mock(),
+        )
+        mocker.patch("sunbeam.provider.maas.commands.JujuHelper", return_value=jhelper)
+        mocker.patch(
+            "sunbeam.provider.maas.commands.retrieve_admin_credentials",
+            return_value={
+                "OS_AUTH_URL": "https://keystone.example.com",
+                "OS_AUTH_VERSION": "3",
+            },
+        )
+        run_plan = mocker.patch("sunbeam.provider.maas.commands.run_plan")
+        mocker.patch(
+            "sunbeam.provider.maas.commands.retrieve_dashboard_url",
+            return_value="https://horizon.example.com",
+        )
+
+        result = CliRunner().invoke(configure_cmd, obj=deployment)
+
+        assert result.exit_code == 0, result.output
+        plan = run_plan.call_args.args[0]
+        network_agents_step = next(
+            step
+            for step in plan
+            if isinstance(step, maas_steps.MaasSetOpenStackNetworkAgentsStep)
+        )
+        assert network_agents_step.names == expected_names
 
 
 class TestAddMaasDeployment:
@@ -430,11 +508,9 @@ class TestMachineComputeNicCheck:
         }
         check = MachineComputeNicCheck(machine)
         result = check.run()
-        assert result.passed is DiagnosticResultType.FAILURE
+        assert result.passed is DiagnosticResultType.SUCCESS
         assert result.details["machine"] == "test_machine"
-        assert result.message and "no neutron NIC found" in result.message
-        assert result.diagnostics
-        assert "https://maas.io/docs/how-to-use-network-tags" in result.diagnostics
+        assert result.message and "not required" in result.message
 
     def test_run_with_neutron_nic(self):
         machine = {
@@ -444,12 +520,12 @@ class TestMachineComputeNicCheck:
         }
         check = MachineComputeNicCheck(machine)
         result = check.run()
-        assert result.passed is DiagnosticResultType.SUCCESS
+        assert result.passed is DiagnosticResultType.WARNING
         assert result.details["machine"] == "test_machine"
-        assert result.message and "neutron NIC found" in result.message
+        assert result.message and "will be ignored" in result.message
 
     def test_run_with_different_physnet_tag(self):
-        """Any neutron:<physnet> tag should be accepted."""
+        """Any compute-only neutron:<physnet> tag should warn."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.COMPUTE.value],
@@ -457,7 +533,7 @@ class TestMachineComputeNicCheck:
         }
         check = MachineComputeNicCheck(machine)
         result = check.run()
-        assert result.passed is DiagnosticResultType.SUCCESS
+        assert result.passed is DiagnosticResultType.WARNING
 
 
 class TestMachineRootDiskCheck:
@@ -2172,18 +2248,25 @@ class TestMachineComputeNicCheckNetworkNode:
         assert result.details["machine"] == "test_machine"
         assert result.message and "no neutron NIC found" in result.message
 
-    def test_run_with_compute_and_network_both_need_nic(self):
-        """Both compute and network nodes require a neutron NIC."""
-        for role in [RoleTags.COMPUTE.value, RoleTags.NETWORK.value]:
-            machine = {
-                "hostname": f"test_machine_{role}",
-                "roles": [role],
-                "nics": [{"name": "eth1", "tags": ["neutron:physnet1"]}],
-            }
-            check = MachineComputeNicCheck(machine)
-            result = check.run()
-            assert result.passed is DiagnosticResultType.SUCCESS
-            assert result.message and "neutron NIC found" in result.message
+    def test_run_with_compute_role_warns_and_network_role_passes_with_nic(self):
+        """Only network nodes require and consume a neutron NIC."""
+        compute_machine = {
+            "hostname": "test_machine_compute",
+            "roles": [RoleTags.COMPUTE.value],
+            "nics": [{"name": "eth1", "tags": ["neutron:physnet1"]}],
+        }
+        compute_result = MachineComputeNicCheck(compute_machine).run()
+        assert compute_result.passed is DiagnosticResultType.WARNING
+        assert compute_result.message and "will be ignored" in compute_result.message
+
+        network_machine = {
+            "hostname": "test_machine_network",
+            "roles": [RoleTags.NETWORK.value],
+            "nics": [{"name": "eth1", "tags": ["neutron:physnet1"]}],
+        }
+        network_result = MachineComputeNicCheck(network_machine).run()
+        assert network_result.passed is DiagnosticResultType.SUCCESS
+        assert network_result.message and "neutron NIC found" in network_result.message
 
     def test_run_with_network_node_different_physnet(self):
         """Network node with any neutron:<physnet> tag should pass."""
@@ -2197,12 +2280,11 @@ class TestMachineComputeNicCheckNetworkNode:
         assert result.passed is DiagnosticResultType.SUCCESS
 
 
-class TestMachineComputeNicCheckSplitRoles:
-    """Test MachineComputeNicCheck behavior when feature.split-roles is enabled."""
+class TestMachineComputeNicCheckDefaultRoles:
+    """Test MachineComputeNicCheck behavior with default role separation."""
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_compute_only_no_nic_success(self, mock_split):
-        """Split-roles ON + compute-only node without NIC → SUCCESS."""
+    def test_compute_only_no_nic_success(self):
+        """Compute-only node without NIC succeeds."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.COMPUTE.value],
@@ -2213,9 +2295,8 @@ class TestMachineComputeNicCheckSplitRoles:
         assert result.passed is DiagnosticResultType.SUCCESS
         assert result.message and "not required" in result.message
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_compute_only_with_nic_warns(self, mock_split):
-        """Split-roles ON + compute-only with neutron NIC → WARNING."""
+    def test_compute_only_with_nic_warns(self):
+        """Compute-only node with neutron NIC warns."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.COMPUTE.value],
@@ -2226,9 +2307,8 @@ class TestMachineComputeNicCheckSplitRoles:
         assert result.passed is DiagnosticResultType.WARNING
         assert result.message and "will be ignored" in result.message
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_network_node_no_nic_failure(self, mock_split):
-        """Split-roles ON + network node without NIC → FAILURE."""
+    def test_network_node_no_nic_failure(self):
+        """Network node without NIC fails."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.NETWORK.value],
@@ -2238,9 +2318,8 @@ class TestMachineComputeNicCheckSplitRoles:
         result = check.run()
         assert result.passed is DiagnosticResultType.FAILURE
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_network_node_with_nic_success(self, mock_split):
-        """Split-roles ON + network node with NIC → SUCCESS."""
+    def test_network_node_with_nic_success(self):
+        """Network node with NIC succeeds."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.NETWORK.value],
@@ -2250,9 +2329,8 @@ class TestMachineComputeNicCheckSplitRoles:
         result = check.run()
         assert result.passed is DiagnosticResultType.SUCCESS
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_compute_network_with_nic_success(self, mock_split):
-        """Split-roles ON + compute+network node with NIC → SUCCESS."""
+    def test_compute_network_with_nic_success(self):
+        """Compute+network node with NIC succeeds."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.COMPUTE.value, RoleTags.NETWORK.value],
@@ -2262,9 +2340,8 @@ class TestMachineComputeNicCheckSplitRoles:
         result = check.run()
         assert result.passed is DiagnosticResultType.SUCCESS
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_compute_network_no_nic_failure(self, mock_split):
-        """Split-roles ON + compute+network node without NIC → FAILURE."""
+    def test_compute_network_no_nic_failure(self):
+        """Compute+network node without NIC fails."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.COMPUTE.value, RoleTags.NETWORK.value],
@@ -2274,9 +2351,8 @@ class TestMachineComputeNicCheckSplitRoles:
         result = check.run()
         assert result.passed is DiagnosticResultType.FAILURE
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_control_only_success(self, mock_split):
-        """Split-roles ON + control-only node → SUCCESS."""
+    def test_control_only_success(self):
+        """Control-only node succeeds."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.CONTROL.value],
@@ -2286,9 +2362,8 @@ class TestMachineComputeNicCheckSplitRoles:
         result = check.run()
         assert result.passed is DiagnosticResultType.SUCCESS
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_control_with_nic_warns(self, mock_split):
-        """Split-roles ON + control-only with neutron NIC → WARNING."""
+    def test_control_with_nic_warns(self):
+        """Control-only node with neutron NIC warns."""
         machine = {
             "hostname": "test_machine",
             "roles": [RoleTags.CONTROL.value],
@@ -2299,36 +2374,11 @@ class TestMachineComputeNicCheckSplitRoles:
         assert result.passed is DiagnosticResultType.WARNING
         assert result.message and "will be ignored" in result.message
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_on_no_roles_failure(self, mock_split):
-        """Split-roles ON + no roles → FAILURE."""
+    def test_no_roles_failure(self):
+        """Machine with no roles fails."""
         machine = {
             "hostname": "test_machine",
             "roles": [],
-            "nics": [{"name": "eth0", "tags": []}],
-        }
-        check = MachineComputeNicCheck(machine)
-        result = check.run()
-        assert result.passed is DiagnosticResultType.FAILURE
-
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=False)
-    def test_split_roles_off_compute_only_no_nic_failure(self, mock_split):
-        """Split-roles OFF + compute-only without NIC → FAILURE."""
-        machine = {
-            "hostname": "test_machine",
-            "roles": [RoleTags.COMPUTE.value],
-            "nics": [{"name": "eth0", "tags": []}],
-        }
-        check = MachineComputeNicCheck(machine)
-        result = check.run()
-        assert result.passed is DiagnosticResultType.FAILURE
-
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=False)
-    def test_split_roles_off_network_only_no_nic_failure(self, mock_split):
-        """Split-roles OFF + network-only without NIC → FAILURE."""
-        machine = {
-            "hostname": "test_machine",
-            "roles": [RoleTags.NETWORK.value],
             "nics": [{"name": "eth0", "tags": []}],
         }
         check = MachineComputeNicCheck(machine)
@@ -2376,8 +2426,7 @@ class TestMachineComputeNicCheckMultiPhysnet:
         result = check.run()
         assert result.passed is DiagnosticResultType.FAILURE
 
-    @patch("sunbeam.provider.maas.steps.split_roles_enabled", return_value=True)
-    def test_split_roles_compute_with_physnet2_warns(self, mock_split):
+    def test_compute_with_physnet2_warns(self):
         """Compute-only with neutron:physnet2 warns (NIC ignored)."""
         machine = {
             "hostname": "test_machine",

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_configure.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_configure.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -150,11 +150,54 @@ class BaseTestSetHypervisorUnitsOptionsStep:
         step = self.get_step()
         assert step.has_prompts()
 
+    def test_run_compute_only_does_not_send_gateway_flag(self, step_context):
+        name = self.get_machine_name()
+        self.cclient.cluster.get_node_info.return_value = {
+            "machineid": 1,
+            "role": ["compute"],
+        }
+        step = self.get_step()
+        step.names = [name]
+        step.get_unit = Mock(return_value="openstack-hypervisor/0")
+        step.bridge_mappings = {name: "br-physnet1:physnet1:eth2"}
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        self.jhelper.run_action.assert_called_once_with(
+            "openstack-hypervisor/0",
+            "test-model",
+            "set-hypervisor-local-settings",
+            action_params={},
+        )
+
+    def test_run_network_node_sends_only_bridge_mapping(self, step_context):
+        name = self.get_machine_name()
+        self.cclient.cluster.get_node_info.return_value = {
+            "machineid": 1,
+            "role": ["network"],
+        }
+        step = self.get_step()
+        step.names = [name]
+        step.get_unit = Mock(return_value="openstack-hypervisor/0")
+        step.bridge_mappings = {name: "br-physnet1:physnet1:eth2"}
+
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        self.jhelper.run_action.assert_called_once_with(
+            "openstack-hypervisor/0",
+            "test-model",
+            "set-hypervisor-local-settings",
+            action_params={"bridge-mapping": "br-physnet1:physnet1:eth2"},
+        )
+
 
 class _TestableStep(SetExternalNetworkUnitsOptionsStep):
     APP = "openstack-network-agents"
     DISPLAY_NAME = "OpenStack Network Agents"
     ACTION = "set-network-agents-local-settings"
+    SUPPORTS_CHASSIS_AS_GW = True
 
     def get_unit(self, name: str) -> str:
         raise NotImplementedError
@@ -174,51 +217,8 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
         step.get_unit = MagicMock(return_value="openstack-network-agents/0")
         return step
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=False)
-    def test_split_roles_off_with_bridge_mapping(
-        self, mock_split, cclient, jhelper, step_context
-    ):
-        cclient.cluster.get_node_info.return_value = {
-            "machineid": 1,
-            "role": ["network"],
-        }
-        step = self._make_step(cclient, jhelper, ["node1"])
-        step.bridge_mappings = {"node1": "br-physnet1:physnet1:eth2"}
-
-        result = step.run(step_context)
-
-        assert result.result_type == ResultType.COMPLETED
-        jhelper.run_action.assert_called_once_with(
-            "openstack-network-agents/0",
-            "openstack",
-            "set-network-agents-local-settings",
-            action_params={"bridge-mapping": "br-physnet1:physnet1:eth2"},
-        )
-
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=False)
-    def test_split_roles_off_no_bridge_mapping_skipped(
+    def test_network_node_with_bridge(
         self,
-        mock_split,
-        cclient,
-        jhelper,
-        step_context,
-    ):
-        cclient.cluster.get_node_info.return_value = {
-            "machineid": 1,
-            "role": ["network"],
-        }
-        step = self._make_step(cclient, jhelper, ["node1"])
-        step.bridge_mappings = {}
-
-        result = step.run(step_context)
-
-        assert result.result_type == ResultType.COMPLETED
-        jhelper.run_action.assert_not_called()
-
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_split_roles_on_network_node_with_bridge(
-        self,
-        mock_split,
         cclient,
         jhelper,
         step_context,
@@ -243,10 +243,8 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
             },
         )
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_split_roles_on_compute_only_with_bridge(
+    def test_compute_only_with_bridge(
         self,
-        mock_split,
         cclient,
         jhelper,
         step_context,
@@ -271,10 +269,7 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
             },
         )
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_split_roles_on_compute_only_no_bridge(
-        self, mock_split, cclient, jhelper, step_context
-    ):
+    def test_compute_only_no_bridge(self, cclient, jhelper, step_context):
         cclient.cluster.get_node_info.return_value = {
             "machineid": 3,
             "role": ["compute"],
@@ -292,10 +287,7 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
             action_params={"enable-chassis-as-gw": False},
         )
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_split_roles_on_control_only_no_bridge(
-        self, mock_split, cclient, jhelper, step_context
-    ):
+    def test_control_only_no_bridge(self, cclient, jhelper, step_context):
         cclient.cluster.get_node_info.return_value = {
             "machineid": 4,
             "role": ["control"],
@@ -313,10 +305,8 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
             action_params={"enable-chassis-as-gw": False},
         )
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_split_roles_on_control_only_with_bridge_stripped(
+    def test_control_only_with_bridge_stripped(
         self,
-        mock_split,
         cclient,
         jhelper,
         step_context,
@@ -339,10 +329,8 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
             action_params={"enable-chassis-as-gw": False},
         )
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_split_roles_on_compute_network_with_bridge(
+    def test_compute_network_with_bridge(
         self,
-        mock_split,
         cclient,
         jhelper,
         step_context,
@@ -367,10 +355,7 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
             },
         )
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_split_roles_on_multiple_mixed_nodes(
-        self, mock_split, cclient, jhelper, step_context
-    ):
+    def test_multiple_mixed_nodes(self, cclient, jhelper, step_context):
         node_info = {
             "net-node": {"machineid": 1, "role": ["network"]},
             "compute-node": {"machineid": 2, "role": ["compute"]},
@@ -430,10 +415,7 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
             }
         }
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_action_fails_returns_failed(
-        self, mock_split, cclient, jhelper, step_context
-    ):
+    def test_action_fails_returns_failed(self, cclient, jhelper, step_context):
         cclient.cluster.get_node_info.return_value = {
             "machineid": 1,
             "role": ["network"],
@@ -446,10 +428,8 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
 
         assert result.result_type == ResultType.FAILED
 
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=True)
-    def test_split_roles_multi_physnet_different_hosts(
+    def test_multi_physnet_different_hosts(
         self,
-        mock_split,
         cclient,
         jhelper,
         step_context,
@@ -486,46 +466,5 @@ class TestSetExternalNetworkUnitsOptionsStepRun:
             "action_params": {
                 "bridge-mapping": "br-physnet2:physnet2:eth3",
                 "enable-chassis-as-gw": True,
-            }
-        }
-
-    @patch("sunbeam.feature_gates.split_roles_enabled", return_value=False)
-    def test_no_split_roles_multi_physnet_different_hosts(
-        self,
-        mock_split,
-        cclient,
-        jhelper,
-        step_context,
-    ):
-        """Without split-roles, different physnets still work."""
-        node_info = {
-            "node-a": {"machineid": 1, "role": ["compute", "network"]},
-            "node-b": {"machineid": 2, "role": ["compute", "network"]},
-        }
-        cclient.cluster.get_node_info.side_effect = lambda n: node_info[n]
-        units = {
-            "node-a": "openstack-network-agents/0",
-            "node-b": "openstack-network-agents/1",
-        }
-        step = self._make_step(cclient, jhelper, ["node-a", "node-b"])
-        step.get_unit = MagicMock(side_effect=lambda n: units[n])
-        step.bridge_mappings = {
-            "node-a": "br-physnet1:physnet1:eth2",
-            "node-b": "br-physnet2:physnet2:eth3",
-        }
-
-        result = step.run(step_context)
-
-        assert result.result_type == ResultType.COMPLETED
-        assert jhelper.run_action.call_count == 2
-        calls = jhelper.run_action.call_args_list
-        assert calls[0].kwargs == {
-            "action_params": {
-                "bridge-mapping": "br-physnet1:physnet1:eth2",
-            }
-        }
-        assert calls[1].kwargs == {
-            "action_params": {
-                "bridge-mapping": "br-physnet2:physnet2:eth3",
             }
         }

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_microovn.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_microovn.py
@@ -59,6 +59,24 @@ class TestDeployMicroOVNApplicationStep:
         timeout = deploy_microovn_step.get_application_timeout()
         assert timeout == 1200
 
+    def test_get_accepted_application_status_allows_blocked_for_ovn_k8s(
+        self, deploy_microovn_step, ovn_manager
+    ):
+        ovn_manager.get_provider.return_value = ovn.OvnProvider.OVN_K8S
+
+        statuses = deploy_microovn_step.get_accepted_application_status()
+
+        assert statuses == ["active", "unknown", "blocked"]
+
+    def test_get_accepted_application_status_excludes_blocked_for_microovn_provider(
+        self, deploy_microovn_step, ovn_manager
+    ):
+        ovn_manager.get_provider.return_value = ovn.OvnProvider.MICROOVN
+
+        statuses = deploy_microovn_step.get_accepted_application_status()
+
+        assert statuses == ["active", "unknown"]
+
     def test_extra_tfvars(
         self,
         deploy_microovn_step,
@@ -335,6 +353,52 @@ class TestReapplyMicroOVNTerraformPlanStep:
                 "charm_openstack_network_agents_config"
             ]["external-bridge-address"]
             == "10.0.0.1/24"
+        )
+
+    def test_run_allows_blocked_status_for_ovn_k8s(
+        self,
+        reapply_microovn_terraform_step,
+        basic_jhelper,
+        step_context,
+    ):
+        reapply_microovn_terraform_step.ovn_manager.get_provider.return_value = (
+            ovn.OvnProvider.OVN_K8S
+        )
+
+        with patch(
+            "sunbeam.steps.microovn.get_external_network_configs", return_value={}
+        ):
+            result = reapply_microovn_terraform_step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.wait_application_ready.assert_called_once_with(
+            "microovn",
+            "test-model",
+            accepted_status=["active", "unknown", "blocked"],
+            timeout=1200,
+        )
+
+    def test_run_excludes_blocked_status_for_microovn_provider(
+        self,
+        reapply_microovn_terraform_step,
+        basic_jhelper,
+        step_context,
+    ):
+        reapply_microovn_terraform_step.ovn_manager.get_provider.return_value = (
+            ovn.OvnProvider.MICROOVN
+        )
+
+        with patch(
+            "sunbeam.steps.microovn.get_external_network_configs", return_value={}
+        ):
+            result = reapply_microovn_terraform_step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        basic_jhelper.wait_application_ready.assert_called_once_with(
+            "microovn",
+            "test-model",
+            accepted_status=["active", "unknown"],
+            timeout=1200,
         )
 
 

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_microovn.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_microovn.py
@@ -339,45 +339,27 @@ class TestReapplyMicroOVNTerraformPlanStep:
 
 
 class TestSetOvnProviderStep:
-    def test_get_config_from_snap_feature_gate_disabled(self, basic_client):
-        """Test get_config_from_snap when feature gate is disabled."""
-        mock_snap = Mock()
-        mock_snap.config.get.return_value = "microovn"
-        step = SetOvnProviderStep(basic_client, mock_snap)
-
-        with patch("sunbeam.steps.microovn.is_feature_gate_enabled") as mock_gate:
-            mock_gate.return_value = False
-            result = step.get_config_from_snap(mock_snap)
-            assert result == ovn.DEFAULT_PROVIDER
-            mock_gate.assert_called_once_with("feature.microovn-sdn", mock_snap)
-
-    def test_get_config_from_snap_feature_gate_enabled_provider_not_set(
-        self, basic_client
-    ):
-        """Test get_config_from_snap when gate enabled but no provider."""
+    def test_get_config_from_snap_provider_not_set(self, basic_client):
+        """Test get_config_from_snap when no provider is configured."""
         mock_snap = Mock()
         mock_snap.config.get.return_value = None
         step = SetOvnProviderStep(basic_client, mock_snap)
 
-        with patch("sunbeam.steps.microovn.is_feature_gate_enabled") as mock_gate:
-            mock_gate.return_value = True
-            result = step.get_config_from_snap(mock_snap)
-            assert result == ovn.DEFAULT_PROVIDER
-            mock_gate.assert_called_once_with("feature.microovn-sdn", mock_snap)
+        result = step.get_config_from_snap(mock_snap)
 
-    def test_get_config_from_snap_feature_gate_enabled_provider_microovn(
-        self, basic_client
-    ):
-        """Test get_config_from_snap when both gate enabled and provider set."""
+        assert result == ovn.DEFAULT_PROVIDER
+        mock_snap.config.get.assert_called_once_with(ovn.SNAP_PROVIDER_CONFIG_KEY)
+
+    def test_get_config_from_snap_provider_microovn(self, basic_client):
+        """Test get_config_from_snap when provider is set to microovn."""
         mock_snap = Mock()
         mock_snap.config.get.return_value = ovn.OvnProvider.MICROOVN
         step = SetOvnProviderStep(basic_client, mock_snap)
 
-        with patch("sunbeam.steps.microovn.is_feature_gate_enabled") as mock_gate:
-            mock_gate.return_value = True
-            result = step.get_config_from_snap(mock_snap)
-            assert result == ovn.OvnProvider.MICROOVN
-            mock_gate.assert_called_once_with("feature.microovn-sdn", mock_snap)
+        result = step.get_config_from_snap(mock_snap)
+
+        assert result == ovn.OvnProvider.MICROOVN
+        mock_snap.config.get.assert_called_once_with(ovn.SNAP_PROVIDER_CONFIG_KEY)
 
     def test_get_config_from_snap_unknown_config_key(self, basic_client):
         """Test get_config_from_snap when snap config key doesn't exist."""
@@ -387,10 +369,9 @@ class TestSetOvnProviderStep:
         mock_snap.config.get.side_effect = UnknownConfigKey("ovn.provider")
         step = SetOvnProviderStep(basic_client, mock_snap)
 
-        with patch("sunbeam.steps.microovn.is_feature_gate_enabled") as mock_gate:
-            mock_gate.return_value = True
-            result = step.get_config_from_snap(mock_snap)
-            assert result == ovn.DEFAULT_PROVIDER
+        result = step.get_config_from_snap(mock_snap)
+
+        assert result == ovn.DEFAULT_PROVIDER
 
     def test_get_config_from_snap_invalid_provider_value(self, basic_client):
         """Test get_config_from_snap with invalid provider value raises error."""
@@ -398,13 +379,11 @@ class TestSetOvnProviderStep:
         mock_snap.config.get.return_value = "invalid-provider"
         step = SetOvnProviderStep(basic_client, mock_snap)
 
-        with patch("sunbeam.steps.microovn.is_feature_gate_enabled") as mock_gate:
-            mock_gate.return_value = True
-            with pytest.raises(ValueError) as exc_info:
-                step.get_config_from_snap(mock_snap)
-            assert "Invalid value 'invalid-provider'" in str(exc_info.value)
-            assert "ovn.provider" in str(exc_info.value)
-            assert "Valid values are:" in str(exc_info.value)
+        with pytest.raises(ValueError) as exc_info:
+            step.get_config_from_snap(mock_snap)
+        assert "Invalid value 'invalid-provider'" in str(exc_info.value)
+        assert "ovn.provider" in str(exc_info.value)
+        assert "Valid values are:" in str(exc_info.value)
 
     def test_is_skip(self, basic_client, step_context):
         """Test is_skip method."""

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_role_distributor.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_role_distributor.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 - Canonical Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import yaml
 
@@ -24,10 +24,8 @@ def test_role_distributor_config_is_not_generic_manifest_tfvar():
 
 
 class TestDeployRoleDistributorApplicationStep:
-    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=True)
     def test_extra_tfvars_emits_role_mapping_config(
         self,
-        split_roles_enabled,
         basic_deployment,
         basic_client,
         basic_tfhelper,
@@ -64,12 +62,9 @@ class TestDeployRoleDistributorApplicationStep:
             "2": {"roles": ["chassis", "gateway"]},
         }
         assert extra_tfvars["role_distributor_machine_ids"] == ["0"]
-        split_roles_enabled.assert_called_once()
 
-    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=True)
     def test_extra_tfvars_does_not_assign_central_for_ovn_k8s(
         self,
-        split_roles_enabled,
         basic_deployment,
         basic_client,
         basic_tfhelper,
@@ -104,7 +99,6 @@ class TestDeployRoleDistributorApplicationStep:
         assert role_mapping["openstack-machines"]["microovn"]["machines"] == {
             "0": {"roles": ["chassis", "gateway"]},
         }
-        split_roles_enabled.assert_called_once()
 
     def test_get_accepted_application_status_allows_waiting(
         self,
@@ -229,10 +223,8 @@ class TestReapplyRoleDistributorApplicationStep:
             "openstack-machines",
         )
 
-    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=False)
     def test_run_skips_tf_apply_when_no_targets(
         self,
-        split_roles_enabled,
         basic_deployment,
         basic_client,
         basic_tfhelper,
@@ -255,12 +247,9 @@ class TestReapplyRoleDistributorApplicationStep:
         assert result.result_type == ResultType.SKIPPED
         basic_tfhelper.update_tfvars_and_apply_tf.assert_not_called()
         basic_jhelper.wait_application_ready.assert_not_called()
-        split_roles_enabled.assert_not_called()
 
-    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=False)
     def test_run_waits_for_role_distributor_when_targets_remain(
         self,
-        split_roles_enabled,
         basic_deployment,
         basic_client,
         basic_tfhelper,
@@ -300,16 +289,13 @@ class TestReapplyRoleDistributorApplicationStep:
             kwargs["override_tfvars"]["charm_role_distributor_config"]["role-mapping"]
         )
         assert role_mapping["openstack-machines"]["microovn"]["machines"] == {
-            "1": {"roles": ["chassis", "gateway"]},
+            "1": {"roles": ["chassis"]},
             "2": {"roles": ["chassis", "gateway"]},
         }
         assert kwargs["override_tfvars"]["role_distributor_machine_ids"] == ["0"]
-        split_roles_enabled.assert_called_once()
 
-    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=False)
     def test_run_relocates_to_remaining_control_machine(
         self,
-        split_roles_enabled,
         basic_deployment,
         basic_client,
         basic_tfhelper,
@@ -339,12 +325,9 @@ class TestReapplyRoleDistributorApplicationStep:
         assert result.result_type == ResultType.COMPLETED
         _, _, kwargs = basic_tfhelper.update_tfvars_and_apply_tf.mock_calls[0]
         assert kwargs["override_tfvars"]["role_distributor_machine_ids"] == ["2"]
-        split_roles_enabled.assert_called_once()
 
-    @patch("sunbeam.steps.role_distributor.split_roles_enabled", return_value=False)
     def test_run_fails_when_targets_exist_without_control_machine(
         self,
-        split_roles_enabled,
         basic_deployment,
         basic_client,
         basic_tfhelper,
@@ -372,7 +355,6 @@ class TestReapplyRoleDistributorApplicationStep:
         assert "control" in result.message
         basic_tfhelper.update_tfvars_and_apply_tf.assert_not_called()
         basic_jhelper.wait_application_ready.assert_not_called()
-        split_roles_enabled.assert_not_called()
 
 
 class TestRemoveRoleDistributorUnitsStep:

--- a/sunbeam-python/tests/unit/sunbeam/test_feature_gates.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_feature_gates.py
@@ -18,7 +18,6 @@ from sunbeam.feature_gates import (
     check_option_value,
     feature_gate_option_on_value,
     is_feature_gate_enabled,
-    split_roles_enabled,
     validate_feature_gate_config,
 )
 
@@ -730,49 +729,6 @@ class TestFeatureGatedChoice:
         assert result.lower() == "control"
 
 
-class TestSplitRolesEnabled:
-    """Test split_roles_enabled convenience function."""
-
-    def test_returns_true_when_enabled(self):
-        """Returns True when feature.split-roles is enabled via snap config."""
-        mock_snap = MagicMock()
-        mock_snap.config.get.return_value = True
-        assert split_roles_enabled(mock_snap) is True
-        mock_snap.config.get.assert_called_once_with("feature.split-roles")
-
-    def test_returns_false_when_not_set(self):
-        """Returns False when feature.split-roles is not set (UnknownConfigKey)."""
-        mock_snap = MagicMock()
-        mock_snap.config.get.side_effect = UnknownConfigKey("")
-        assert split_roles_enabled(mock_snap) is False
-
-    def test_returns_false_when_explicitly_false(self):
-        """Returns False when feature.split-roles is explicitly False."""
-        mock_snap = MagicMock()
-        mock_snap.config.get.return_value = False
-        assert split_roles_enabled(mock_snap) is False
-
-    @patch(
-        "sunbeam.feature_gates.FEATURE_GATES",
-        {
-            "feature.split-roles": {"generally_available": True},
-        },
-    )
-    def test_returns_true_when_generally_available(self):
-        """Returns True when feature.split-roles has generally_available=True."""
-        assert split_roles_enabled() is True
-
-    @patch("sunbeam.feature_gates.Snap")
-    def test_passes_snap_argument_through(self, mock_snap_cls):
-        """Passes snap argument through to is_feature_gate_enabled."""
-        mock_snap = MagicMock()
-        mock_snap.config.get.return_value = True
-        result = split_roles_enabled(mock_snap)
-        assert result is True
-        # Snap() should not be called when snap is provided
-        mock_snap_cls.assert_not_called()
-
-
 class TestValidateFeatureGateConfig:
     """Test validate_feature_gate_config dependency enforcement."""
 
@@ -791,11 +747,9 @@ class TestValidateFeatureGateConfig:
         mock_snap.config.get.side_effect = config_get
         return mock_snap
 
-    def test_valid_config_both_enabled(self):
-        """No error when split-roles and microovn-sdn are both enabled."""
-        snap = self._mock_snap_with_gates(
-            {"feature.split-roles": True, "feature.microovn-sdn": True}
-        )
+    def test_loadbalancer_amphora_no_longer_requires_microovn_sdn(self):
+        """Amphora gate does not depend on a retired gate."""
+        snap = self._mock_snap_with_gates({"feature.loadbalancer-amphora": True})
         validate_feature_gate_config(snap)
 
     def test_valid_config_no_gates_set(self):
@@ -803,59 +757,23 @@ class TestValidateFeatureGateConfig:
         snap = self._mock_snap_with_gates({})
         validate_feature_gate_config(snap)
 
-    def test_valid_config_dep_enabled_alone(self):
-        """No error when only microovn-sdn is enabled (no dependents)."""
-        snap = self._mock_snap_with_gates({"feature.microovn-sdn": True})
-        validate_feature_gate_config(snap)
-
-    def test_valid_config_both_disabled(self):
-        """No error when both gates are explicitly disabled."""
-        snap = self._mock_snap_with_gates(
-            {"feature.split-roles": False, "feature.microovn-sdn": False}
-        )
-        validate_feature_gate_config(snap)
-
-    def test_forward_dep_violation(self):
-        """Error when split-roles enabled without microovn-sdn."""
-        snap = self._mock_snap_with_gates({"feature.split-roles": True})
-        with pytest.raises(FeatureGateError, match="requires.*microovn-sdn"):
-            validate_feature_gate_config(snap)
-
-    def test_forward_dep_violation_explicit_false(self):
-        """Error when split-roles enabled but microovn-sdn explicitly False."""
-        snap = self._mock_snap_with_gates(
-            {"feature.split-roles": True, "feature.microovn-sdn": False}
-        )
-        with pytest.raises(FeatureGateError, match="requires.*microovn-sdn"):
-            validate_feature_gate_config(snap)
-
-    def test_reverse_dep_violation(self):
-        """Error when microovn-sdn disabled while split-roles still active.
-
-        This is caught as a forward violation: split-roles is enabled but
-        its dependency microovn-sdn is not.
-        """
-        snap = self._mock_snap_with_gates(
-            {"feature.split-roles": True, "feature.microovn-sdn": False}
-        )
-        with pytest.raises(FeatureGateError, match="split-roles.*requires"):
-            validate_feature_gate_config(snap)
-
-    def test_error_message_includes_both_gates(self):
-        """Error message mentions both the gate and its missing dependency."""
-        snap = self._mock_snap_with_gates({"feature.split-roles": True})
-        with pytest.raises(FeatureGateError) as exc_info:
-            validate_feature_gate_config(snap)
-        assert "feature.split-roles" in str(exc_info.value)
-        assert "feature.microovn-sdn" in str(exc_info.value)
-
     def test_is_sunbeam_exception(self):
         """FeatureGateError is a SunbeamException for CatchGroup handling."""
         from sunbeam.errors import SunbeamException
 
-        snap = self._mock_snap_with_gates({"feature.split-roles": True})
+        snap = self._mock_snap_with_gates({"feature.a": True})
         with pytest.raises(SunbeamException):
-            validate_feature_gate_config(snap)
+            with patch(
+                "sunbeam.feature_gates.FEATURE_GATES",
+                {
+                    "feature.a": {
+                        "generally_available": False,
+                        "requires": ["feature.b"],
+                    },
+                    "feature.b": {"generally_available": False},
+                },
+            ):
+                validate_feature_gate_config(snap)
 
     @patch(
         "sunbeam.feature_gates.FEATURE_GATES",

--- a/sunbeam-python/tests/unit/sunbeam/test_hooks.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_hooks.py
@@ -12,28 +12,13 @@ from sunbeam.hooks import (
 class TestCheckFeatureGateDependencies:
     """Tests for _check_feature_gate_dependencies."""
 
-    def test_split_roles_with_dependency_enabled(self):
-        """split-roles with microovn-sdn=True returns no missing deps."""
-        flattened = {"microovn-sdn": True}
-        result = _check_feature_gate_dependencies("feature.split-roles", flattened)
-        assert result == []
-
-    def test_split_roles_with_dependency_disabled(self):
-        """split-roles with microovn-sdn=False returns missing dep."""
-        flattened = {"microovn-sdn": False}
-        result = _check_feature_gate_dependencies("feature.split-roles", flattened)
-        assert result == ["feature.microovn-sdn"]
-
-    def test_split_roles_with_dependency_absent(self):
-        """split-roles with microovn-sdn absent returns missing dep."""
+    def test_loadbalancer_amphora_no_dependencies(self):
+        """loadbalancer-amphora has no retired dependency."""
         flattened = {}
-        result = _check_feature_gate_dependencies("feature.split-roles", flattened)
-        assert result == ["feature.microovn-sdn"]
-
-    def test_microovn_sdn_no_dependencies(self):
-        """microovn-sdn has no requires, returns empty list."""
-        flattened = {}
-        result = _check_feature_gate_dependencies("feature.microovn-sdn", flattened)
+        result = _check_feature_gate_dependencies(
+            "feature.loadbalancer-amphora",
+            flattened,
+        )
         assert result == []
 
     def test_multi_region_no_dependencies(self):
@@ -44,15 +29,9 @@ class TestCheckFeatureGateDependencies:
 
     def test_unknown_gate_key(self):
         """Unknown gate key returns empty list."""
-        flattened = {"microovn-sdn": True}
+        flattened = {"unknown": True}
         result = _check_feature_gate_dependencies("feature.nonexistent", flattened)
         assert result == []
-
-    def test_split_roles_with_dependency_none(self):
-        """split-roles with microovn-sdn=None returns missing dep (None is falsy)."""
-        flattened = {"microovn-sdn": None}
-        result = _check_feature_gate_dependencies("feature.split-roles", flattened)
-        assert result == ["feature.microovn-sdn"]
 
 
 class TestSyncFeatureGatesWithDependencies:
@@ -89,54 +68,16 @@ class TestSyncFeatureGatesWithDependencies:
         mock_snap.config.get_options.return_value = options
         return mock_snap
 
-    def test_enable_split_roles_with_microovn_enabled(self):
-        """Enabling split-roles when microovn-sdn is also enabled succeeds."""
+    def test_enable_loadbalancer_amphora_without_microovn_syncs(self):
+        """Amphora gate syncs without a retired dependency."""
         client = self._make_client()
-        snap = self._make_snap({"split-roles": True, "microovn-sdn": True})
-
-        sync_feature_gates_from_snap_to_cluster(client, snap)
-
-        # Both gates should be synced (added since they don't exist)
-        add_calls = client.cluster.add_feature_gate.call_args_list
-        added_keys = {call[0][0] for call in add_calls}
-        assert "feature.split-roles" in added_keys
-        assert "feature.microovn-sdn" in added_keys
-
-    def test_enable_split_roles_without_microovn_skipped(self):
-        """Enabling split-roles without microovn-sdn skips split-roles."""
-        client = self._make_client()
-        snap = self._make_snap({"split-roles": True, "microovn-sdn": False})
-
-        sync_feature_gates_from_snap_to_cluster(client, snap)
-
-        # split-roles should NOT be synced; microovn-sdn (False) should be synced
-        add_calls = client.cluster.add_feature_gate.call_args_list
-        added_keys = {call[0][0] for call in add_calls}
-        assert "feature.split-roles" not in added_keys
-        assert "feature.microovn-sdn" in added_keys
-
-    def test_enable_microovn_alone(self):
-        """Enabling microovn-sdn alone syncs normally (no deps)."""
-        client = self._make_client()
-        snap = self._make_snap({"microovn-sdn": True})
+        snap = self._make_snap({"loadbalancer-amphora": True})
 
         sync_feature_gates_from_snap_to_cluster(client, snap)
 
         add_calls = client.cluster.add_feature_gate.call_args_list
         assert len(add_calls) == 1
-        assert add_calls[0][0] == ("feature.microovn-sdn", True)
-
-    def test_disable_split_roles_syncs_normally(self):
-        """Disabling split-roles (False) syncs without checking deps."""
-        client = self._make_client()
-        snap = self._make_snap({"split-roles": False})
-
-        sync_feature_gates_from_snap_to_cluster(client, snap)
-
-        # Should be synced even without microovn-sdn in config
-        add_calls = client.cluster.add_feature_gate.call_args_list
-        assert len(add_calls) == 1
-        assert add_calls[0][0] == ("feature.split-roles", False)
+        assert add_calls[0][0] == ("feature.loadbalancer-amphora", True)
 
 
 class TestConfigureHookEnforcement:
@@ -163,32 +104,13 @@ class TestConfigureHookEnforcement:
         mock_snap.paths.data = MagicMock()
         return mock_snap
 
-    def test_configure_rejects_unmet_dependency(self):
-        """configure() raises when split-roles enabled without microovn-sdn."""
-        from unittest.mock import patch
-
-        import pytest
-
-        from sunbeam.feature_gates import FeatureGateError
-        from sunbeam.hooks import configure
-
-        snap = self._make_snap({"feature.split-roles": True})
-
-        with (
-            patch("sunbeam.hooks.setup_logging"),
-            pytest.raises(FeatureGateError, match="requires.*microovn-sdn"),
-        ):
-            configure(snap)
-
     def test_configure_accepts_valid_config(self):
         """configure() succeeds when dependencies are met."""
         from unittest.mock import patch
 
         from sunbeam.hooks import configure
 
-        snap = self._make_snap(
-            {"feature.split-roles": True, "feature.microovn-sdn": True}
-        )
+        snap = self._make_snap({"feature.loadbalancer-amphora": True})
 
         # Patch _sync and file operations to avoid side effects
         with (

--- a/sunbeam-python/uv.lock
+++ b/sunbeam-python/uv.lock
@@ -712,6 +712,15 @@ wheels = [
 ]
 
 [[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1000,6 +1009,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1046,6 +1064,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/38/12/49e56f952ec7d1425a27e15b286ac665b243eb0ed79ed35fc735c92d0167/fixtures-4.2.5.tar.gz", hash = "sha256:646a54035166aacd91b87126592449df1d1d4e376bb32db1816124785900493f", size = 48191, upload-time = "2025-04-17T10:48:24.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/90/ed632ce9bc6f683efe590d03fe3cbabffdca0514edabcdb24c7d5f2c336b/fixtures-4.2.5-py3-none-any.whl", hash = "sha256:578e2b9f32ec74ced2ad5fdbe8b6533364c34fd2c2dfa00c6ce7eb62cee32c9a", size = 64034, upload-time = "2025-04-17T10:48:23.394Z" },
+]
+
+[[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
 ]
 
 [[package]]
@@ -1174,6 +1206,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/f3/ef59cee614d5e0accf6fd0cbba025b93b272e626ca89fb70a3e9187c5d15/iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df", size = 6522, upload-time = "2023-10-03T00:25:39.317Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/0c/f37b6a241f0759b7653ffa7213889d89ad49a2b76eb2ddf3b57b2738c347/iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242", size = 7545, upload-time = "2023-10-03T00:25:32.304Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]
@@ -1366,6 +1407,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
     { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1898,6 +1948,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/dd/4dd87f290e035ffd211068db50b276f23b532cc2fc9464b4ee612f038034/pwgen-0.8.2.post0.tar.gz", hash = "sha256:4723279de6f2a5e8e1ab49374334c920d423c5e3d2c224ae5bf82b57b3ac2b3f", size = 2946, upload-time = "2017-08-01T13:50:59.893Z" }
 
 [[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1959,12 +2018,39 @@ wheels = [
 ]
 
 [[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/3bb57f303701549550d74bf7ced2b07412be97125c167a0c9d216aa9f762/pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5", size = 1585588, upload-time = "2026-06-14T14:43:26.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54", size = 538389, upload-time = "2026-06-14T14:43:24.873Z" },
 ]
 
 [[package]]
@@ -3051,6 +3137,10 @@ openstackclients = [
     { name = "setuptools-scm" },
     { name = "toml" },
 ]
+tics = [
+    { name = "flake8" },
+    { name = "pylint" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -3063,6 +3153,7 @@ requires-dist = [
     { name = "cython", marker = "extra == 'openstackclients'" },
     { name = "ddt", marker = "extra == 'dev'", specifier = ">=1.0.1" },
     { name = "fixtures", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "flake8", marker = "extra == 'tics'" },
     { name = "gnocchiclient", marker = "extra == 'openstackclients'" },
     { name = "jinja2" },
     { name = "jubilant", specifier = ">=1.3.0" },
@@ -3079,6 +3170,7 @@ requires-dist = [
     { name = "pexpect" },
     { name = "pwgen" },
     { name = "pydantic" },
+    { name = "pylint", marker = "extra == 'tics'" },
     { name = "pyroute2" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-mock", marker = "extra == 'dev'" },
@@ -3130,7 +3222,7 @@ requires-dist = [
     { name = "types-requests", marker = "extra == 'dev'" },
     { name = "wrapt", marker = "extra == 'dev'", specifier = ">=1.7.0" },
 ]
-provides-extras = ["openstackclients", "dev"]
+provides-extras = ["openstackclients", "dev", "tics"]
 
 [[package]]
 name = "tempest"


### PR DESCRIPTION
Remove feature.microovn-sdn and feature.split-roles from main. Both behaviours are now GA, so main no longer carries old paths. Make MicroOVN and split-role topology handling the default path across local and MAAS providers, role distribution, and external network configuration. Update unit tests for default-only behaviour and remove retired gate dependency checks.