### PR TITLE
loadbalancer: increase database connections

### DIFF
--- a/sunbeam-python/sunbeam/features/loadbalancer/feature.py
+++ b/sunbeam-python/sunbeam/features/loadbalancer/feature.py
@@ -1653,8 +1653,9 @@ class LoadbalancerFeature(OpenStackControlPlaneFeature):
 
     def get_database_charm_processes(self) -> dict[str, dict[str, int]]:
         """Returns the database processes accessing this service."""
+        # API: 3, driver-agent: 2, housekeeping: 1, worker: 1, health-manager: 4
         return {
-            "octavia": {"octavia-k8s": 6},
+            "octavia": {"octavia-k8s": 10},
         }
 
     def run_enable_plans(


### PR DESCRIPTION
Currently the number of processes that consumes
database connections is sufficient for OVN but
not for Amphora as amphora brings health-manager
process which in turn spawns threads for health
updates and stats updates.

Increase the number of processes that consumes
database connections for octavia-k8s charm to
10 to account for health-manager threads.

Closes-Bug: https://bugs.launchpad.net/snap-openstack/+bug/2158278


(cherry picked from commit 9f0d9a166c31146b3d7dacac6f24cda230a02e5b)