### PR TITLE
chore: update outdated help flag output

### DIFF
--- a/sunbeam-python/sunbeam/provider/local/commands.py
+++ b/sunbeam-python/sunbeam/provider/local/commands.py
@@ -609,7 +609,7 @@ def deploy_and_migrate_juju_controller(
     default=["control", "compute", "network"],
     callback=validate_roles,
     help="Specify additional roles for the bootstrap node. "
-    "Possible values: compute, storage, network, region_controller. "
+    "Possible values: compute, storage, network, control. "
     "Defaults to the compute role. Can be repeated and comma separated.",
 )
 @click_option_topology


### PR DESCRIPTION
I updated the output of the help flag to ensure that it is up to date with current sunbeam since to my knowledge, region-controller is not a valid value if its not yet enabled by feature gates

## QA steps

run 
```
sunbeam cluster bootstrap --help
```

## Links

