### PR TITLE
feat: move microcluster-token-distributor to v1/stable

### DIFF
--- a/cloud/etc/deploy-microovn/variables.tf
+++ b/cloud/etc/deploy-microovn/variables.tf
@@ -48,7 +48,7 @@ variable "openstack_network_agents_endpoint_bindings" {
 variable "charm_microcluster_token_distributor_channel" {
   description = "Operator channel for microcluster-token-distributor deployment"
   type        = string
-  default     = "latest/edge"
+  default     = "v1/stable"
 }
 
 variable "charm_microcluster_token_distributor_revision" {

--- a/manifests/2024.1/edge.yml
+++ b/manifests/2024.1/edge.yml
@@ -50,7 +50,7 @@ core:
         config:
           snap-channel: 2024.1/edge
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       role-distributor:
         channel: latest/stable
       sunbeam-ovn-proxy:

--- a/manifests/2025.1/edge.yml
+++ b/manifests/2025.1/edge.yml
@@ -48,7 +48,7 @@ core:
         config:
           snap-channel: 2025.1/edge
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       role-distributor:
         channel: latest/stable
       sunbeam-ovn-proxy:

--- a/manifests/2026.1/edge.yml
+++ b/manifests/2026.1/edge.yml
@@ -48,7 +48,7 @@ core:
         config:
           snap-channel: 2026.1/edge
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       role-distributor:
         channel: latest/stable
       sunbeam-ovn-proxy:

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -77,8 +77,7 @@ MACHINE_CHARMS = {
     "microovn": MICROOVN_CHANNEL,
     "role-distributor": ROLE_DISTRIBUTOR_CHANNEL,
     "openstack-network-agents": OPENSTACK_CHANNEL,
-    # TODO: ensure correct channel for the distributor
-    "microcluster-token-distributor": "latest/edge",
+    "microcluster-token-distributor": "v1/stable",
     "sunbeam-ovn-proxy": OPENSTACK_CHANNEL,
     "k8s": K8S_CHANNEL,
     "openstack-hypervisor": OPENSTACK_CHANNEL,


### PR DESCRIPTION
microcluster-token-distributor charm has v1/stable version. Change the default version from latest/edge to v1/stable