### PR TITLE
chore (loadbalancer): Make Amphora feature generally available

### DIFF
--- a/sunbeam-python/sunbeam/feature_gates.py
+++ b/sunbeam-python/sunbeam/feature_gates.py
@@ -230,7 +230,7 @@ FEATURE_GATES: dict[str, dict[str, bool | list[str]]] = {
         "generally_available": False,  # TODO: Set to True when multi-region is GA
     },
     "feature.loadbalancer-amphora": {
-        "generally_available": False,  # TODO: Set to True when Amphora support is GA
+        "generally_available": True,
     },
 }
 


### PR DESCRIPTION
Loadbalancer Amphora feature is behind a feature gate. Operator needs to set the following config option on snap openstack `feature.loadbalancer-amphora=True`.

The idea is to make the feature Generally Available and move  it out of feature gate. 

## QA steps

sudo snap install openstack --channel <>
sunbeam cluster bootstrap --role control,compute,storage -a
sunbeam configure -a
sunbeam configure loadbalancer

## Links
https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/features/load-balancer/#enabling-the-amphora-provider
