### PR TITLE
fix: scope LDAP domain terraform applies to LDAP resources

### DIFF
--- a/sunbeam-python/sunbeam/features/ldap/feature.py
+++ b/sunbeam-python/sunbeam/features/ldap/feature.py
@@ -47,6 +47,16 @@ console = Console()
 APPLICATION_DEPLOY_TIMEOUT = 900  # 15 minutes
 APPLICATION_REMOVE_TIMEOUT = 300  # 5 minutes
 
+# The LDAP steps reapply the whole OpenStack plan, which reverts any
+# out-of-band charm config (e.g. Traefik TLS set with juju config) as
+# drift. Restrict the apply to the LDAP domain resources only.
+# See LP#2159042.
+LDAP_APPLY_TARGETS = [
+    "-target=juju_application.ldap-apps",
+    "-target=juju_integration.ldap-apps-to-logging",
+    "-target=juju_integration.ldap-to-keystone",
+]
+
 
 class DisableLDAPDomainStep(BaseStep, JujuStepHelper):
     """Generic step to enable OpenStack application using Terraform."""
@@ -95,7 +105,7 @@ class DisableLDAPDomainStep(BaseStep, JujuStepHelper):
         update_config(self.client, config_key, tfvars)
 
         try:
-            self.tfhelper.apply(reporter=context.reporter)
+            self.tfhelper.apply(LDAP_APPLY_TARGETS, reporter=context.reporter)
         except TerraformException as e:
             return Result(ResultType.FAILED, str(e))
 
@@ -163,7 +173,7 @@ class UpdateLDAPDomainStep(BaseStep, JujuStepHelper):
         update_config(self.client, config_key, tfvars)
 
         try:
-            self.tfhelper.apply(reporter=context.reporter)
+            self.tfhelper.apply(LDAP_APPLY_TARGETS, reporter=context.reporter)
         except TerraformException as e:
             return Result(ResultType.FAILED, str(e))
         charm_name = "keystone-ldap-{}".format(self.charm_config["domain-name"])
@@ -233,7 +243,7 @@ class AddLDAPDomainStep(BaseStep, JujuStepHelper):
         update_config(self.client, config_key, tfvars)
 
         try:
-            self.tfhelper.apply(reporter=context.reporter)
+            self.tfhelper.apply(LDAP_APPLY_TARGETS, reporter=context.reporter)
         except TerraformException as e:
             return Result(ResultType.FAILED, str(e))
         charm_name = "keystone-ldap-{}".format(self.charm_config["domain-name"])

--- a/sunbeam-python/tests/unit/sunbeam/features/test_ldap.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_ldap.py
@@ -9,6 +9,7 @@ from sunbeam.core.common import ResultType
 from sunbeam.core.terraform import TerraformException
 from sunbeam.features.interface.v1.openstack import TerraformPlanLocation
 from sunbeam.features.ldap.feature import (
+    LDAP_APPLY_TARGETS,
     AddLDAPDomainStep,
     DisableLDAPDomainStep,
     LDAPFeature,
@@ -71,7 +72,9 @@ class TestAddLDAPDomainStep:
                 "ldap-apps": {"dom1": {"domain-name": "dom1"}},
             }
         )
-        step.tfhelper.apply.assert_called_once_with(reporter=step_context.reporter)
+        step.tfhelper.apply.assert_called_once_with(
+            LDAP_APPLY_TARGETS, reporter=step_context.reporter
+        )
         assert result.result_type == ResultType.COMPLETED
 
     def test_enable_second_domain(self, read_config, update_config, snap, step_context):
@@ -90,7 +93,9 @@ class TestAddLDAPDomainStep:
                 },
             }
         )
-        step.tfhelper.apply.assert_called_once_with(reporter=step_context.reporter)
+        step.tfhelper.apply.assert_called_once_with(
+            LDAP_APPLY_TARGETS, reporter=step_context.reporter
+        )
         assert result.result_type == ResultType.COMPLETED
 
     def test_enable_tf_apply_failed(
@@ -120,7 +125,9 @@ class TestAddLDAPDomainStep:
                 "ldap-apps": {"dom1": {"domain-name": "dom1"}},
             }
         )
-        step.tfhelper.apply.assert_called_once_with(reporter=step_context.reporter)
+        step.tfhelper.apply.assert_called_once_with(
+            LDAP_APPLY_TARGETS, reporter=step_context.reporter
+        )
         assert result.result_type == ResultType.FAILED
         assert result.message == "timed out"
 
@@ -150,7 +157,9 @@ class TestDisableLDAPDomainStep:
         step.tfhelper.write_tfvars.assert_called_with(
             {"ldap-channel": "2023.2/edge", "ldap-apps": {}}
         )
