### PR TITLE
fix: add telemetry notifications support for manila-data

### DIFF
--- a/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/main.tf
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/main.tf
@@ -31,7 +31,8 @@ resource "juju_application" "manila-data" {
   }
 
   config = merge({
-    snap-channel = var.manila-data-channel
+    snap-channel                   = var.manila-data-channel
+    enable-telemetry-notifications = var.enable-telemetry-notifications
   }, var.charm-manila-data-config)
   endpoint_bindings = var.endpoint_bindings
 }

--- a/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/variables.tf
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/etc/deploy-manila-data/variables.tf
@@ -59,3 +59,9 @@ variable "database-offer-url" {
   type        = string
   default     = null
 }
+
+variable "enable-telemetry-notifications" {
+  description = "Enable telemetry notifications for manila-data"
+  type        = bool
+  default     = false
+}

--- a/sunbeam-python/sunbeam/features/shared_filesystem/manila_data.py
+++ b/sunbeam-python/sunbeam/features/shared_filesystem/manila_data.py
@@ -52,6 +52,7 @@ class DeployManilaDataApplicationStep(DeployMachineApplicationStep):
         jhelper: JujuHelper,
         manifest: Manifest,
         model: str,
+        extra_tfvars: dict | None = None,
     ):
         super().__init__(
             deployment,
@@ -67,6 +68,7 @@ class DeployManilaDataApplicationStep(DeployMachineApplicationStep):
             "Deploying Manila Data",
         )
         self._offers: dict[str, str | None] = {}
+        self.override_tfvars: dict[str, Any] = extra_tfvars or {}
 
     def get_application_timeout(self) -> int:
         """Return application timeout in seconds."""
@@ -132,6 +134,15 @@ class DeployManilaDataApplicationStep(DeployMachineApplicationStep):
         }
 
         tfvars.update(self._get_offers())
+
+        feature_manager = self.deployment.get_feature_manager()
+        if feature_manager.is_feature_enabled(self.deployment, "telemetry"):
+            tfvars["enable-telemetry-notifications"] = True
+        else:
+            tfvars["enable-telemetry-notifications"] = False
+
+        # Any tfvars that needs override will take precedence from self.override_tfvars
+        tfvars.update(self.override_tfvars)
 
         return tfvars
 

--- a/sunbeam-python/sunbeam/features/telemetry/feature.py
+++ b/sunbeam-python/sunbeam/features/telemetry/feature.py
@@ -24,6 +24,9 @@ from sunbeam.features.interface.v1.openstack import (
     OpenStackControlPlaneFeature,
     TerraformPlanLocation,
 )
+from sunbeam.features.shared_filesystem.manila_data import (
+    DeployManilaDataApplicationStep,
+)
 from sunbeam.steps.cinder_volume import DeployCinderVolumeApplicationStep
 from sunbeam.steps.hypervisor import ReapplyHypervisorTerraformPlanStep
 from sunbeam.steps.juju import RemoveSaasApplicationsStep
@@ -204,6 +207,25 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
             if len(plan3) > 1:  # More than just TerraformInitStep
                 run_plan(plan3, console, show_hints)
 
+        # Reapply manila-data if shared-filesystem feature is enabled
+        feature_manager = deployment.get_feature_manager()
+        if feature_manager.is_feature_enabled(deployment, "shared-filesystem"):
+            tfhelper_manila_data = deployment.get_tfhelper("manila-data-plan")
+            extra_tfvars_manila_data = {"enable-telemetry-notifications": True}
+            manila_data_plan: list[BaseStep] = [
+                TerraformInitStep(tfhelper_manila_data),
+                DeployManilaDataApplicationStep(
+                    deployment,
+                    deployment.get_client(),
+                    tfhelper_manila_data,
+                    jhelper,
+                    self.manifest,
+                    deployment.openstack_machines_model,
+                    extra_tfvars=extra_tfvars_manila_data,
+                ),
+            ]
+            run_plan(manila_data_plan, console, show_hints)
+
         click.echo(f"OpenStack {self.display_name} application enabled.")
 
     def run_disable_plans(self, deployment: Deployment, show_hints: bool) -> None:
