### PR TITLE
feat: move microcluster-token-distributor to v1/stable

### DIFF
--- a/cloud/etc/deploy-microovn/variables.tf
+++ b/cloud/etc/deploy-microovn/variables.tf
@@ -48,7 +48,7 @@ variable "openstack_network_agents_endpoint_bindings" {
 variable "charm_microcluster_token_distributor_channel" {
   description = "Operator channel for microcluster-token-distributor deployment"
   type        = string
-  default     = "latest/edge"
+  default     = "v1/stable"
 }
 
 variable "charm_microcluster_token_distributor_revision" {

--- a/manifests/2024.1/beta.yml
+++ b/manifests/2024.1/beta.yml
@@ -50,7 +50,7 @@ core:
         config:
           snap-channel: 2024.1/beta
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       sunbeam-ovn-proxy:
         channel: 2024.1/beta
 features:

--- a/manifests/2024.1/edge.yml
+++ b/manifests/2024.1/edge.yml
@@ -50,7 +50,7 @@ core:
         config:
           snap-channel: 2024.1/edge
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       sunbeam-ovn-proxy:
         channel: 2024.1/edge
 features:

--- a/manifests/2024.1/stable.yml
+++ b/manifests/2024.1/stable.yml
@@ -50,7 +50,7 @@ core:
         config:
           snap-channel: 2024.1/stable
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       sunbeam-ovn-proxy:
         channel: 2024.1/stable
 features:

--- a/manifests/2025.1/beta.yml
+++ b/manifests/2025.1/beta.yml
@@ -46,7 +46,7 @@ core:
         config:
           snap-channel: 2025.1/beta
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       sunbeam-ovn-proxy:
         channel: 2025.1/beta
 features:

--- a/manifests/2025.1/candidate.yml
+++ b/manifests/2025.1/candidate.yml
@@ -46,7 +46,7 @@ core:
         config:
           snap-channel: 2025.1/candidate
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       sunbeam-ovn-proxy:
         channel: 2025.1/candidate
 features:

--- a/manifests/2025.1/edge.yml
+++ b/manifests/2025.1/edge.yml
@@ -48,7 +48,7 @@ core:
         config:
           snap-channel: 2025.1/edge
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       sunbeam-ovn-proxy:
         channel: 2025.1/edge
 features:

--- a/manifests/2025.1/stable.yml
+++ b/manifests/2025.1/stable.yml
@@ -48,7 +48,7 @@ core:
         config:
           snap-channel: 2025.1/stable
       microcluster-token-distributor:
-        channel: latest/edge
+        channel: v1/stable
       sunbeam-ovn-proxy:
         channel: 2025.1/stable
 features:

--- a/manifests/2026.1/edge.yml
+++ b/manifests/2026.1/edge.yml
@@ -2,148 +2,148 @@ core:
   software:
     charms:
       cinder-volume:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
         config:
-          snap-channel: 2024.1/candidate
+          snap-channel: 2026.1/edge
       cinder-volume-ceph:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       cinder-k8s:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       glance-k8s:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       horizon-k8s:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       keystone-k8s:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       neutron-k8s:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       nova-k8s:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       openstack-hypervisor:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
         config:
-          snap-channel: 2024.1/candidate
+          snap-channel: 2026.1/edge
       ovn-central-k8s:
-        channel: 24.03/candidate
+        channel: 26.03/edge
       ovn-relay-k8s:
-        channel: 24.03/candidate
+        channel: 26.03/edge
       placement-k8s:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       sunbeam-clusterd:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
         config:
-          snap-channel: 2024.1/candidate
+          snap-channel: 2026.1/edge
       sunbeam-machine:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
       epa-orchestrator:
-        channel: 2024.1/candidate
-        config:
-          snap-channel: 2024.1/candidate
+        channel: 2026.1/edge
       microceph:
         channel: squid/stable
         config:
           snap-channel: squid/stable
       microovn:
-        channel: 24.03/stable
+        channel: 25.03/stable
       openstack-network-agents:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
         config:
-          snap-channel: 2024.1/candidate
+          snap-channel: 2026.1/edge
       microcluster-token-distributor:
         channel: v1/stable
+      role-distributor:
+        channel: latest/stable
       sunbeam-ovn-proxy:
-        channel: 2024.1/candidate
+        channel: 2026.1/edge
 features:
   baremetal:
     software:
       charms:
         ironic-conductor-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         ironic-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         nova-ironic-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         neutron-baremetal-switch-config-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         neutron-generic-switch-config-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   caas:
     software:
       charms:
         magnum-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   dns:
     software:
       charms:
         designate-bind-k8s:
-          channel: 9/candidate
+          channel: 9/edge
         designate-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   images-sync:
     software:
       charms:
         openstack-images-sync-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   instance-recovery:
     software:
       charms:
         consul-k8s:
-          channel: 1.19/candidate
+          channel: 1.19/edge
         consul-client:
-          channel: 1.19/candidate
+          channel: 1.19/edge
         masakari-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   ldap:
     software:
       charms:
         keystone-ldap-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   loadbalancer:
     software:
       charms:
         multus:
           channel: latest/stable
         octavia-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         openstack-port-cni-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   orchestration:
     software:
       charms:
         heat-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   resource-optimization:
     software:
       charms:
         watcher-k8s:
-          channel: 2024.1/candidate
-  secrets:
-    software:
-      charms:
-        barbican-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   shared-filesystem:
     software:
       charms:
         manila-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         manila-cephfs-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         manila-data:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
+  secrets:
+    software:
+      charms:
+        barbican-k8s:
+          channel: 2026.1/edge
   telemetry:
     software:
       charms:
         aodh-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         ceilometer-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         gnocchi-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
         openstack-exporter-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge
   validation:
     software:
       charms:
         tempest-k8s:
-          channel: 2024.1/candidate
+          channel: 2026.1/edge

--- a/sunbeam-python/sunbeam/versions.py
+++ b/sunbeam-python/sunbeam/versions.py
@@ -75,8 +75,7 @@ MACHINE_CHARMS = {
     "microceph": MICROCEPH_CHANNEL,
     "microovn": MICROOVN_CHANNEL,
     "openstack-network-agents": OPENSTACK_CHANNEL,
-    # TODO: ensure correct channel for the distributor
-    "microcluster-token-distributor": "latest/edge",
+    "microcluster-token-distributor": "v1/stable",
     "sunbeam-ovn-proxy": OPENSTACK_CHANNEL,
     "k8s": K8S_CHANNEL,
     "openstack-hypervisor": OPENSTACK_CHANNEL,


### PR DESCRIPTION
microcluster-token-distributor charm has v1/stable version. Change the default version from latest/edge to v1/stable


(cherry picked from commit 5416f0dfcf5929e4a1f3f5fa8011cb15d6bfe045)