### PR TITLE
feat: use traefik 26.04 base by default

### DIFF
--- a/cloud/etc/deploy-cinder-volume/main.tf
+++ b/cloud/etc/deploy-cinder-volume/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/cloud/etc/deploy-k8s/main.tf
+++ b/cloud/etc/deploy-k8s/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/cloud/etc/deploy-microceph/main.tf
+++ b/cloud/etc/deploy-microceph/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/cloud/etc/deploy-microovn/main.tf
+++ b/cloud/etc/deploy-microovn/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/cloud/etc/deploy-openstack-hypervisor/main.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 

--- a/cloud/etc/deploy-role-distributor/main.tf
+++ b/cloud/etc/deploy-role-distributor/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/cloud/etc/deploy-storage/main.tf
+++ b/cloud/etc/deploy-storage/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/cloud/etc/deploy-storage/modules/backend/main.tf
+++ b/cloud/etc/deploy-storage/modules/backend/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/cloud/etc/deploy-storage/modules/cinder-volume/main.tf
+++ b/cloud/etc/deploy-storage/modules/cinder-volume/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/cloud/etc/deploy-sunbeam-machine/main.tf
+++ b/cloud/etc/deploy-sunbeam-machine/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/sunbeam-python/sunbeam/features/instance_recovery/etc/deploy-consul-client/main.tf
+++ b/sunbeam-python/sunbeam/features/instance_recovery/etc/deploy-consul-client/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/sunbeam-python/sunbeam/features/instance_recovery/etc/deploy-consul-client/modules/consul-client/main.tf
+++ b/sunbeam-python/sunbeam/features/instance_recovery/etc/deploy-consul-client/modules/consul-client/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-cni/main.tf
+++ b/sunbeam-python/sunbeam/features/loadbalancer/etc/deploy-cni/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-cos/main.tf
@@ -36,7 +36,7 @@ resource "juju_application" "traefik" {
     name     = "traefik-k8s"
     channel  = var.traefik-channel == null ? var.cos-channel : var.traefik-channel
     revision = var.traefik-revision
-    base     = "ubuntu@20.04"
+    base     = "ubuntu@26.04"
   }
 
   config = var.traefik-config

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-grafana-agent/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/sunbeam-python/sunbeam/features/observability/etc/deploy-hardware-observer/main.tf
+++ b/sunbeam-python/sunbeam/features/observability/etc/deploy-hardware-observer/main.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/sunbeam-python/sunbeam/features/pro/etc/deploy-pro/main.tf
+++ b/sunbeam-python/sunbeam/features/pro/etc/deploy-pro/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }

--- a/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/main.tf
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "= 1.3.1"
+      version = "= 1.5.6"
     }
   }
 }


### PR DESCRIPTION
Switch traefik to use 26.04 base by default, which is the 26.04 cycle support stable release of Traefik-k8s charm.

Same as in the sunbeam-terraform provider

## QA steps

Deploying a single node sunbeam, and using: `juju show-application -m openstack <any traefik-app>` should show base: ubuntu@26.04

Enabling observability feature should also have traefik in the `observability` model displaying the same base.

## Links
Related:
- [ ] https://github.com/canonical/sunbeam-terraform/pull/153

<!-- Place JIRA number in both places below. -->
**Jira card:** [OPEN-4630](https://warthogs.atlassian.net/browse/OPEN-4630)

[OPEN-4630]: https://warthogs.atlassian.net/browse/OPEN-4630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