### PR TITLE
Fix/lp 2158343 invalid backend names

### DIFF
--- a/sunbeam-python/sunbeam/storage/base.py
+++ b/sunbeam-python/sunbeam/storage/base.py
@@ -49,7 +49,7 @@ console = Console()
 # Based on Juju's naming rules: must start with letter, contain only
 # letters, numbers, hyphens. Cannot end with hyphen, cannot have
 # consecutive hyphens, cannot end with a purely numeric segment
-JUJU_APP_NAME_PATTERN = re.compile(r"^[a-z]([a-z0-9]*(-[a-z0-9]*)*)?$")
+JUJU_APP_NAME_PATTERN = re.compile(r"^(?:[a-z][a-z0-9]*(?:-[a-z0-9]*[a-z][a-z0-9]*)*)$")
 
 # Regex pattern for validating FQDN (Fully Qualified Domain Name)
 FQDN_PATTERN = (

--- a/sunbeam-python/sunbeam/storage/base.py
+++ b/sunbeam-python/sunbeam/storage/base.py
@@ -48,7 +48,7 @@ console = Console()
 # Juju application name validation pattern
 # Based on Juju's naming rules: must start with letter, contain only
 # letters, numbers, hyphens. Cannot end with hyphen, cannot have
-# consecutive hyphens, cannot have numbers after final hyphen
+# consecutive hyphens, cannot end with a purely numeric segment
 JUJU_APP_NAME_PATTERN = re.compile(r"^[a-z]([a-z0-9]*(-[a-z0-9]*)*)?$")
 
 # Regex pattern for validating FQDN (Fully Qualified Domain Name)
@@ -84,11 +84,12 @@ def validate_juju_application_name(name: str) -> bool:
     if "--" in name:
         return False
 
-    # Check that numbers don't appear after the final hyphen
+    # Check that the segment after the final hyphen is not purely numeric
+    # (Juju reserves the pattern <app-name>-<number> for unit names)
     if "-" in name:
         parts = name.split("-")
         last_part = parts[-1]
-        if any(char.isdigit() for char in last_part):
+        if last_part.isdigit():
             return False
 
     return True
@@ -311,10 +312,10 @@ class StorageBackendBase(FeatureGateMixin, typing.Generic[BackendConfig]):
             raise click.ClickException(
                 f"Invalid backend name '{name}'. "
                 "Backend names must be valid Juju application names: "
-                "start with a letter, contain only lowercase letters, numbers,"
-                "and hyphens, cannot end with hyphen, cannot"
-                "have consecutive hyphens, and cannot have numbers"
-                "after the final hyphen."
+                "start with a letter, contain only lowercase letters, numbers, "
+                "and hyphens, cannot end with a hyphen, cannot "
+                "have consecutive hyphens, and cannot end with a "
+                "purely numeric segment after a hyphen."
             )
 
         openstack_tfhelper = deployment.get_tfhelper("openstack-plan")

--- a/sunbeam-python/tests/unit/sunbeam/storage/test_base.py
+++ b/sunbeam-python/tests/unit/sunbeam/storage/test_base.py
@@ -34,6 +34,9 @@ class TestJujuApplicationNameValidation:
             "a1",
             "app123",
             "my-storage",
+            "my-hpe3par",
+            "cinder-vol3",
+            "backend-v2storage",
         ]
         for name in valid_names:
             assert validate_juju_application_name(name), f"{name} should be valid"
@@ -48,7 +51,8 @@ class TestJujuApplicationNameValidation:
             "-myapp",  # Starts with hyphen
             "myapp-",  # Ends with hyphen
             "my--app",  # Consecutive hyphens
-            "my-app-1",  # Number after final hyphen
+            "my-app-1",  # Purely numeric segment after final hyphen
+            "my-app-123",  # Purely numeric segment after final hyphen
         ]
         for name in invalid_names:
             assert not validate_juju_application_name(name), f"{name} should be invalid"


### PR DESCRIPTION
Root cause: 
The check in sunbeam-python/sunbeam/storage/base.py:91 is overly strict:
```
if any(char.isdigit() for char in last_part):
    return False
```
This rejects any name where the last segment (after the final hyphen) contains any digit character. For my-hpe3par, it splits to `["my", "hpe3par"]` and the last part "hpe3par" contains the digit 3, so it's rejected.

The fix is a one-line change in sunbeam-python/sunbeam/storage/base.py:91:
```
# Before (too strict):
if any(char.isdigit() for char in last_part):
    return False


# After (correct behavior):
if last_part.isdigit():
    return False
```

I have also added the related tests in tox