### PR TITLE
fix: group role-distributor role-mapping by DPU (microovn-<arch>) ins…

### DIFF
--- a/sunbeam-python/sunbeam/core/ovn.py
+++ b/sunbeam-python/sunbeam/core/ovn.py
@@ -10,6 +10,21 @@ from sunbeam.core.juju import JujuHelper
 
 DEFAULT_ARCHITECTURE = "amd64"
 ARM64_ARCHITECTURE = "arm64"
+MICROOVN_APPLICATION = "microovn"
+
+
+def microovn_application_name_for_node(node: dict) -> str:
+    """Return the MicroOVN application a node's unit belongs to.
+
+    DPU nodes get their own per-architecture application (e.g. microovn-arm64);
+    everything else uses the default microovn application. We key off is_dpu
+    rather than arch so a DPU is never grouped with regular nodes of the same
+    architecture.
+    """
+    if not node.get("is_dpu", False):
+        return MICROOVN_APPLICATION
+    arch = node.get("arch") or DEFAULT_ARCHITECTURE
+    return f"{MICROOVN_APPLICATION}-{arch}"
 
 
 class OvnManager:

--- a/sunbeam-python/sunbeam/core/ovn.py
+++ b/sunbeam-python/sunbeam/core/ovn.py
@@ -16,14 +16,13 @@ MICROOVN_APPLICATION = "microovn"
 def microovn_application_name_for_node(node: dict) -> str:
     """Return the MicroOVN application a node's unit belongs to.
 
-    DPU nodes get their own per-architecture application (e.g. microovn-arm64);
-    everything else uses the default microovn application. We key off is_dpu
-    rather than arch so a DPU is never grouped with regular nodes of the same
-    architecture.
+    The application is chosen purely by architecture, matching the deployment
+    naming: the default architecture (amd64) is deployed as plain microovn,
+    and every other architecture gets a microovn-<arch> application.
     """
-    if not node.get("is_dpu", False):
-        return MICROOVN_APPLICATION
     arch = node.get("arch") or DEFAULT_ARCHITECTURE
+    if arch == DEFAULT_ARCHITECTURE:
+        return MICROOVN_APPLICATION
     return f"{MICROOVN_APPLICATION}-{arch}"
 
 

--- a/sunbeam-python/sunbeam/core/ovn.py
+++ b/sunbeam-python/sunbeam/core/ovn.py
@@ -16,9 +16,11 @@ MICROOVN_APPLICATION = "microovn"
 def microovn_application_name_for_node(node: dict) -> str:
     """Return the MicroOVN application a node's unit belongs to.
 
-    The application is chosen purely by architecture, matching the deployment
-    naming: the default architecture (amd64) is deployed as plain microovn,
-    and every other architecture gets a microovn-<arch> application.
+    Find the deployed MicroOVN juju application name based on architecture.
+    The name is dependent on the architecture of the machine is it deployed
+    on. For backwards compatibility and upgrade reasons, a juju application
+    cannot renamed, the amd64 version of the juju application does not include
+    an architecture in the name.
     """
     arch = node.get("arch") or DEFAULT_ARCHITECTURE
     if arch == DEFAULT_ARCHITECTURE:

--- a/sunbeam-python/sunbeam/core/role_assignments.py
+++ b/sunbeam-python/sunbeam/core/role_assignments.py
@@ -8,9 +8,7 @@ from collections.abc import Iterable
 import yaml
 
 from sunbeam.clusterd.client import Client
-
-MICROOVN_APPLICATION = "microovn"
-
+from sunbeam.core.ovn import microovn_application_name_for_node
 
 RoleMapping = dict[str, dict[str, dict[str, dict[str, dict[str, list[str]]]]]]
 
@@ -20,8 +18,13 @@ def build_microovn_role_mapping(
     model_name: str,
     machine_ids: Iterable[str],
 ) -> RoleMapping:
-    """Build the role-distributor mapping for MicroOVN."""
-    machine_roles: dict[str, list[str]] = {}
+    """Build the role-distributor mapping for MicroOVN.
+
+    Machines are grouped by the MicroOVN application their unit belongs to, so
+    the mapping keys line up with the deployed juju applications (microovn for
+    regular nodes, microovn-<arch> for DPUs).
+    """
+    machine_roles_by_app: dict[str, dict[str, list[str]]] = {}
     microovn_machine_ids = {str(machine_id) for machine_id in machine_ids}
 
     for role in ("control", "compute", "network"):
