### PR TITLE
Fix bug (#2157025): sunbeam cluster list reports invalid network roles when using split roles feature

### DIFF
--- a/sunbeam-python/sunbeam/steps/cluster_status.py
+++ b/sunbeam-python/sunbeam/steps/cluster_status.py
@@ -150,6 +150,30 @@ class ClusterStatusStep(abc.ABC, BaseStep):
             status[node] = _status.get("status")
         return status
 
+    def _get_node_roles_by_machine(self) -> dict[str, set[str]]:
+        """Return mapping of machine_id to set of assigned roles from clusterd.
+
+        Used to filter application-to-column mapping so that applications
+        deployed to multiple roles (e.g. microovn) only show in the column
+        corresponding to the node's actual assigned role.
+        """
+        client = self.deployment.get_client()
+        try:
+            nodes = client.cluster.list_nodes()
+        except ClusterServiceUnavailableException:
+            LOG.debug("Failed to fetch node roles", exc_info=True)
+            return {}
+        roles_by_machine: dict[str, set[str]] = {}
+        for node in nodes:
+            machine_id = node.get("machineid")
+            if machine_id in (-1, None):
+                continue
+            roles = node.get("role", [])
+            if isinstance(roles, str):
+                roles = [roles]
+            roles_by_machine[str(machine_id)] = {r.lower() for r in roles}
+        return roles_by_machine
+
     def _get_application_status_per_machine(self, model: str) -> dict:
         """Return status of every units of applications in a given model.
 
@@ -191,7 +215,19 @@ class ClusterStatusStep(abc.ABC, BaseStep):
             }
         return machines_status
 
-    def _to_status(self, status: dict, application_column_mapping: dict) -> dict:
+    # Applications that are deployed to nodes regardless of their assigned role.
+    # Mapping: application -> the column it represents.
+    # The column will only be shown if the node actually has that role assigned.
+    _role_restricted_applications: dict[str, str] = {
+        microovn.APPLICATION: "network",
+    }
+
+    def _to_status(
+        self,
+        status: dict,
+        application_column_mapping: dict,
+        roles_by_machine: dict[str, set[str]] | None = None,
+    ) -> dict:
         """Return dict to the correct status format.
 
         Return format:
@@ -215,6 +251,16 @@ class ClusterStatusStep(abc.ABC, BaseStep):
                         column = application_column_mapping.get(app)
                         if column is None:
                             continue
+                        # For role-restricted applications, only show the column
+                        # if the node actually has the corresponding role assigned.
+                        if (
+                            roles_by_machine
+                            and app in self._role_restricted_applications
+                        ):
+                            required_role = self._role_restricted_applications[app]
+                            machine_roles = roles_by_machine.get(machine, set())
+                            if required_role not in machine_roles:
+                                continue
                         _status[column] = self.map_application_status(
                             app, app_status["status"]
                         )
@@ -244,7 +290,8 @@ class ClusterStatusStep(abc.ABC, BaseStep):
                 self._get_application_status_per_machine(model),
             )
         self._update_microcluster_status(status, self._get_microcluster_status())
-        return self._to_status(status, self.applications_to_columns())
+        roles_by_machine = self._get_node_roles_by_machine()
+        return self._to_status(status, self.applications_to_columns(), roles_by_machine)
 
     def run(self, context: StepContext) -> Result:
         """Run the step to completion."""

--- a/sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
+++ b/sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
@@ -337,6 +337,7 @@ class TestLocalClusterStatusStep:
         deployment.get_client().cluster.get_status.return_value = {
             "node-1": {"status": "ONLINE", "address": "10.0.0.1"}
         }
+        deployment.get_client().cluster.list_nodes.return_value = []
 
         step = local_steps.LocalClusterStatusStep(deployment, jhelper)
         result = step.run(step_context)
@@ -350,6 +351,9 @@ class TestLocalClusterStatusStep:
         deployment.get_client().cluster.get_status.return_value = {
             hostname: {"status": "ONLINE", "address": f"{host_ip}:7000"}
         }
