### PR TITLE
feat: drop hypervisor OVSDB CMS integration

### DIFF
--- a/cloud/etc/deploy-openstack-hypervisor/main.tf
+++ b/cloud/etc/deploy-openstack-hypervisor/main.tf
@@ -98,24 +98,6 @@ resource "juju_integration" "hypervisor-certs" {
   }
 }
 
-moved {
-  from = juju_integration.hypervisor-ovn-proxy[0]
-  to   = juju_integration.hypervisor-ovn-proxy
-}
-
-resource "juju_integration" "hypervisor-ovn-proxy" {
-  model_uuid = data.juju_model.machine_model.uuid
-  application {
-    name     = juju_application.openstack-hypervisor.name
-    endpoint = "ovsdb-cms"
-  }
-
-  application {
-    name     = "sunbeam-ovn-proxy"
-    endpoint = "ovsdb-cms"
-  }
-}
-
 resource "juju_integration" "hypervisor-ceilometer" {
   count      = (var.ceilometer-offer-url != null) ? 1 : 0
   model_uuid = data.juju_model.machine_model.uuid

--- a/sunbeam-python/sunbeam/steps/hypervisor.py
+++ b/sunbeam-python/sunbeam/steps/hypervisor.py
@@ -163,10 +163,6 @@ class DeployHypervisorApplicationStep(DeployMachineApplicationStep):
                         "space": self.deployment.get_space(Networks.INTERNAL),
                     },
                     {
-                        "endpoint": "ovsdb-cms",
-                        "space": self.deployment.get_space(Networks.INTERNAL),
-                    },
-                    {
                         "endpoint": "receive-ca-cert",
                         "space": self.deployment.get_space(Networks.INTERNAL),
                     },


### PR DESCRIPTION
The OVN agent now reads database connections from the local MicroOVN ovn-env interface. Stop relating the hypervisor to sunbeam-ovn-proxy and remove the obsolete endpoint binding.

Assisted-By: Codex (gpt-5-6-sol)

Requires:
- [x] https://github.com/canonical/snap-openstack-hypervisor/pull/217
- [x] https://review.opendev.org/c/openstack/sunbeam-charms/+/1003518

## QA steps

Deploy sunbeam. This change happens at deploying the hypervisor time. If it's not applied correctly, Juju will refuse the deployment, as Sunbeam will try to bind a non-existing relation to a space.

This CI should be green as the current functional testing exercises this path.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Place JIRA number in both places below. -->
**Jira card:** [OPEN-4626](https://warthogs.atlassian.net/browse/OPEN-4626)


[OPEN-4626]: https://warthogs.atlassian.net/browse/OPEN-4626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