@@ -33,13 +36,12 @@ def build_microovn_role_mapping(
             if machine_id_str not in microovn_machine_ids:
                 continue
             node_roles = set(node.get("role", []))
-            machine_roles[machine_id_str] = _microovn_roles_for_node(node_roles)
+            application_name = microovn_application_name_for_node(node)
+            machine_roles_by_app.setdefault(application_name, {})[machine_id_str] = (
+                _microovn_roles_for_node(node_roles)
+            )
 
-    return _build_mapping(
-        model_name,
-        MICROOVN_APPLICATION,
-        machine_roles,
-    )
+    return _build_mapping(model_name, machine_roles_by_app)
 
 
 def dump_role_mapping(mapping: RoleMapping) -> str:
@@ -49,8 +51,7 @@ def dump_role_mapping(mapping: RoleMapping) -> str:
 
 def _build_mapping(
     model_name: str,
-    application_name: str,
-    machine_roles: dict[str, list[str]],
+    machine_roles_by_app: dict[str, dict[str, list[str]]],
 ) -> RoleMapping:
     return {
         model_name: {
@@ -60,6 +61,7 @@ def _build_mapping(
                     for machine_id, roles in sorted(machine_roles.items())
                 }
             }
+            for application_name, machine_roles in sorted(machine_roles_by_app.items())
         }
     }
 

