### PR TITLE
chore: upgrade terraform

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -131,7 +131,7 @@ parts:
     source: https://github.com/hashicorp/terraform
     source-depth: 1
     source-type: git
-    source-tag: "v1.5.7"
+    source-tag: "v1.15.8"
     build-snaps: [go]
     build-environment:
       - CGO_ENABLED: "0"


### PR DESCRIPTION
Newer version of the juju terraform provider require terraform 1.6 or more, or is failing with: `Missing Resource Identity After Update.` on plan re-apply with a harmless config change.

Terraform was kept <1.6 mainly because of the license change at 1.6, but we're still under BUSL Additional Use because we do not offer terraform service, but use it as an internal mechanism to manage the deployment.

## QA steps

QA can be validated by deploying and configure a sunbeam deployment.
Most sunbeam commands will apply terraform plans, and the hypervisor plans is getting re-applied with a minor config change through bootstrap and configure commands.

