### PR TITLE
Fix traefik tls certs during refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 .vscode/
 
 .stestr/
+
+# Git worktrees
+.worktrees/

--- a/sunbeam-python/sunbeam/commands/refresh.py
+++ b/sunbeam-python/sunbeam/commands/refresh.py
@@ -26,6 +26,7 @@ from sunbeam.core.manifest import AddManifestStep
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.core.terraform import TerraformInitStep
 from sunbeam.features.interface.v1.base import is_maas_deployment
+from sunbeam.features.tls.ca import CaTlsFeature
 from sunbeam.steps.horizon import AttachHorizonThemeStep
 from sunbeam.steps.k8s import DeployK8SApplicationStep
 from sunbeam.steps.k8s_upgrade import K8SCharmUpgradeStep
@@ -71,6 +72,22 @@ def _stored_manifest_risk(client) -> str | None:
         return None
     # Return the risk that appears most often across charm channels.
     return risk_counts.most_common(1)[0][0]
+
+
+def _fix_tls_certs(deployment: Deployment, show_hints: bool) -> None:
+    """Re-provide stored tls.ca certificates for any outstanding CSRs.
+
+    No-op when tls.ca is not the active TLS provider.
+    """
+    feature = deployment.get_feature_manager().resolve_feature(CaTlsFeature.name)
+    if not isinstance(feature, CaTlsFeature) or not feature.is_enabled(
+        deployment.get_client()
+    ):
+        LOG.debug("tls.ca is not enabled; skipping TLS certificate re-provision.")
+        return
+
+    feature.reapply_certificates(deployment, show_hints)
+    click.echo("TLS certificate re-provision complete.")
 
 
 @click.group("refresh", invoke_without_command=True)
@@ -204,6 +221,12 @@ def refresh(
         console,
         show_hints,
     )
+
+    if not upgrade_release:
+        # Recover deployments affected by the traefik certificate bug by
+        # re-providing stored tls.ca certificates for any outstanding CSRs.
+        # No-op unless tls.ca is enabled and there are outstanding requests.
+        _fix_tls_certs(deployment, show_hints)
 
     click.echo("Refresh complete.")
 
