### PR TITLE
chore: Make Loadbalancer Amphora feature generally available

### DIFF
--- a/sunbeam-python/sunbeam/feature_gates.py
+++ b/sunbeam-python/sunbeam/feature_gates.py
@@ -238,7 +238,7 @@ FEATURE_GATES: dict[str, dict[str, bool | list[str]]] = {
         "requires": ["feature.microovn-sdn"],
     },
     "feature.loadbalancer-amphora": {
-        "generally_available": False,  # TODO: Set to True when Amphora support is GA
+        "generally_available": True,
         "requires": ["feature.microovn-sdn"],
     },
 }

--- a/sunbeam-python/sunbeam/feature_gates.py
+++ b/sunbeam-python/sunbeam/feature_gates.py
@@ -239,6 +239,9 @@ FEATURE_GATES: dict[str, dict[str, bool | list[str]]] = {
     },
     "feature.loadbalancer-amphora": {
         "generally_available": True,
+        # Amphora requires MicroOVN as the SDN provider. Enforced at use-time
+        # (sunbeam/features/loadbalancer/feature.py) so a default deployment
+        # without microovn-sdn enabled is not blocked at CLI startup.
         "requires": ["feature.microovn-sdn"],
     },
 }
@@ -329,6 +332,11 @@ def validate_feature_gate_config(snap: Optional[Snap] = None) -> None:
     violations: list[str] = []
 
     for gate_key, gate_config in FEATURE_GATES.items():
+        # GA gates' `requires` are enforced at use-time, not at startup/config
+        # validation. Otherwise a GA gate requiring a still-gated feature would
+        # block every default CLI run where that feature is off by default.
+        if gate_config.get("generally_available"):
+            continue
         dep_keys = gate_config.get("requires", [])
         if not isinstance(dep_keys, list) or not dep_keys:
             continue

--- a/sunbeam-python/sunbeam/features/loadbalancer/feature.py
+++ b/sunbeam-python/sunbeam/features/loadbalancer/feature.py
@@ -1800,6 +1800,14 @@ class LoadbalancerFeature(OpenStackControlPlaneFeature):
             run_plan(plan, console, show_hints)
             click.echo("Octavia Amphora provider disabled.")
         else:
+            # Enforce amphora's requires at use-time: amphora needs MicroOVN as
+            # the SDN provider. Declared in FEATURE_GATES but not checked at
+            # startup (GA gate), so verify here before deploying anything.
+            if not is_feature_gate_enabled("feature.microovn-sdn"):
+                raise click.ClickException(
+                    "Octavia Amphora provider requires the MicroOVN SDN feature. "
+                    "Enable it with: snap set openstack feature.microovn-sdn=true"
+                )
             # Enable path: credentials are only needed here
             # (OpenStack resource creation).
             jhelper_keystone = deployment.get_juju_helper(keystone=True)

--- a/sunbeam-python/tests/unit/sunbeam/features/test_loadbalancer.py
+++ b/sunbeam-python/tests/unit/sunbeam/features/test_loadbalancer.py
@@ -1103,6 +1103,66 @@ class TestRunConfigurePlansEarlyExit:
 
 
 # ---------------------------------------------------------------------------
+# run_configure_plans — use-time check for amphora's microovn-sdn requirement
+# ---------------------------------------------------------------------------
+
+
+class TestRunConfigurePlansMicroovnCheck:
+    """Amphora's requires:["feature.microovn-sdn"] is enforced at use-time.
+
+    Amphora is GA, so its `requires` is not checked at startup/config
+    validation (validate_feature_gate_config skips GA gates). Instead it is
+    enforced here, in the enable path of run_configure_plans, before any
+    amphora infrastructure is deployed.
+    """
+
+    def _run_configure_plans(self, amphora_enabled=True, microovn_enabled=True):
+        from unittest.mock import PropertyMock
+
+        feature = LoadbalancerFeature()
+        deployment = Mock()
+
+        answers_sequence = [
+            {_AMPHORA_ENABLED_KEY: True},  # previous state
+            {_AMPHORA_ENABLED_KEY: amphora_enabled},  # after AmphoraConfigStep
+        ]
+        load_answers_iter = iter(answers_sequence)
+
+        with (
+            patch.object(
+                type(feature), "manifest", new_callable=PropertyMock, return_value=None
+            ),
+            patch(
+                "sunbeam.features.loadbalancer.feature.questions.load_answers",
+                side_effect=lambda *_: dict(next(load_answers_iter)),
+            ),
+            patch("sunbeam.features.loadbalancer.feature.run_preflight_checks"),
+            patch("sunbeam.features.loadbalancer.feature.run_plan"),
+            patch("sunbeam.features.loadbalancer.feature.JujuHelper"),
+            patch("sunbeam.features.loadbalancer.feature.is_feature_gate_enabled") as m,
+            patch("sunbeam.features.loadbalancer.feature.retrieve_admin_credentials"),
+            patch("click.echo"),
+        ):
+            m.side_effect = lambda key, snap=None: (
+                key == "feature.microovn-sdn" and microovn_enabled
+            )
+            feature.run_configure_plans(deployment, show_hints=False)
+
+    def test_enable_raises_when_microovn_sdn_disabled(self):
+        """Enable path raises if feature.microovn-sdn is not enabled."""
+        with pytest.raises(click.ClickException, match="MicroOVN SDN feature"):
+            self._run_configure_plans(amphora_enabled=True, microovn_enabled=False)
+
+    def test_enable_proceeds_when_microovn_sdn_enabled(self):
+        """Enable path does not raise when feature.microovn-sdn is enabled."""
+        self._run_configure_plans(amphora_enabled=True, microovn_enabled=True)
+
+    def test_disable_does_not_check_microovn_sdn(self):
+        """Disable path doesn't require microovn-sdn (only enabling does)."""
+        self._run_configure_plans(amphora_enabled=False, microovn_enabled=False)
+
+
+# ---------------------------------------------------------------------------
 # RemoveCNIInfraStep
 # ---------------------------------------------------------------------------
 

--- a/sunbeam-python/tests/unit/sunbeam/test_feature_gates.py
+++ b/sunbeam-python/tests/unit/sunbeam/test_feature_gates.py
@@ -884,7 +884,11 @@ class TestValidateFeatureGateConfig:
         },
     )
     def test_ga_gate_with_unmet_dep(self):
-        """GA gate with unmet dependency still raises."""
+        """GA gate with unmet dependency does not raise at validation.
+
+        GA gates' `requires` are enforced at use-time, not at startup/config
+        validation — otherwise a GA gate requiring a still-gated feature
+        would block every default CLI run where that feature is off.
+        """
         snap = self._mock_snap_with_gates({})
-        with pytest.raises(FeatureGateError, match="feature.x.*requires.*feature.y"):
-            validate_feature_gate_config(snap)
+        validate_feature_gate_config(snap)


### PR DESCRIPTION
Loadbalancer Amphora feature is behind a feature gate. Operator needs to set the following config option on snap openstack feature.loadbalancer-amphora=True.

The idea is to make the feature Generally Available and move it out of feature gate.

Enforce to have checks on microovn-sdn feature gate enablement while running sunbeam configure loadbalancer.

## QA steps

sudo snap install openstack --channel <>
sudo snap set openstack feature.microovn-sdn=True
sudo snap set openstack ovn.provider=microovn
sudo snap set openstack feature.split-roles=true
sunbeam cluster bootstrap --role control,compute,storage -a
sunbeam configure -a
sunbeam configure loadbalancer

## Links
https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/features/load-balancer/#enabling-the-amphora-provider