+        deployment.get_client().cluster.list_nodes.return_value = [
+            {"name": hostname, "role": ["control"], "machineid": 0}
+        ]
         deployment.openstack_machines_model = model
         jhelper.get_model_status.return_value = Mock(
             machines={
@@ -398,6 +402,9 @@ class TestLocalClusterStatusStep:
         deployment.get_client().cluster.get_status.return_value = {
             hostname: {"status": "ONLINE", "address": f"{host_ip}:7000"}
         }
+        deployment.get_client().cluster.list_nodes.return_value = [
+            {"name": hostname, "role": ["control"], "machineid": 0}
+        ]
         deployment.openstack_machines_model = model
         # missing hostname attribute in model status
         jhelper.get_model_status.return_value = Mock(
@@ -437,6 +444,199 @@ class TestLocalClusterStatusStep:
         actual_status = step._compute_status()
 
         assert expected_status == actual_status
+
+    def test_compute_status_microovn_with_network_role(self, deployment, jhelper):
+        """MicroOVN on a node WITH network role should show 'network' column."""
+        model = "test-model"
+        hostname = "node-1"
+        host_ip = "10.0.0.1"
+
+        deployment.get_client().cluster.get_status.return_value = {
+            hostname: {"status": "ONLINE", "address": f"{host_ip}:7000"}
+        }
+        deployment.get_client().cluster.list_nodes.return_value = [
+            {
+                "name": hostname,
+                "role": ["control", "compute", "network"],
+                "machineid": 0,
+            }
+        ]
+        deployment.openstack_machines_model = model
+        jhelper.get_model_status.return_value = Mock(
+            machines={
+                "0": Mock(
+                    hostname=hostname,
+                    dns_name=host_ip,
+                    machine_status=Mock(current="running"),
+                )
+            },
+            apps={
+                "k8s": Mock(
+                    units={
+                        "k8s/0": Mock(
+                            machine="0",
+                            workload_status=Mock(current="active"),
+                        )
+                    }
+                ),
+                "microovn": Mock(
+                    units={
+                        "microovn/0": Mock(
+                            machine="0",
+                            workload_status=Mock(current="active"),
+                        )
+                    }
+                ),
+            },
+        )
+        expected_status = {
+            model: {
+                "0": {
+                    "hostname": hostname,
+                    "status": {
+                        "cluster": "ONLINE",
+                        "machine": "running",
+                        "control": "active",
+                        "network": "active",
+                    },
+                }
+            }
+        }
+
+        step = local_steps.LocalClusterStatusStep(deployment, jhelper)
+        actual_status = step._compute_status()
+
+        assert expected_status == actual_status
+
+    def test_compute_status_microovn_without_network_role(self, deployment, jhelper):
+        """MicroOVN on a node WITHOUT network role should NOT show 'network' column."""
+        model = "test-model"
+        hostname = "node-1"
+        host_ip = "10.0.0.1"
+
+        deployment.get_client().cluster.get_status.return_value = {
+            hostname: {"status": "ONLINE", "address": f"{host_ip}:7000"}
+        }
+        deployment.get_client().cluster.list_nodes.return_value = [
+            {"name": hostname, "role": ["control", "compute"], "machineid": 0}
+        ]
+        deployment.openstack_machines_model = model
+        jhelper.get_model_status.return_value = Mock(
+            machines={
+                "0": Mock(
+                    hostname=hostname,
+                    dns_name=host_ip,
+                    machine_status=Mock(current="running"),
+                )
+            },
+            apps={
+                "k8s": Mock(
+                    units={
+                        "k8s/0": Mock(
+                            machine="0",
+                            workload_status=Mock(current="active"),
+                        )
+                    }
+                ),
+                "microovn": Mock(
+                    units={
+                        "microovn/0": Mock(
+                            machine="0",
+                            workload_status=Mock(current="active"),
+                        )
+                    }
+                ),
+            },
+        )
+        expected_status = {
+            model: {
+                "0": {
+                    "hostname": hostname,
+                    "status": {
+                        "cluster": "ONLINE",
+                        "machine": "running",
+                        "control": "active",
+                        # "network" should NOT appear here
+                    },
+                }
+            }
+        }
+
+        step = local_steps.LocalClusterStatusStep(deployment, jhelper)
+        actual_status = step._compute_status()
+
+        assert expected_status == actual_status
+        assert "network" not in actual_status[model]["0"]["status"]
+
+    def test_compute_status_microovn_role_filtering_multi_node(
+        self, deployment, jhelper
+    ):
+        """In multi-node, only nodes with network role should show 'network'."""
+        model = "test-model"
+
+        deployment.get_client().cluster.get_status.return_value = {
+            "node-1": {"status": "ONLINE", "address": "10.0.0.1:7000"},
+            "node-2": {"status": "ONLINE", "address": "10.0.0.2:7000"},
+        }
+        deployment.get_client().cluster.list_nodes.return_value = [
+            {
+                "name": "node-1",
+                "role": ["control", "compute", "network"],
+                "machineid": 0,
+            },
+            {"name": "node-2", "role": ["control", "compute"], "machineid": 1},
+        ]
+        deployment.openstack_machines_model = model
+        jhelper.get_model_status.return_value = Mock(
+            machines={
+                "0": Mock(
+                    hostname="node-1",
+                    dns_name="10.0.0.1",
+                    machine_status=Mock(current="running"),
+                ),
+                "1": Mock(
+                    hostname="node-2",
+                    dns_name="10.0.0.2",
+                    machine_status=Mock(current="running"),
+                ),
+            },
+            apps={
+                "k8s": Mock(
+                    units={
+                        "k8s/0": Mock(
+                            machine="0",
+                            workload_status=Mock(current="active"),
+                        ),
+                        "k8s/1": Mock(
+                            machine="1",
+                            workload_status=Mock(current="active"),
+                        ),
+                    }
+                ),
+                "microovn": Mock(
+                    units={
+                        "microovn/0": Mock(
+                            machine="0",
+                            workload_status=Mock(current="active"),
+                        ),
+                        "microovn/1": Mock(
+                            machine="1",
+                            workload_status=Mock(current="active"),
+                        ),
+                    }
+                ),
+            },
+        )
+
+        step = local_steps.LocalClusterStatusStep(deployment, jhelper)
+        actual_status = step._compute_status()
+
+        # node-1 has network role -> should show "network"
+        assert "network" in actual_status[model]["0"]["status"]
+        assert actual_status[model]["0"]["status"]["network"] == "active"
+
+        # node-2 does NOT have network role -> should NOT show "network"
+        assert "network" not in actual_status[model]["1"]["status"]
 
 
 class TestLocalConfigSRIOVStep:


### PR DESCRIPTION

Problem: sunbeam cluster list incorrectly showed "network: active" for all nodes even when the node was not assigned the network role.

Root Cause: cluster_status.py:133 had the hardcoded mapping microovn.APPLICATION: "network", but when the OVN provider is MICROOVN, MicroOVN gets deployed to all nodes (network + compute + control).

Modified files:

1. sunbeam-python/sunbeam/steps/cluster_status.py
- Added _get_node_roles_by_machine() method to fetch machine_id -> roles mapping from clusterd
- Added _role_restricted_applications class variable for applications that need role filtering
- Modified _to_status() to accept and use the roles mapping for filtering
- Modified _compute_status() to fetch roles and pass them through

2. sunbeam-python/tests/unit/sunbeam/provider/local/test_steps.py
- Updated 3 existing tests to explicitly mock list_nodes()
- Added test_compute_status_microovn_with_network_role - verifies network shows when role is assigned
- Added test_compute_status_microovn_without_network_role - verifies network is hidden when role is NOT assigned
- Added test_compute_status_microovn_role_filtering_multi_node - verifies correct filtering in multi-node scenarios