-        step.tfhelper.apply.assert_called_once_with(reporter=step_context.reporter)
+        step.tfhelper.apply.assert_called_once_with(
+            LDAP_APPLY_TARGETS, reporter=step_context.reporter
+        )
 
     def test_disable_tf_apply_failed(
         self, read_config, update_config, snap, step_context
@@ -165,7 +174,9 @@ class TestDisableLDAPDomainStep:
         step.tfhelper.write_tfvars.assert_called_with(
             {"ldap-channel": "2023.2/edge", "ldap-apps": {}}
         )
-        step.tfhelper.apply.assert_called_once_with(reporter=step_context.reporter)
+        step.tfhelper.apply.assert_called_once_with(
+            LDAP_APPLY_TARGETS, reporter=step_context.reporter
+        )
         assert result.result_type == ResultType.FAILED
         assert result.message == "apply failed..."
 
@@ -214,7 +225,9 @@ class TestUpdateLDAPDomainStep:
                 "ldap-apps": {"dom1": {"domain-name": "dom1"}},
             }
         )
-        step.tfhelper.apply.assert_called_once_with(reporter=step_context.reporter)
+        step.tfhelper.apply.assert_called_once_with(
+            LDAP_APPLY_TARGETS, reporter=step_context.reporter
+        )
         assert result.result_type == ResultType.COMPLETED
 
     def test_update_wrong_domain(self, read_config, update_config, snap, step_context):
@@ -239,7 +252,9 @@ class TestUpdateLDAPDomainStep:
         )
         step.tfhelper.apply.side_effect = TerraformException("apply failed...")
         result = step.run(step_context)
-        step.tfhelper.apply.assert_called_once_with(reporter=step_context.reporter)
+        step.tfhelper.apply.assert_called_once_with(
+            LDAP_APPLY_TARGETS, reporter=step_context.reporter
+        )
         assert result.result_type == ResultType.FAILED
         assert result.message == "apply failed..."
 
@@ -256,6 +271,8 @@ class TestUpdateLDAPDomainStep:
         self.jhelper.wait_until_active.side_effect = TimeoutError("timed out")
         step.tfhelper.apply.side_effect = TerraformException("apply failed...")
         result = step.run(step_context)
-        step.tfhelper.apply.assert_called_once_with(reporter=step_context.reporter)
+        step.tfhelper.apply.assert_called_once_with(
+            LDAP_APPLY_TARGETS, reporter=step_context.reporter
+        )
         assert result.result_type == ResultType.FAILED
         assert result.message == "apply failed..."


### PR DESCRIPTION
Clean cherry-pick of bf67f546 (#877) to stable/2024.1.

The LDAP add/update/remove-domain steps re-apply the entire OpenStack
Terraform plan. Since Terraform owns the charm config of every application in
the plan, any config set out-of-band with juju config (e.g. Traefik TLS
certificates) was reverted as drift whenever an LDAP domain was managed.

Pass -target flags for the three LDAP domain resources
(juju_application.ldap-apps, juju_integration.ldap-apps-to-logging,
juju_integration.ldap-to-keystone) so these steps only reconcile what they
own — the same pattern already used in steps/mysql.py, steps/hypervisor.py
and steps/vault.py. Targeted applies still destroy orphaned for_each
instances, so remove-domain continues to remove the keystone-ldap-<domain>
application.

Closes-bug: [#2159042](https://bugs.launchpad.net/snap-openstack/+bug/2159042)

### QA steps

On a deployment with the LDAP feature enabled:

1. Set TLS config on traefik-public out-of-band (a self-signed cert is fine):

```
    openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
      -keyout key.pem -out cert.pem -subj "/CN=cloud.test"
    juju config -m openstack traefik-public \
      tls-cert="$(cat cert.pem)" tls-key="$(cat key.pem)"
```

2. Run each LDAP domain operation (the LDAP server does not need to exist;

    keystone-ldap-k8s is a config-only charm):

```
    sunbeam ldap add-domain testdom --domain-config-file domain.yaml
    sunbeam ldap update-domain testdom --domain-config-file domain.yaml
    sunbeam ldap remove-domain testdom
```

3. After each operation, verify the TLS config survived (without this fix,
    add-domain clears it):

`    juju config -m openstack traefik-public tls-cert`

4. Verify remove-domain still deletes the domain application:

`    juju status -m openstack | grep keystone-ldap   # expect no output`

Verified end-to-end on a single-node 2024.1 deployment (repro on stock rev
1060, fix confirmed with a patched snap); transcript and logs attached to the
LP bug.

### Links

Bug: https://bugs.launchpad.net/snap-openstack/+bug/2159042
Jira card: [OPEN-4637](https://warthogs.atlassian.net/browse/OPEN-4637)


[OPEN-4637]: https://warthogs.atlassian.net/browse/OPEN-4637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