@@ -419,3 +442,21 @@ def refresh_k8s(
     if message:
         click.echo(message)
     click.echo("k8s refresh complete.")
+
+
+@refresh.command("certificates")
+@click_option_show_hints
+@click.pass_context
+def refresh_certificates(
+    ctx: click.Context,
+    show_hints: bool = False,
+) -> None:
+    """Re-provide stored tls.ca certificates for outstanding CSRs.
+
+    This is the same as the last step of `sunbeam cluster refresh`
+    and it is a no-op unless tls.ca is enabled and there are outstanding csrs to be
+    reprovisioned.
+    """
+    deployment: Deployment = ctx.obj
+    run_preflight_checks([JujuLoginCheck(deployment.juju_account)], console)
+    _fix_tls_certs(deployment, show_hints)

--- a/sunbeam-python/sunbeam/features/interface/utils.py
+++ b/sunbeam-python/sunbeam/features/interface/utils.py
@@ -3,6 +3,7 @@
 
 import base64
 import binascii
+import datetime
 import logging
 import re
 import typing
@@ -156,6 +157,52 @@ def get_subject_from_csr(csr: str) -> str | None:
     except (binascii.Error, TypeError, ValueError) as e:
         LOG.debug("Failed to get subject from CSR: %r", e)
         return None
+
+
+def get_cn_from_csr(csr: str) -> str | None:
+    """Return the Common Name from a PEM-encoded CSR string, or None."""
+    try:
+        req = x509.load_pem_x509_csr(bytes(csr, "utf-8"))
+        cn_attrs = req.subject.get_attributes_for_oid(x509_oid.NameOID.COMMON_NAME)
+        if not cn_attrs:
+            return None
+        return str(cn_attrs[0].value)
+    except (binascii.Error, TypeError, ValueError) as e:
+        LOG.debug("Failed to get CN from CSR: %r", e)
+        return None
+
+
+def get_cn_from_cert(certificate: str) -> str | None:
+    """Return the Common Name from a base64-encoded PEM certificate, or None."""
+    try:
+        certificate_bytes = base64.b64decode(certificate)
+        cert = x509.load_pem_x509_certificate(certificate_bytes)
+        cn_attrs = cert.subject.get_attributes_for_oid(x509_oid.NameOID.COMMON_NAME)
+        if not cn_attrs:
+            return None
+        return str(cn_attrs[0].value)
+    except (binascii.Error, TypeError, ValueError) as e:
+        LOG.debug("Failed to get CN from certificate: %r", e)
+        return None
+
+
+def is_cert_expired(certificate: str) -> bool:
+    """Return True if the base64-encoded PEM certificate has expired.
+
+    Returns True (treat as expired) if the certificate cannot be decoded.
+    """
+    try:
+        certificate_bytes = base64.b64decode(certificate)
+        cert = x509.load_pem_x509_certificate(certificate_bytes)
+        try:
+            expiry = cert.not_valid_after_utc
+        except AttributeError:
+            # cryptography < 42 returns a naive datetime; assume UTC
+            expiry = cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
+        return expiry < datetime.datetime.now(datetime.timezone.utc)
+    except (binascii.Error, TypeError, ValueError) as e:
+        LOG.debug("Failed to check certificate expiry: %r", e)
+        return True
 
 
 def encode_base64_as_string(data: str) -> str | None:

--- a/sunbeam-python/sunbeam/features/interface/utils.py
+++ b/sunbeam-python/sunbeam/features/interface/utils.py
@@ -221,6 +221,28 @@ def decode_base64_as_string(data: str) -> str | None:
         return None
 
 
+def cert_and_csr_public_key_match(cert_b64: str, csr: str) -> bool:
+    """Return True if the public key in the certificate matches the one in the CSR.
+
+    Returns False if either cannot be decoded.
+    """
+    try:
+        cert = x509.load_pem_x509_certificate(base64.b64decode(cert_b64))
+        req = x509.load_pem_x509_csr(bytes(csr, "utf-8"))
+        cert_pub = cert.public_key()
+        csr_pub = req.public_key()
+        if hasattr(cert_pub, "public_numbers") and hasattr(csr_pub, "public_numbers"):
+            return cert_pub.public_numbers() == csr_pub.public_numbers()
+        if hasattr(cert_pub, "public_bytes_raw") and hasattr(
+            csr_pub, "public_bytes_raw"
+        ):
+            return cert_pub.public_bytes_raw() == csr_pub.public_bytes_raw()
+        return False
+    except (binascii.Error, TypeError, ValueError) as e:
+        LOG.debug("Failed to compare public keys: %r", e)
+        return False
+
+
 def cert_and_key_match(certificate: bytes, key: bytes) -> bool:
     """Checks if the supplied cert is derived from the supplied key."""
     crt = x509.load_pem_x509_certificate(certificate, backends.default_backend())

--- a/sunbeam-python/sunbeam/features/tls/ca.py
+++ b/sunbeam-python/sunbeam/features/tls/ca.py
@@ -18,14 +18,13 @@ from sunbeam.core import questions
 from sunbeam.core.common import (
     FORMAT_TABLE,
     FORMAT_YAML,
+    ResultType,
+    get_step_result,
     read_config,
     run_plan,
     str_presenter,
 )
 from sunbeam.core.deployment import Deployment
-from sunbeam.core.juju import (
-    JujuHelper,
-)
 from sunbeam.core.manifest import (
     AddManifestStep,
     FeatureConfig,
@@ -45,6 +44,7 @@ from sunbeam.features.tls.common import (
     CERTIFICATE_FEATURE_KEY,
     INGRESS_CHANGE_APPLICATION_TIMEOUT,
     ConfigureTLSCertificatesStep,
+    ReapplyTLSCertificatesStep,
     TlsFeature,
     TlsFeatureConfig,
     certificate_questions,
@@ -180,6 +180,16 @@ class CaTlsFeature(TlsFeature):
         """Set terraform variables to resize the application."""
         return {}
 
+    def _local_apps_to_monitor(self, deployment: Deployment) -> list[str]:
+        """Local applications to monitor after a TLS certificate change."""
+        client = deployment.get_client()
+        apps = ["traefik", "traefik-public"]
+        if not deployment.external_keystone_model:
+            apps.append("keystone")
+        if client.cluster.list_nodes_by_role("storage"):
+            apps.append("traefik-rgw")
+        return apps
+
     @click.group()
     def ca_group(self) -> None:
         """Manage CA."""
@@ -242,9 +252,7 @@ class CaTlsFeature(TlsFeature):
         if (ca := manifest.get_feature(self.name.split(".")[-1])) and ca.config:
             preseed = ca.config.model_dump(by_alias=True)
         model = OPENSTACK_MODEL
-        apps_to_monitor = ["traefik", "traefik-public", "keystone"]
-        if client.cluster.list_nodes_by_role("storage"):
-            apps_to_monitor.append("traefik-rgw")
+        apps_to_monitor = self._local_apps_to_monitor(deployment)
 
         try:
             config = read_config(client, CERTIFICATE_FEATURE_KEY)
@@ -256,7 +264,7 @@ class CaTlsFeature(TlsFeature):
         if ca is None:
             raise click.ClickException("CA is not configured")
 
-        jhelper = JujuHelper(deployment.juju_controller)
+        jhelper = deployment.get_juju_helper()
         plan = [
             AddManifestStep(client, manifest_path),
             ConfigureTLSCertificatesStep(
@@ -275,6 +283,52 @@ class CaTlsFeature(TlsFeature):
         ]
         run_plan(plan, console, show_hints)
         click.echo("CA certs configured")
+
+    def reapply_certificates(
+        self, deployment: Deployment, show_hints: bool = False
+    ) -> None:
+        """Re-provide stored certificates for any outstanding CSRs.
+
+        Used to recover a deployment after a charm refresh (e.g. the traefik
+        charm crossing revision 308) leaves applications with outstanding
+        certificate requests. Reuses the certificates already stored in
+        clusterd; never prompts. No-op when there are no outstanding CSRs or
+        none match a stored certificate.
+        """
+        client = deployment.get_client()
+        try:
+            config = read_config(client, CERTIFICATE_FEATURE_KEY)
+        except ConfigItemNotFoundException:
+            config = {}
+        ca = config.get("ca")
+        ca_chain = config.get("chain")
+
+        if ca is None:
+            raise click.ClickException("CA is not configured")
+
+        model = OPENSTACK_MODEL
+        apps_to_monitor = self._local_apps_to_monitor(deployment)
+
+        jhelper = deployment.get_juju_helper()
+        rerun_provide_certificates_plan = [
+            ReapplyTLSCertificatesStep(client, jhelper, ca, ca_chain)
+        ]
+        results = run_plan(rerun_provide_certificates_plan, console, show_hints)
+
+        reapply_result = get_step_result(results, ReapplyTLSCertificatesStep)
+        if reapply_result.result_type != ResultType.SKIPPED:
+            run_plan(
+                [
+                    WaitForApplicationsStep(
+                        jhelper,
+                        apps_to_monitor,
+                        model,
+                        INGRESS_CHANGE_APPLICATION_TIMEOUT,
+                    )
+                ],
+                console,
+                show_hints,
+            )
 
     def enabled_commands(self) -> dict[str, list[dict]]:
         """Dict of clickgroup along with commands.

--- a/sunbeam-python/sunbeam/features/tls/common.py
+++ b/sunbeam-python/sunbeam/features/tls/common.py
@@ -38,6 +38,7 @@ from sunbeam.core.manifest import (
 )
 from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.features.interface.utils import (
+    cert_and_csr_public_key_match,
     encode_base64_as_string,
     generate_ca_chain,
     get_cn_from_cert,
@@ -799,20 +800,31 @@ class ReapplyTLSCertificatesStep(ConfigureTLSCertificatesStep):
                 LOG.warning("Skipping CSR with no CN for unit %s", unit_name)
                 continue
 
-            # Find a stored certificate whose CN matches the CSR's CN
+            # Find a stored certificate whose CN and public key match the CSR
             # and that has not yet expired.
             stored_cert = None
             for stored_data in stored_certs.values():
                 cert_b64 = stored_data.get("certificate")
-                if cert_b64 and get_cn_from_cert(cert_b64) == cn:
-                    if is_cert_expired(cert_b64):
-                        LOG.warning(
-                            "Stored certificate for CN %s has expired; skipping.",
-                            cn,
-                        )
-                        continue
-                    stored_cert = cert_b64
-                    break
+                if not cert_b64:
+                    continue
+                if get_cn_from_cert(cert_b64) != cn:
+                    continue
+                if not cert_and_csr_public_key_match(cert_b64, csr):
+                    LOG.warning(
+                        "Stored certificate CN matches but public key differs "
+                        "for CSR (app=%s, cn=%s); skipping.",
+                        app,
+                        cn,
+                    )
+                    continue
+                if is_cert_expired(cert_b64):
+                    LOG.warning(
+                        "Stored certificate for CN %s has expired; skipping.",
+                        cn,
+                    )
+                    continue
+                stored_cert = cert_b64
+                break
 
             if not stored_cert:
                 LOG.warning(

--- a/sunbeam-python/sunbeam/features/tls/common.py
+++ b/sunbeam-python/sunbeam/features/tls/common.py
@@ -713,3 +713,110 @@ class ConfigureTLSCertificatesStep(BaseStep):
                 )
 
         return Result(ResultType.COMPLETED)
+
+
+class ReapplyTLSCertificatesStep(ConfigureTLSCertificatesStep):
+    """Re-provide previously signed certificates for outstanding CSRs.
+
+    Recovers a deployment after a charm refresh (e.g. the traefik charm
+    crossing revision 308) leaves applications with outstanding certificate
+    requests. It re-runs the ``provide-certificate`` action using the
+    certificates already stored in clusterd, matched to each outstanding CSR
+    by its subject.
+
+    Unlike :class:`ConfigureTLSCertificatesStep`, this step is non-interactive:
+    it never prompts. Outstanding CSRs without a matching stored certificate
+    (e.g. a genuinely new CSR) are skipped with a warning so that a stale
+    certificate is never provided for an unknown request.
+    """
+
+    def has_prompts(self) -> bool:
+        """This step never prompts the user."""
+        return False
+
+    def is_skip(self, context: StepContext) -> Result:
+        """Collect outstanding CSRs and match them to stored certificates.
+
+        Populates ``self.process_certs`` from the certificates stored in
+        clusterd so the inherited ``run()`` re-provides them.
+
+        :return: SKIPPED when there is nothing to re-provide, FAILED on error,
+                 COMPLETED when at least one CSR was matched to a stored cert.
+        """
+        try:
+            action_result = get_outstanding_certificate_requests(
+                self.app, self.model, self.jhelper
+            )
+        except (LeaderNotFoundException, ActionFailedException) as e:
+            LOG.debug("Failed to get CSRs for %s: %s", self.app, e)
+            return Result(ResultType.FAILED, str(e))
+
+        if action_result.get("return-code", 0) > 1:
+            return Result(
+                ResultType.FAILED,
+                "Unable to get outstanding certificate requests from CA",
+            )
+
+        certs_to_process = json.loads(action_result.get("result", "[]"))
+        if not certs_to_process:
+            return Result(ResultType.SKIPPED, "No outstanding certificate requests")
+
+        stored_certs = questions.load_answers(self.client, self._CONFIG).get(
+            "certificates", {}
+        )
+        if not stored_certs:
+            return Result(ResultType.SKIPPED, "No stored certificates to re-provide")
+
+        try:
+            relation_map = self.jhelper.get_relation_map(
+                self.app, self.interface, self.model
+            )
+        except JujuException as e:
+            return Result(ResultType.FAILED, f"Unable to get relation map: {e}")
+
+        processed_records: set = set()
+        for record in certs_to_process:
+            # Multiple units of the same application may share a CSR/relation_id.
+            hashable_record = tuple(sorted(record.items()))
+            if hashable_record in processed_records:
+                continue
+            processed_records.add(hashable_record)
+
+            unit_name = record.get("unit_name")
+            csr = record.get("csr")
+            app = record.get("application_name")
+            relation_id = record.get("relation_id")
+            if relation_id:
+                app = relation_map.get(f"{self.interface}:{relation_id}")
+            elif unit_name:
+                app = unit_name.split("/")[0]
+
+            subject = get_subject_from_csr(csr)
+            if not subject:
+                LOG.warning("Skipping invalid CSR for unit %s", unit_name)
+                continue
+
+            stored_cert = stored_certs.get(subject, {}).get("certificate")
+            if not stored_cert:
+                LOG.warning(
+                    "No stored certificate for outstanding CSR (app=%s, subject=%s); "
+                    "skipping. Sign it with `sunbeam tls ca unit_certs`.",
+                    app,
+                    subject,
+                )
+                continue
+
+            self.process_certs[subject] = {
+                "app": app,
+                "unit": unit_name,
+                "relation_id": relation_id,
+                "csr": csr,
+                "certificate": stored_cert,
+            }
+
+        if not self.process_certs:
+            return Result(
+                ResultType.SKIPPED,
+                "No outstanding CSRs matched a stored certificate",
+            )
+        return Result(ResultType.COMPLETED)

--- a/sunbeam-python/sunbeam/features/tls/common.py
+++ b/sunbeam-python/sunbeam/features/tls/common.py
@@ -40,7 +40,10 @@ from sunbeam.core.openstack import OPENSTACK_MODEL
 from sunbeam.features.interface.utils import (
     encode_base64_as_string,
     generate_ca_chain,
+    get_cn_from_cert,
+    get_cn_from_csr,
     get_subject_from_csr,
+    is_cert_expired,
     is_certificate_valid,
     normalize_pem,
 )
@@ -791,22 +794,43 @@ class ReapplyTLSCertificatesStep(ConfigureTLSCertificatesStep):
             elif unit_name:
                 app = unit_name.split("/")[0]
 
-            subject = get_subject_from_csr(csr)
-            if not subject:
-                LOG.warning("Skipping invalid CSR for unit %s", unit_name)
+            cn = get_cn_from_csr(csr)
+            if not cn:
+                LOG.warning("Skipping CSR with no CN for unit %s", unit_name)
                 continue
 
-            stored_cert = stored_certs.get(subject, {}).get("certificate")
+            # Find a stored certificate whose CN matches the CSR's CN
+            # and that has not yet expired.
+            stored_cert = None
+            for stored_data in stored_certs.values():
+                cert_b64 = stored_data.get("certificate")
+                if cert_b64 and get_cn_from_cert(cert_b64) == cn:
+                    if is_cert_expired(cert_b64):
+                        LOG.warning(
+                            "Stored certificate for CN %s has expired; skipping.",
+                            cn,
+                        )
+                        continue
+                    stored_cert = cert_b64
+                    break
+
             if not stored_cert:
                 LOG.warning(
-                    "No stored certificate for outstanding CSR (app=%s, subject=%s); "
+                    "No stored certificate for outstanding CSR (app=%s, cn=%s); "
                     "skipping. Sign it with `sunbeam tls ca unit_certs`.",
                     app,
-                    subject,
+                    cn,
                 )
                 continue
+                
+            LOG.debug(
+                "Re-providing stored certificate for outstanding CSR (app=%s, cn=%s, cert=%s)",
+                app,
+                cn,
+                stored_cert,
+            )
 
-            self.process_certs[subject] = {
+            self.process_certs[cn] = {
                 "app": app,
                 "unit": unit_name,
                 "relation_id": relation_id,

--- a/sunbeam-python/sunbeam/features/tls/common.py
+++ b/sunbeam-python/sunbeam/features/tls/common.py
@@ -738,6 +738,45 @@ class ReapplyTLSCertificatesStep(ConfigureTLSCertificatesStep):
         """This step never prompts the user."""
         return False
 
+    def _find_matching_stored_cert(
+        self,
+        stored_certs: dict,
+        csr: str,
+        cn: str,
+        app: str | None,
+    ) -> str | None:
+        """Return a stored certificate matching the CSR, if any.
+
+        A stored certificate matches when its CN and public key match the
+        CSR and it has not yet expired.
+        """
+        for stored_data in stored_certs.values():
+            cert_b64 = stored_data.get("certificate")
+            if not cert_b64:
+                continue
+            if (cert_cn := get_cn_from_cert(cert_b64)) and cert_cn != cn:
+                LOG.warning(
+                    "Stored certificate CN doesn't match CSR: %s != %s",
+                    cert_cn,
+                    cn,
+                )
+            if not cert_and_csr_public_key_match(cert_b64, csr):
+                LOG.warning(
+                    "Stored certificate CN matches but public key differs "
+                    "for CSR (app=%s, cn=%s); skipping.",
+                    app,
+                    cn,
+                )
+                continue
+            if is_cert_expired(cert_b64):
+                LOG.warning(
+                    "Stored certificate for CN %s has expired; skipping.",
+                    cn,
+                )
+                continue
+            return cert_b64
+        return None
+
     def is_skip(self, context: StepContext) -> Result:
         """Collect outstanding CSRs and match them to stored certificates.
 
@@ -802,29 +841,7 @@ class ReapplyTLSCertificatesStep(ConfigureTLSCertificatesStep):
 
             # Find a stored certificate whose CN and public key match the CSR
             # and that has not yet expired.
-            stored_cert = None
-            for stored_data in stored_certs.values():
-                cert_b64 = stored_data.get("certificate")
-                if not cert_b64:
-                    continue
-                if get_cn_from_cert(cert_b64) != cn:
-                    continue
-                if not cert_and_csr_public_key_match(cert_b64, csr):
-                    LOG.warning(
-                        "Stored certificate CN matches but public key differs "
-                        "for CSR (app=%s, cn=%s); skipping.",
-                        app,
-                        cn,
-                    )
-                    continue
-                if is_cert_expired(cert_b64):
-                    LOG.warning(
-                        "Stored certificate for CN %s has expired; skipping.",
-                        cn,
-                    )
-                    continue
-                stored_cert = cert_b64
-                break
+            stored_cert = self._find_matching_stored_cert(stored_certs, csr, cn, app)
 
             if not stored_cert:
                 LOG.warning(
@@ -834,9 +851,10 @@ class ReapplyTLSCertificatesStep(ConfigureTLSCertificatesStep):
                     cn,
                 )
                 continue
-                
+
             LOG.debug(
-                "Re-providing stored certificate for outstanding CSR (app=%s, cn=%s, cert=%s)",
+                "Re-providing stored certificate for outstanding CSR "
+                "(app=%s, cn=%s, cert=%s)",
                 app,
                 cn,
                 stored_cert,

--- a/sunbeam-python/tests/unit/sunbeam/commands/test_refresh.py
+++ b/sunbeam-python/tests/unit/sunbeam/commands/test_refresh.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 from sunbeam.clusterd.service import ManifestItemNotFoundException
 from sunbeam.commands.refresh import _stored_manifest_risk, refresh
 from sunbeam.core.common import RiskLevel
+from sunbeam.features.tls.ca import CaTlsFeature
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -430,3 +431,58 @@ class TestRefreshWarning:
 
         assert result.exit_code != 0
         assert "mutually exclusive" in result.output.lower()
+
+
+class TestRefreshFixTlsCerts:
+    """Tests for the automatic tls.ca certificate re-provision on refresh."""
+
+    def _invoke(self, args, deployment):
+        runner = CliRunner()
+        return runner.invoke(refresh, args, obj=deployment)
+
+    def _deployment_with_feature(self, mocker, feature):
+        mocker.patch(
+            "sunbeam.commands.refresh.infer_risk",
+            return_value=RiskLevel.STABLE,
+        )
+        client = _build_client("stable")
+        deployment = _build_deployment(client)
+        deployment.get_feature_manager.return_value.resolve_feature.return_value = (
+            feature
+        )
+        return deployment
+
+    def test_reapply_called_when_tls_ca_enabled(self, mocker):
+        feature = MagicMock(spec=CaTlsFeature)
+        feature.is_enabled.return_value = True
+        deployment = self._deployment_with_feature(mocker, feature)
+
+        result = self._invoke([], deployment)
+
+        assert result.exit_code == 0
+        feature.reapply_certificates.assert_called_once()
+        assert "TLS certificate re-provision complete." in result.output
+
+    @pytest.mark.parametrize(
+        "is_enabled,args",
+        [
+            pytest.param(False, [], id="tls_ca_not_enabled"),
+            pytest.param(True, ["--upgrade-release"], id="upgrade_release"),
+        ],
+    )
+    def test_reapply_not_called(self, mocker, is_enabled, args):
+        feature = MagicMock(spec=CaTlsFeature)
+        feature.is_enabled.return_value = is_enabled
+        deployment = self._deployment_with_feature(mocker, feature)
+
+        result = self._invoke(args, deployment)
+
+        assert result.exit_code == 0
+        feature.reapply_certificates.assert_not_called()
+
+    def test_skipped_when_tls_ca_feature_missing(self, mocker):
+        deployment = self._deployment_with_feature(mocker, None)
+
+        result = self._invoke([], deployment)
+
+        assert result.exit_code == 0

--- a/sunbeam-python/tests/unit/sunbeam/features/test_tls.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_tls.py
@@ -546,6 +546,125 @@ class TestConfigureTLSCertificatesStep:
         assert result.result_type == ResultType.COMPLETED
 
 
+class TestReapplyTLSCertificatesStep:
+    def _outstanding(self, jhelper, certs):
+        jhelper.run_action.return_value = {
+            "return-code": 0,
+            "result": json.dumps(certs),
+        }
+
+    def test_has_no_prompts(self, cclient, jhelper):
+        step = tls.ReapplyTLSCertificatesStep(cclient, jhelper, "fake-cert")
+        assert step.has_prompts() is False
+
+    def test_is_skip_when_no_outstanding_requests(
+        self, cclient, jhelper, step_context, load_answers
+    ):
+        self._outstanding(jhelper, [])
+        step = tls.ReapplyTLSCertificatesStep(cclient, jhelper, "fake-cert")
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        load_answers.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "stored,csr_subject",
+        [
+            pytest.param({}, None, id="no_stored_certificates"),
+            pytest.param(
+                {"certificates": {"subject-old": {"certificate": "stored-cert"}}},
+                "subject-new",
+                id="subject_mismatch",
+            ),
+        ],
+    )
+    def test_is_skip_when_no_cert_can_be_matched(
+        self,
+        cclient,
+        jhelper,
+        step_context,
+        load_answers,
+        get_subject_from_csr,
+        stored,
+        csr_subject,
+    ):
+        self._outstanding(
+            jhelper, [{"unit_name": "traefik/0", "csr": "csr", "relation_id": 1}]
+        )
+        load_answers.return_value = stored
+        get_subject_from_csr.return_value = csr_subject
+        jhelper.get_relation_map.return_value = {"certificates:1": "traefik"}
+        step = tls.ReapplyTLSCertificatesStep(cclient, jhelper, "fake-cert")
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.SKIPPED
+        assert step.process_certs == {}
+
+    def test_is_skip_matches_stored_certificate(
+        self, cclient, jhelper, step_context, load_answers, get_subject_from_csr
+    ):
+        self._outstanding(
+            jhelper, [{"unit_name": "traefik/0", "csr": "csr", "relation_id": 1}]
+        )
+        get_subject_from_csr.return_value = "subject1"
+        load_answers.return_value = {
+            "certificates": {"subject1": {"certificate": "stored-cert"}}
+        }
+        jhelper.get_relation_map.return_value = {"certificates:1": "traefik"}
+        step = tls.ReapplyTLSCertificatesStep(cclient, jhelper, "fake-cert")
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        assert step.process_certs == {
+            "subject1": {
+                "app": "traefik",
+                "unit": "traefik/0",
+                "relation_id": 1,
+                "csr": "csr",
+                "certificate": "stored-cert",
+            }
+        }
+
+    def test_is_skip_when_action_returns_failed_return_code(
+        self, cclient, jhelper, step_context, load_answers
+    ):
+        jhelper.run_action.return_value = {"return-code": 2}
+        step = tls.ReapplyTLSCertificatesStep(cclient, jhelper, "fake-cert")
+
+        result = step.is_skip(step_context)
+
+        assert result.result_type == ResultType.FAILED
+        load_answers.assert_not_called()
+
+    def test_run_reprovides_matched_certificate(
+        self, cclient, jhelper, step_context, load_answers, get_subject_from_csr
+    ):
+        self._outstanding(
+            jhelper, [{"unit_name": "traefik/0", "csr": "csr", "relation_id": 1}]
+        )
+        get_subject_from_csr.return_value = "subject1"
+        load_answers.return_value = {
+            "certificates": {"subject1": {"certificate": "stored-cert"}}
+        }
+        jhelper.get_relation_map.return_value = {"certificates:1": "traefik"}
+        step = tls.ReapplyTLSCertificatesStep(cclient, jhelper, "fake-cert")
+
+        assert step.is_skip(step_context).result_type == ResultType.COMPLETED
+
+        jhelper.run_action.return_value = {"return-code": 0}
+        result = step.run(step_context)
+
+        assert result.result_type == ResultType.COMPLETED
+        action_name = jhelper.run_action.call_args.args[2]
+        action_params = jhelper.run_action.call_args.args[3]
+        assert action_name == "provide-certificate"
+        assert action_params["certificate"] == "stored-cert"
+        assert action_params["relation-id"] == 1
+
+
 class FakeUnit:
     def __init__(self, status, message):
         class WorkloadStatus:

--- a/sunbeam-python/tests/unit/sunbeam/features/test_tls.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_tls.py
@@ -41,6 +41,30 @@ def get_subject_from_csr():
 
 
 @pytest.fixture()
+def get_cn_from_csr():
+    with patch.object(tls, "get_cn_from_csr") as p:
+        yield p
+
+
+@pytest.fixture()
+def get_cn_from_cert():
+    with patch.object(tls, "get_cn_from_cert") as p:
+        yield p
+
+
+@pytest.fixture()
+def cert_and_csr_public_key_match():
+    with patch.object(tls, "cert_and_csr_public_key_match", return_value=True) as p:
+        yield p
+
+
+@pytest.fixture()
+def is_cert_expired():
+    with patch.object(tls, "is_cert_expired", return_value=False) as p:
+        yield p
+
+
+@pytest.fixture()
 def is_certificate_valid():
     with patch.object(tls, "is_certificate_valid") as p:
         yield p
@@ -569,13 +593,29 @@ class TestReapplyTLSCertificatesStep:
         load_answers.assert_not_called()
 
     @pytest.mark.parametrize(
-        "stored,csr_subject",
+        "stored,cn,public_key_match,expired",
         [
-            pytest.param({}, None, id="no_stored_certificates"),
+            pytest.param({}, "subject1", True, False, id="no_stored_certificates"),
             pytest.param(
-                {"certificates": {"subject-old": {"certificate": "stored-cert"}}},
-                "subject-new",
-                id="subject_mismatch",
+                {"certificates": {"subject1": {"certificate": "stored-cert"}}},
+                "subject1",
+                False,
+                False,
+                id="public_key_mismatch",
+            ),
+            pytest.param(
+                {"certificates": {"subject1": {"certificate": "stored-cert"}}},
+                "subject1",
+                True,
+                True,
+                id="certificate_expired",
+            ),
+            pytest.param(
+                {"certificates": {"subject1": {"certificate": "stored-cert"}}},
+                None,
+                True,
+                False,
+                id="csr_without_cn",
             ),
         ],
     )
@@ -585,15 +625,23 @@ class TestReapplyTLSCertificatesStep:
         jhelper,
         step_context,
         load_answers,
-        get_subject_from_csr,
+        get_cn_from_csr,
+        get_cn_from_cert,
+        cert_and_csr_public_key_match,
+        is_cert_expired,
         stored,
-        csr_subject,
+        cn,
+        public_key_match,
+        expired,
     ):
         self._outstanding(
             jhelper, [{"unit_name": "traefik/0", "csr": "csr", "relation_id": 1}]
         )
         load_answers.return_value = stored
-        get_subject_from_csr.return_value = csr_subject
+        get_cn_from_csr.return_value = cn
+        get_cn_from_cert.return_value = cn
+        cert_and_csr_public_key_match.return_value = public_key_match
+        is_cert_expired.return_value = expired
         jhelper.get_relation_map.return_value = {"certificates:1": "traefik"}
         step = tls.ReapplyTLSCertificatesStep(cclient, jhelper, "fake-cert")
 
@@ -603,12 +651,21 @@ class TestReapplyTLSCertificatesStep:
         assert step.process_certs == {}
 
     def test_is_skip_matches_stored_certificate(
-        self, cclient, jhelper, step_context, load_answers, get_subject_from_csr
+        self,
+        cclient,
+        jhelper,
+        step_context,
+        load_answers,
+        get_cn_from_csr,
+        get_cn_from_cert,
+        cert_and_csr_public_key_match,
+        is_cert_expired,
     ):
         self._outstanding(
             jhelper, [{"unit_name": "traefik/0", "csr": "csr", "relation_id": 1}]
         )
-        get_subject_from_csr.return_value = "subject1"
+        get_cn_from_csr.return_value = "subject1"
+        get_cn_from_cert.return_value = "subject1"
         load_answers.return_value = {
             "certificates": {"subject1": {"certificate": "stored-cert"}}
         }
@@ -640,12 +697,21 @@ class TestReapplyTLSCertificatesStep:
         load_answers.assert_not_called()
 
     def test_run_reprovides_matched_certificate(
-        self, cclient, jhelper, step_context, load_answers, get_subject_from_csr
+        self,
+        cclient,
+        jhelper,
+        step_context,
+        load_answers,
+        get_cn_from_csr,
+        get_cn_from_cert,
+        cert_and_csr_public_key_match,
+        is_cert_expired,
     ):
         self._outstanding(
             jhelper, [{"unit_name": "traefik/0", "csr": "csr", "relation_id": 1}]
         )
-        get_subject_from_csr.return_value = "subject1"
+        get_cn_from_csr.return_value = "subject1"
+        get_cn_from_cert.return_value = "subject1"
         load_answers.return_value = {
             "certificates": {"subject1": {"certificate": "stored-cert"}}
         }


### PR DESCRIPTION
The release of traefik revision 281 introduces managing certificates in "APP" mode. However, due to an issue with the tls-certiicates library, the corresponding private_key did not had the correct scope, which introduce a risk of service disruption . This PR proposes a fix so that deployments that are in a "degraded" state can self-heal after running the `sunbeam refresh` command.

The PR adds a custom logic towards the end of the `refresh` command to find outstanding CSRs, check that:
1. The subject matches the certificates provided by the operator via `sunbeam tls ca unit_certs`
2. The public key of the certificate matches the outstanding CSR
3. The certificate has not expired

Then rerun `provide-certifcate` action on `manual-tls-certificates` using a certificate that matched from the previous step.

<!--
The PR title should comply with conventional commits: <type>(optional <scope>): <description>

Please also ensure all commits in this PR comply with our conventional commits
specification: https://www.conventionalcommits.org/en/v1.0.0/
-->

<!-- Why this change is needed and what it does. -->

Assisted-By: copilot

Related-PR: https://github.com/canonical/traefik-k8s-operator/pull/729/changes
Related-bug: https://github.com/canonical/traefik-k8s-operator/issues/709


## QA steps

<!--

Describe how a reviewer can test this change.

-->

These steps need to be performed on a sunbeam deployment after enabling tls ca for the public endpoints

1. Save the current private key
```
TLS_KEY_SECRET_ID=$(juju secrets --format yaml | python3 -c "
import sys,yaml
s=yaml.safe_load(sys.stdin)
[print(k) for k,v in s.items() if v.get(label)==tls-key]")

juju show-secret ${TLS_KEY_SECRET_ID} --reveal --format yaml \
    | python3 -c "
import sys,yaml,json
d=list(yaml.safe_load(sys.stdin).values())[0]
yaml.dump({private-keys:d[content][private-keys]},open(/tmp/orig.yaml,w))"
```

2. Replace the current private key with a random one ( we'll throw it away later, it's just to simulate a replacement of the CSR )
```
juju update-secret ${TLS_KEY_SECRET_ID} --file /tmp/new_tls_key.yaml
jhack fire traefik-public/0 config-changed
sleep 15
```

3. Restore the original key
```
juju update-secret ${TLS_KEY_SECRET_ID} --file /tmp/orig.yaml
jhack fire traefik-public/0 config-changed
sleep 15
```

4. Re-provide certificate
```
openstack.sunbeam cluster refresh
```