@@ -315,6 +337,25 @@ class TelemetryFeature(OpenStackControlPlaneFeature):
 
             if len(plan2) > 1:  # More than just TerraformInitStep
                 run_plan(plan2, console, show_hints)
+
+        # Reapply manila-data if shared-filesystem feature is enabled
+        feature_manager = deployment.get_feature_manager()
+        if feature_manager.is_feature_enabled(deployment, "shared-filesystem"):
+            tfhelper_manila_data = deployment.get_tfhelper("manila-data-plan")
+            extra_tfvars_manila_data = {"enable-telemetry-notifications": False}
+            manila_data_plan: list[BaseStep] = [
+                TerraformInitStep(tfhelper_manila_data),
+                DeployManilaDataApplicationStep(
+                    deployment,
+                    deployment.get_client(),
+                    tfhelper_manila_data,
+                    jhelper,
+                    self.manifest,
+                    deployment.openstack_machines_model,
+                    extra_tfvars=extra_tfvars_manila_data,
+                ),
+            ]
+            run_plan(manila_data_plan, console, show_hints)
 
         click.echo(f"OpenStack {self.display_name} application disabled.")
 

--- a/sunbeam-python/tests/unit/sunbeam/features/shared_filesystem/test_manila_data.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/shared_filesystem/test_manila_data.py
@@ -140,6 +140,9 @@ class TestDeployManilaDataApplicationStep:
             Networks.INTERNAL: "internal",
         }[network]
 
+        feature_manager = basic_deployment.get_feature_manager.return_value
+        feature_manager.is_feature_enabled.return_value = False
+
         tfvars = deploy_manila_data_step.extra_tfvars()
 
         expected_tfvars = {
@@ -165,6 +168,7 @@ class TestDeployManilaDataApplicationStep:
             "keystone-offer-url": "keystone-offer",
             "database-offer-url": "database-offer",
             "amqp-offer-url": "amqp-offer",
+            "enable-telemetry-notifications": False,
         }
         print(tfvars)
         print(expected_tfvars)

--- a/sunbeam-python/tests/unit/sunbeam/features/test_telemetry.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_telemetry.py
@@ -17,6 +17,9 @@ def deployment():
     client = deploy.get_client.return_value
     client.cluster.list_nodes_by_role.return_value = [{"name": "node1", "machineid": 1}]
 
+    feature_manager = deploy.get_feature_manager.return_value
+    feature_manager.is_feature_enabled.return_value = False
+
     return deploy
 
 


### PR DESCRIPTION
Add enable-telemetry-notifications variable to the manila-data terraform plan and feature_manager.is_feature_enabled check in extra_tfvars, mirroring the existing cinder-volume pattern. Reapply manila-data in telemetry enable/disable plans when shared-filesystem is active. Fix existing unit tests to account for the new telemetry flag.

Assisted-By: Copilot (Claude Opus 4.6)

Partial-bug: [#2162762](https://bugs.launchpad.net/snap-openstack/+bug/2162762)

## QA steps

1. Deploy sunbeam
2. Enable telemetry and and shared-filesystem
```
sunbeam enable telemetry
sunbeam enable shared-filesystem
```
4. Verify the config was propagated
```
juju config manila-data enable-telemetry-notifications      # should be true
```
5. Verify config is false after disabling telemetry
```
sunbeam disable telemetry
juju config manila-data enable-telemetry-notifications      # should be false
```

## Links
**Jira card:** [OPEN-4670](https://warthogs.atlassian.net/browse/OPEN-4670)

[OPEN-4670]: https://warthogs.atlassian.net/browse/OPEN-4670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