--- a/sunbeam-python/sunbeam/core/role_assignments.py
+++ b/sunbeam-python/sunbeam/core/role_assignments.py
@@ -22,7 +22,7 @@ def build_microovn_role_mapping(
 
     Machines are grouped by the MicroOVN application their unit belongs to, so
     the mapping keys line up with the deployed juju applications (microovn for
-    regular nodes, microovn-<arch> for DPUs).
+    amd64 nodes, microovn-<arch> for DPUs).
     """
     machine_roles_by_app: dict[str, dict[str, list[str]]] = {}
     microovn_machine_ids = {str(machine_id) for machine_id in machine_ids}

--- a/sunbeam-python/tests/unit/sunbeam/core/test_ovn.py
+++ b/sunbeam-python/tests/unit/sunbeam/core/test_ovn.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 - Canonical Ltd
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from sunbeam.core.ovn import (
+    DEFAULT_ARCHITECTURE,
+    MICROOVN_APPLICATION,
+    microovn_application_name_for_node,
+)
+
+
+class TestMicroovnApplicationNameForNode:
+    def test_default_architecture_uses_default_application(self):
+        node = {"arch": DEFAULT_ARCHITECTURE}
+
+        assert microovn_application_name_for_node(node) == MICROOVN_APPLICATION
+
+    def test_missing_architecture_defaults_to_default_application(self):
+        node = {}
+
+        assert microovn_application_name_for_node(node) == MICROOVN_APPLICATION
+
+    def test_empty_architecture_defaults_to_default_application(self):
+        node = {"arch": ""}
+
+        assert microovn_application_name_for_node(node) == MICROOVN_APPLICATION
+
+    def test_non_default_architecture_uses_per_arch_application(self):
+        node = {"arch": "arm64"}
+
+        assert (
+            microovn_application_name_for_node(node) == f"{MICROOVN_APPLICATION}-arm64"
+        )
+
+    @pytest.mark.parametrize("is_dpu", [True, False])
+    def test_grouping_is_independent_of_is_dpu(self, is_dpu):
+        # Application selection is purely architecture based; is_dpu must not
+        # change the result.
+        amd64_node = {"arch": DEFAULT_ARCHITECTURE, "is_dpu": is_dpu}
+        arm64_node = {"arch": "arm64", "is_dpu": is_dpu}
+
+        assert microovn_application_name_for_node(amd64_node) == MICROOVN_APPLICATION
+        assert (
+            microovn_application_name_for_node(arm64_node)
+            == f"{MICROOVN_APPLICATION}-arm64"
+        )

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_role_distributor.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_role_distributor.py
@@ -62,6 +62,62 @@ class TestDeployRoleDistributorApplicationStep:
         }
         assert extra_tfvars["role_distributor_machine_ids"] == ["0"]
 
+    def test_extra_tfvars_groups_dpu_nodes_under_dedicated_application(
+        self,
+        basic_deployment,
+        basic_client,
+        basic_tfhelper,
+        basic_jhelper,
+        basic_manifest,
+        test_model,
+    ):
+        # DPUs move to microovn-<arch>; the amd64 DPU must not fall back to microovn.
+        basic_deployment.get_ovn_manager.return_value.get_machines.return_value = [
+            "0",
+            "5",
+            "6",
+        ]
+        basic_client.cluster.list_nodes_by_role.side_effect = lambda role: {
+            "control": [{"machineid": "0", "role": ["control"]}],
+            "network": [
+                {
+                    "machineid": "5",
+                    "role": ["network"],
+                    "arch": "arm64",
+                    "is_dpu": True,
+                },
+                {
+                    "machineid": "6",
+                    "role": ["network"],
+                    "arch": "amd64",
+                    "is_dpu": True,
+                },
+            ],
+        }.get(role, [])
+
+        step = DeployRoleDistributorApplicationStep(
+            basic_deployment,
+            basic_client,
+            basic_tfhelper,
+            basic_jhelper,
+            basic_manifest,
+            "openstack-machines",
+        )
+
+        machines = yaml.safe_load(
+            step.extra_tfvars()["charm_role_distributor_config"]["role-mapping"]
+        )["openstack-machines"]
+
+        assert machines["microovn"]["machines"] == {
+            "0": {"roles": ["chassis", "central"]}
+        }
+        assert machines["microovn-arm64"]["machines"] == {
+            "5": {"roles": ["chassis", "gateway"]}
+        }
+        assert machines["microovn-amd64"]["machines"] == {
+            "6": {"roles": ["chassis", "gateway"]}
+        }
+
     def test_get_accepted_application_status_allows_waiting(
         self,
         basic_deployment,
@@ -112,9 +168,8 @@ class TestDeployRoleDistributorApplicationStep:
         config = step.extra_tfvars()["charm_role_distributor_config"]
 
         assert config["log-level"] == "DEBUG"
-        assert yaml.safe_load(config["role-mapping"]) == {
-            "openstack-machines": {"microovn": {"machines": {}}}
-        }
+        # No machines means no application blocks to emit.
+        assert yaml.safe_load(config["role-mapping"]) == {"openstack-machines": {}}
 
     def test_is_skip_skips_when_no_microovn_machines(
         self,

--- a/sunbeam-python/tests/unit/sunbeam/steps/test_role_distributor.py
+++ b/sunbeam-python/tests/unit/sunbeam/steps/test_role_distributor.py
@@ -71,7 +71,9 @@ class TestDeployRoleDistributorApplicationStep:
         basic_manifest,
         test_model,
     ):
-        # DPUs move to microovn-<arch>; the amd64 DPU must not fall back to microovn.
+        # Grouping is purely by architecture: non-default archs go to
+        # microovn-<arch>, amd64 goes to the default microovn application,
+        # regardless of is_dpu.
         basic_deployment.get_ovn_manager.return_value.get_machines.return_value = [
             "0",
             "5",
@@ -109,14 +111,13 @@ class TestDeployRoleDistributorApplicationStep:
         )["openstack-machines"]
 
         assert machines["microovn"]["machines"] == {
-            "0": {"roles": ["chassis", "central"]}
+            "0": {"roles": ["chassis", "central"]},
+            "6": {"roles": ["chassis", "gateway"]},
         }
         assert machines["microovn-arm64"]["machines"] == {
             "5": {"roles": ["chassis", "gateway"]}
         }
-        assert machines["microovn-amd64"]["machines"] == {
-            "6": {"roles": ["chassis", "gateway"]}
-        }
+        assert "microovn-amd64" not in machines
 
     def test_get_accepted_application_status_allows_waiting(
         self,


### PR DESCRIPTION
The role-distributor and  role-mapping  put every MicroOVN machine under a single microovn config option, so DPU nodes (deployed as microvn-arm64) got role assignments for the wrong application and stayed stuck "Waiting for role assignment".

Now machines are grouped by the MicroOVN application their unit belongs to, keyed off the node's is_dpu lag (not architecture, so a future amd64 DPU is handled too):
openstack-machines:
  microovn:
    machines: {'0': ..., '3': ...}
  microovn-arm64:
    machines: {'5': ...}   # DPU under its own application

## Links
[JIRA](https://warthogs.atlassian.net/browse/OPEN-4692)
