### PR TITLE
fix: enable observability with external COS on MAAS deployments

### DIFF
--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -1715,6 +1715,7 @@ class ExternalObservabilityFeature(ObservabilityFeature):
                     self,
                     tfhelper_observability_agent_infra,
                     jhelper,
+                    accepted_app_status=["active", "blocked"],
                 ),
             ]
             run_plan(infra_agent_plan, console, show_hints)

--- a/sunbeam-python/sunbeam/features/observability/feature.py
+++ b/sunbeam-python/sunbeam/features/observability/feature.py
@@ -937,7 +937,7 @@ class RemoveRemoteCosOffersStep(BaseStep, JujuStepHelper):
         self.endpoints = [
             "opentelemetry-collector:grafana-dashboards-provider",
             "opentelemetry-collector:send-remote-write",
-            "opentelemetry-collector:logging-consumer",
+            "opentelemetry-collector:send-loki-logs",
         ]
 
     def _get_relations(self, model: str, endpoints: list[str]) -> list[tuple]:

--- a/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
@@ -794,7 +794,7 @@ class TestRemoveRemoteCosOffersStep:
             Mock(
                 apps={
                     "opentelemetry-collector": Mock(
-                        relations={"logging-consumer": "loki:loki_push_api"}
+                        relations={"send-loki-logs": "loki:loki_push_api"}
                     )
                 }
             ),
@@ -849,7 +849,7 @@ class TestRemoveRemoteCosOffersStep:
             Mock(
                 apps={
                     "opentelemetry-collector": Mock(
-                        relations={"logging-consumer": "loki:loki_push_api"}
+                        relations={"send-loki-logs": "loki:loki_push_api"}
                     )
                 }
             ),

--- a/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_observability.py
@@ -930,6 +930,53 @@ class TestRemoveRemoteCosOffersStep:
         assert result.result_type == ResultType.COMPLETED
 
 
+class TestExternalObservabilityEnablePlans:
+    """Test enablement plans for ExternalObservabilityFeature."""
+
+    def _run_enable_plans(self, feature, deployment, run_plan_obs, is_maas):
+        feature._manifest = Mock()
+        with patch(
+            "sunbeam.features.observability.feature.is_maas_deployment",
+            return_value=is_maas,
+        ):
+            feature.run_enable_plans(deployment, Mock(), False)
+
+        return [step for call in run_plan_obs.call_args_list for step in call.args[0]]
+
+    def test_maas_infra_agent_step_accepts_blocked(
+        self, deployment, run_plan_obs, juju_helper_obs
+    ):
+        """External COS: infra agent is blocked until offers are integrated.
+
+        With an external COS, integrations are only created by
+        IntegrateRemoteCosOffersStep after all agents are deployed, so the
+        infra agent deploy step must accept 'blocked' status (LP#2159965).
+        """
+        feature = observability_feature.ExternalObservabilityFeature()
+        steps = self._run_enable_plans(feature, deployment, run_plan_obs, is_maas=True)
+
+        infra_steps = [
+            step
+            for step in steps
+            if isinstance(step, observability_feature.DeployObservabilityAgentInfraStep)
+        ]
+        assert len(infra_steps) == 1
+        assert "blocked" in infra_steps[0].accepted_app_status
+        assert "active" in infra_steps[0].accepted_app_status
+
+    def test_maas_integrate_offers_runs_after_infra_agent(
+        self, deployment, run_plan_obs, juju_helper_obs
+    ):
+        """Offers are integrated only after the infra agent is deployed."""
+        feature = observability_feature.ExternalObservabilityFeature()
+        steps = self._run_enable_plans(feature, deployment, run_plan_obs, is_maas=True)
+
+        step_types = [type(step) for step in steps]
+        assert step_types.index(
+            observability_feature.IntegrateRemoteCosOffersStep
+        ) > step_types.index(observability_feature.DeployObservabilityAgentInfraStep)
+
+
 class TestObservabilityFeatureTimeouts:
     """Test timeout calculation for ObservabilityFeature."""
 


### PR DESCRIPTION
`sunbeam enable observability external ...` on MAAS deployments timed out after 30 minutes with the `opentelemetry-collector` charms stuck in `blocked` across the `openstack`, `openstack-machines`, and `openstack-infra` models, and the COS offers were never consumed or related.

With an external COS, the collector's COS relations are only created by `IntegrateRemoteCosOffersStep` *after* all agents are deployed, since the terraform juju provider cannot consume offers across controllers (juju/terraform-provider-juju#119). The infra agent deploy step added in eb3c5684 runs before that and waits for the collector to reach `active` — which it can never do at that point. The enable therefore timed out at the infra step and aborted before any integrations were created, leaving every model's collector blocked.

This PR contains two commits:

1. **Accept `blocked` status for the infra agent deploy step in the external flow**, matching the other agent deploy steps which already pass `["active", "blocked"]`. The collector settles to `active` once `IntegrateRemoteCosOffersStep` integrates the offers. The embedded flow is unchanged: it passes offer URLs through terraform, so `active` remains reachable during deploy there.

2. **Fix the stale `logging-consumer` endpoint in `RemoveRemoteCosOffersStep`.** The grafana-agent → opentelemetry-collector migration (f5fc0a15) kept grafana-agent's loki endpoint name; 7fdf5bd8 corrected it to `send-loki-logs` in `IntegrateRemoteCosOffersStep` but missed the remove step, so disabling external observability silently skipped removing the loki relation and then waited for the collector to reach `blocked`, which it may never do while the relation remains. Verified against the charm metadata on Charmhub: the machine charm has `send-loki-logs` and no `logging-consumer`.

Assisted-By: Claude Fable 5
Signed-off-by: Myles Penner <myles.penner@canonical.com>

Closes-bug: [#2159965](https://bugs.launchpad.net/snap-openstack/+bug/2159965)

## QA steps

1. Deploy a MAAS-backed Sunbeam cloud (must be MAAS so the `openstack-infra` model exists).
2. Deploy COS on a separate Juju controller (e.g. cos-lite on MicroK8s/Canonical K8s), create the `grafana-dashboards`, `receive-remote-write`, and `loki-logging` offers, and register that controller on the Sunbeam client.
3. Run `sunbeam enable observability external <controller> <grafana-dashboard-offer-url> <prometheus-receive-remote-write-offer-url> <loki-logging-offer-url>`.
4. Verify the command completes without hitting the 30-minute timeout, and that `juju status` in the `openstack`, `openstack-machines`, and `openstack-infra` models shows `opentelemetry-collector` `active` with the consumed COS SaaS relations in place. Confirm metrics/dashboards/logs arrive in the external Grafana.
5. Run `sunbeam disable observability external` and verify it completes, with all three COS relations (including loki) removed in each model.

Unit tests: new `TestExternalObservabilityEnablePlans` tests assert the external flow constructs the infra step accepting `blocked` and integrates offers only after the infra agent deploy (verified to fail without the fix). `tox -e unit`, `tox -e pep8`, and `tox -e mypy` all pass.

## Links

**Jira card:** [OPEN-4643](https://warthogs.atlassian.net/browse/OPEN-4643)
**Launchpad bug:** [LP#2159965](https://bugs.launchpad.net/snap-openstack/+bug/2159965)


[OPEN-4643]: https://warthogs.atlassian.net/browse/OPEN-4643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