### PR TITLE
fix(horizon): do not prompt for custom theme during bootstrap/refresh

### DIFF
--- a/sunbeam-python/sunbeam/core/manifest.py
+++ b/sunbeam-python/sunbeam/core/manifest.py
@@ -265,6 +265,13 @@ class CoreConfig(pydantic.BaseModel):
         class _Resources(pydantic.BaseModel):
             custom_theme: Path | None = None
 
+            @pydantic.field_validator("custom_theme", mode="before")
+            @classmethod
+            def _validate_custom_theme(cls, v):
+                if isinstance(v, str) and not v.strip():
+                    return None
+                return v
+
         resources: _Resources | None = None
 
     class _Endpoints(pydantic.BaseModel):

--- a/sunbeam-python/sunbeam/steps/horizon.py
+++ b/sunbeam-python/sunbeam/steps/horizon.py
@@ -79,16 +79,15 @@ class AttachHorizonThemeStep(BaseStep):
             )
 
     def has_prompts(self) -> bool:
-        """Indicate that this step requires interactive user input."""
-        if self.prompt_mode == PromptMode.NEVER:
-            return False
-        if self.prompt_mode == PromptMode.FORCE:
-            return True
+        """Indicate that this step requires interactive user input.
 
-        manifest_cfg = self._get_horizon_config_from_manifest()
-        if "theme_path" in manifest_cfg:
-            return False
-        return True
+        Theming is purely cosmetic and is managed via the dedicated
+        ``dashboard theme set`` command (PromptMode.FORCE). During bootstrap
+        and refresh the step never prompts: a manifest theme is applied if
+        present, otherwise the default (no theme) is used. This keeps
+        manifest-driven deployments non-interactive (LP#2158268).
+        """
+        return self.prompt_mode == PromptMode.FORCE
 
     def prompt(self, console=None, show_hint=False) -> None:
         """Execute the interactive prompts dynamically."""

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_horizon.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_horizon.py
@@ -9,6 +9,7 @@ import pytest
 
 from sunbeam.core.common import ResultType
 from sunbeam.core.juju import JujuException
+from sunbeam.core.manifest import CoreConfig
 from sunbeam.steps.horizon import AttachHorizonThemeStep, _validate_theme_path
 
 
@@ -255,13 +256,48 @@ def test_has_prompts_with_manifest_theme_is_false(client, jhelper, manifest_with
     assert step.has_prompts() is False
 
 
-def test_has_prompts_no_horizon_section_is_true(client, jhelper, manifest_empty):
+def test_has_prompts_no_horizon_section_is_false(client, jhelper, manifest_empty):
+    """Bootstrap/refresh never prompt for theme (LP#2158268).
+
+    Theming is cosmetic and handled by the dedicated ``dashboard theme set``
+    command; manifest-driven deployments must stay non-interactive.
+    """
     step = _make_step(client, jhelper, manifest_empty)
-    assert step.has_prompts() is True
+    assert step.has_prompts() is False
 
 
-def test_has_prompts_horizon_without_resource_is_true(
+def test_has_prompts_horizon_without_resource_is_false(
     client, jhelper, manifest_no_resource
 ):
     step = _make_step(client, jhelper, manifest_no_resource)
+    assert step.has_prompts() is False
+
+
+def test_has_prompts_force_mode_is_true(client, jhelper, manifest_empty):
+    """``dashboard theme set`` forces the prompt regardless of manifest."""
+    from sunbeam.core.common import PromptMode
+
+    step = AttachHorizonThemeStep(
+        client=client,
+        jhelper=jhelper,
+        manifest=manifest_empty,
+        model="openstack",
+        prompt_mode=PromptMode.FORCE,
+    )
     assert step.has_prompts() is True
+
+
+def test_manifest_empty_string_custom_theme_coerced_to_none():
+    """Empty string in manifest custom_theme must become None, not Path('.').
+
+    Regression test for LP#2158268: an empty custom_theme in the manifest
+    was being coerced by pydantic into PosixPath('.'), which is truthy and
+    broke non-interactive manifest deployments.
+    """
+    cfg = CoreConfig.model_validate({"horizon": {"resources": {"custom_theme": ""}}})
+    assert cfg.horizon.resources.custom_theme is None
+
+
+def test_manifest_missing_custom_theme_is_none():
+    cfg = CoreConfig.model_validate({"horizon": {"resources": {}}})
+    assert cfg.horizon.resources.custom_theme is None


### PR DESCRIPTION
Theming is cosmetic and is managed via the dedicated `dashboard theme set` command, but `has_prompts()` still returned True during bootstrap/refresh whenever the manifest lacked `custom_theme`, blocking unattended manifest-driven deployments.

- manifest: coerce blank `custom_theme` strings to None instead of letting pydantic turn `''` into the truthy `PosixPath('.')`, which broke run() with "Theme file . is invalid or missing".
- horizon: `has_prompts()` now returns True only in PromptMode.FORCE, so bootstrap/refresh never prompt; the manifest theme is applied if present, otherwise the empty sentinel (no theme) is attached.

Closes-Bug: #2158268

Assisted-by: z.ai/glm-5.2

(cherry picked from commit 149bf5a31defae9ab1efbe0fbc9b34f0aac0dde3)